### PR TITLE
internal/csi: change testcmd for aws-ebs-csi-driver in csi.go

### DIFF
--- a/internal/csi/csi.go
+++ b/internal/csi/csi.go
@@ -117,7 +117,7 @@ func (tester *Tester) RunCSIIntegrationTest() error {
 		return fmt.Errorf("failed to connect SSH (%v)", err)
 	}
 
-	testCmd := fmt.Sprintf(`cd /home/%s/go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver && sudo sh -c 'source /home/%s/.bashrc && make test-integration'`, tester.cfg.UserName, tester.cfg.UserName)
+	testCmd := fmt.Sprintf(`cd /home/%s/go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver && sudo sh -c 'source /home/%s/.bashrc && ./hack/test-integration.sh'`, tester.cfg.UserName, tester.cfg.UserName)
 	out, err := sh.Run(
 		testCmd,
 		ssh.WithTimeout(10*time.Minute),


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Changed command used to run test integration with kubernetes-sigs/aws-ebs-csi-driver 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
