### PR TITLE
Handle Interrupt and Terminate Signals in Up

### DIFF
--- a/CHANGELOG-0.1.md
+++ b/CHANGELOG-0.1.md
@@ -1,11 +1,3 @@
-<hr>
-
-
-## [0.1.4]() (TBD)
-
-### `internal`
-
-- Handle [interrupt and terminate signals when creating a cluster](https://github.com/aws/aws-k8s-tester/pull/14).
 
 <hr>
 
@@ -51,6 +43,7 @@ See [code changes](https://github.com/aws/aws-k8s-tester/compare/0.1.2...0.1.3).
 - Improve [worker node log fetcher](https://github.com/aws/aws-k8s-tester/pull/10) with concurrency.
 - Add [retries on `kubectl get all` fail](https://github.com/aws/aws-k8s-tester/pull/8).
 - Add [`kubectl` and `aws-iam-authenticator` downloader](https://github.com/aws/aws-k8s-tester/commit/3b8704fcf0c15229fc3480caca41b4ddec1497a1).
+- Handle [interrupt and terminate signals when creating a cluster](https://github.com/aws/aws-k8s-tester/pull/14).
 
 ### Dependency
 

--- a/CHANGELOG-0.1.md
+++ b/CHANGELOG-0.1.md
@@ -1,6 +1,15 @@
 <hr>
 
 
+## [0.1.4]() (TBD)
+
+### `internal`
+
+- Handle [interrupt and terminate signals when creating a cluster](https://github.com/aws/aws-k8s-tester/pull/14).
+
+<hr>
+
+
 ## [0.1.3](https://github.com/aws/aws-k8s-tester/releases/tag/0.1.3) (2018-11-22)
 
 See [code changes](https://github.com/aws/aws-k8s-tester/compare/0.1.2...0.1.3).

--- a/internal/eks/tester_embedded.go
+++ b/internal/eks/tester_embedded.go
@@ -395,9 +395,8 @@ func (md *embedded) Up() (err error) {
 		}
 	}()
 
-	var termChan = make(chan os.Signal)
-	signal.Notify(termChan, syscall.SIGTERM)
-	signal.Notify(termChan, syscall.SIGINT)
+	termChan := make(chan os.Signal)
+	signal.Notify(termChan, syscall.SIGTERM, syscall.SIGINT)
 
 	if md.cfg.WaitBeforeDown > 0 {
 		md.lg.Info("waiting before cluster tear down", zap.Duration("wait", md.cfg.WaitBeforeDown))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
During cluster creation, there is now a channel listening for interruption or termination syscalls.  If a signal is received from that channel, the resources are cleaned up before exiting the process.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
