### PR TITLE
Flag for GitHub account for CSI (no env var implementation) - OPTION #1

### DIFF
--- a/cmd/aws-k8s-tester/csi/test.go
+++ b/cmd/aws-k8s-tester/csi/test.go
@@ -2,10 +2,9 @@ package csi
 
 import (
 	"fmt"
+	"github.com/aws/aws-k8s-tester/internal/csi"
 	"os"
 	"time"
-
-	"github.com/aws/aws-k8s-tester/internal/csi"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -19,6 +18,7 @@ func newTest() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&terminateOnExit, "terminate-on-exit", true, "true to terminate EC2 instance on test exit")
 	cmd.PersistentFlags().StringVar(&branchOrPR, "csi", "master", "CSI branch name or PR number to check out")
+	cmd.PersistentFlags().StringVar(&githubAccount, "github-account", "kubernetes-sigs", "GitHub account with aws-ebs-csi-driver repo to use for CSI")
 	cmd.PersistentFlags().DurationVar(&timeout, "timeout", 20*time.Minute, "e2e test timeout")
 	cmd.PersistentFlags().StringVar(&vpcID, "vpc-id", "vpc-0c59620d91b2e1f92", "existing VPC ID to use (provided default VPC ID belongs to aws-k8s-tester test account, leave empty to create a new one)")
 	cmd.PersistentFlags().BoolVar(&journalctlLogs, "journalctl-logs", false, "true to get journalctl logs from EC2 instance")
@@ -32,6 +32,7 @@ func newTest() *cobra.Command {
 var (
 	terminateOnExit bool
 	branchOrPR      string
+	githubAccount   string
 	timeout         time.Duration
 	vpcID           string
 	journalctlLogs  bool
@@ -68,10 +69,11 @@ func testIntegrationFunc(cmd *cobra.Command, args []string) {
 	lg.Info(
 		"starting CSI integration tests",
 		zap.String("csi", branchOrPR),
+		zap.String("github-account", githubAccount),
 		zap.Duration("timeout", timeout),
 	)
 
-	cfg := csi.CreateConfig(vpcID, branchOrPR)
+	cfg := csi.CreateConfig(vpcID, branchOrPR, githubAccount)
 	tester, err := csi.NewTester(cfg, terminateOnExit, journalctlLogs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error while creating new tester: (%v)\n", err)

--- a/ec2config/plugins/plugins.go
+++ b/ec2config/plugins/plugins.go
@@ -80,7 +80,7 @@ func convertToScript(userName, plugin string) (script, error) {
 			GitCloneURL:   fmt.Sprintf("https://github.com/%s/aws-ebs-csi-driver.git", gitHubAccount),
 			IsPR:          isPR,
 			GitBranch:     gitBranch,
-			InstallScript: `make aws-ebs-csi-driver && sudo cp ./bin/aws-ebs-csi-driver /usr/local/bin/aws-ebs-csi-driver`,
+			InstallScript: fmt.Sprintf(`[[ %q != "kubernetes-sigs" ]] && mv ../../%s/ ../../kubernetes-sigs && cd ../../kubernetes-sigs/aws-ebs-csi-driver; make aws-ebs-csi-driver && sudo cp ./bin/aws-ebs-csi-driver /usr/local/bin/aws-ebs-csi-driver`, gitHubAccount, gitHubAccount),
 		})
 		if err != nil {
 			return script{}, err

--- a/ec2config/plugins/plugins_test.go
+++ b/ec2config/plugins/plugins_test.go
@@ -114,7 +114,7 @@ func TestPlugins(t *testing.T) {
 			GitCloneURL:   fmt.Sprintf("https://github.com/%s/aws-ebs-csi-driver.git", testGitHubAccount),
 			IsPR:          isPR,
 			GitBranch:     testBranchOrPR,
-			InstallScript: `make aws-ebs-csi-driver && sudo cp ./bin/aws-ebs-csi-driver /usr/local/bin/aws-ebs-csi-driver`,
+			InstallScript: fmt.Sprintf(`[[ %q != "kubernetes-sigs" ]] && mv ../../%s/ ../../kubernetes-sigs && cd ../../kubernetes-sigs/aws-ebs-csi-driver; make aws-ebs-csi-driver && sudo cp ./bin/aws-ebs-csi-driver /usr/local/bin/aws-ebs-csi-driver`, testGitHubAccount, testGitHubAccount),
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/ec2config/plugins/plugins_test.go
+++ b/ec2config/plugins/plugins_test.go
@@ -48,7 +48,7 @@ func TestPlugins(t *testing.T) {
 	script, err := Create(
 		"ubuntu",
 		[]string{
-			"install-csi-101",
+			"install-csi-101/github-account-kubernetes-sigs",
 			"update-amazon-linux-2",
 			"install-go-1.11.3",
 			"install-wrk",
@@ -58,4 +58,102 @@ func TestPlugins(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Println(script)
+
+	expectedErrorForInstallCSI := func(actualNum int) string {
+		return fmt.Sprintf("expected two strings (GitHub account and branch/PR) but got %v", actualNum)
+	}
+
+	// For 'install-csi', expect error when not providing both a PR/branch and a GitHub account.
+	_, err = Create(
+		"ubuntu",
+		[]string{
+			"install-csi-kubernetes-sigs",
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error with 'install-csi' but did not receive one")
+	}
+	if err.Error() != expectedErrorForInstallCSI(1) {
+		t.Fatal("got different error with 'install-csi' than expected: ", err)
+	}
+
+	// For 'install-csi', expect error when providing more than a PR/branch and a GitHub account.
+	_, err = Create(
+		"ubuntu",
+		[]string{
+			"install-csi-master/github-account-test-github-account/github-account-second-github-account",
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error with 'install-csi' but did not receive one")
+	}
+	if err.Error() != expectedErrorForInstallCSI(3) {
+		t.Fatal("got different error with 'install-csi' than expected: ", err)
+	}
+
+	// -----------------------------------------------------------------------------------------------------------------
+	// For 'install-csi', get expected string when provided valid input for branch.
+	testBranch := "test-branch"
+	testPR := "42"
+	testGitHubAccount := "test-github-account"
+	getFullResults := func(result string) string {
+		return headerBash + result + fmt.Sprintf("\n\necho %s\n\n", READY)
+	}
+
+	getExpectedResult := func(isPR bool) string {
+		testBranchOrPR := ""
+		if isPR {
+			testBranchOrPR = testPR
+		} else {
+			testBranchOrPR = testBranch
+		}
+
+		expectedResult, err := createInstallGit(gitInfo{
+			GitRepo:       "aws-ebs-csi-driver",
+			GitClonePath:  fmt.Sprintf("${GOPATH}/src/github.com/%s", testGitHubAccount),
+			GitCloneURL:   fmt.Sprintf("https://github.com/%s/aws-ebs-csi-driver.git", testGitHubAccount),
+			IsPR:          isPR,
+			GitBranch:     testBranchOrPR,
+			InstallScript: `make aws-ebs-csi-driver && sudo cp ./bin/aws-ebs-csi-driver /usr/local/bin/aws-ebs-csi-driver`,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return getFullResults(expectedResult)
+	}
+
+	// Gets expected results when using a branch
+	actualResult, err := Create(
+		"ubuntu",
+		[]string{
+			fmt.Sprintf("install-csi-%s/github-account-%s", testBranch, testGitHubAccount),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedResult := getExpectedResult(false)
+
+	if actualResult != expectedResult {
+		t.Fatalf("EXPECTED:\n%s\nGOT:\n%s", actualResult, expectedResult)
+	}
+
+	// Gets expected results when using a PR
+	actualResult, err = Create(
+		"ubuntu",
+		[]string{
+			fmt.Sprintf("install-csi-%s/github-account-%s", testPR, testGitHubAccount),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedResult = getExpectedResult(true)
+
+	if actualResult != expectedResult {
+		t.Fatalf("EXPECTED:\n%s\nGOT:\n%s", actualResult, expectedResult)
+	}
 }

--- a/internal/csi/csi.go
+++ b/internal/csi/csi.go
@@ -50,7 +50,7 @@ func NewTester(cfg *ec2config.Config, terminateOnExit, journalctlLogs bool) (tes
 	return tester, nil
 }
 
-func CreateConfig(vpcID, branchOrPR string) *ec2config.Config {
+func CreateConfig(vpcID, branchOrPR, githubAccount string) *ec2config.Config {
 	cfg := ec2config.NewDefault()
 	cfg.UploadTesterLogs = false
 	cfg.VPCID = vpcID
@@ -58,7 +58,7 @@ func CreateConfig(vpcID, branchOrPR string) *ec2config.Config {
 	cfg.Plugins = []string{
 		"update-amazon-linux-2",
 		"install-go-1.11.3",
-		"install-csi-" + branchOrPR,
+		"install-csi-" + branchOrPR + "/github-account-" + githubAccount,
 	}
 	cfg.Wait = true
 	return cfg


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/162#discussion_r244186061

*Description of changes:*
Creates a flag (`github-account`) that allows the user to specify which GitHub account's `aws-ebs-csi-driver` repo they want to for CSI tests

NOTE: this implementation does not include using an env var.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
