### PR TITLE
Flag for GitHub account for CSI (with env var implementation) - OPTION #2

### DIFF
--- a/cmd/aws-k8s-tester/csi/test.go
+++ b/cmd/aws-k8s-tester/csi/test.go
@@ -19,6 +19,7 @@ func newTest() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&terminateOnExit, "terminate-on-exit", true, "true to terminate EC2 instance on test exit")
 	cmd.PersistentFlags().StringVar(&branchOrPR, "csi", "master", "CSI branch name or PR number to check out")
+	cmd.PersistentFlags().StringVar(&githubAccount, "github-account", "kubernetes-sigs", "GitHub account with aws-ebs-csi-driver repo to use for CSI")
 	cmd.PersistentFlags().DurationVar(&timeout, "timeout", 20*time.Minute, "e2e test timeout")
 	cmd.PersistentFlags().StringVar(&vpcID, "vpc-id", "vpc-0c59620d91b2e1f92", "existing VPC ID to use (provided default VPC ID belongs to aws-k8s-tester test account, leave empty to create a new one)")
 	cmd.PersistentFlags().BoolVar(&journalctlLogs, "journalctl-logs", false, "true to get journalctl logs from EC2 instance")
@@ -32,6 +33,7 @@ func newTest() *cobra.Command {
 var (
 	terminateOnExit bool
 	branchOrPR      string
+	githubAccount   string
 	timeout         time.Duration
 	vpcID           string
 	journalctlLogs  bool
@@ -68,10 +70,11 @@ func testIntegrationFunc(cmd *cobra.Command, args []string) {
 	lg.Info(
 		"starting CSI integration tests",
 		zap.String("csi", branchOrPR),
+		zap.String("github-account", githubAccount),
 		zap.Duration("timeout", timeout),
 	)
 
-	cfg := csi.CreateConfig(vpcID, branchOrPR)
+	cfg := csi.CreateConfig(vpcID, branchOrPR, githubAccount)
 	tester, err := csi.NewTester(cfg, terminateOnExit, journalctlLogs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error while creating new tester: (%v)\n", err)

--- a/ec2config/plugins/plugins.go
+++ b/ec2config/plugins/plugins.go
@@ -91,7 +91,7 @@ func convertToScript(userName, plugin string) (script, error) {
 			GitCloneURL:   fmt.Sprintf("https://github.com/${CSI_GITHUB_ACCOUNT}/aws-ebs-csi-driver.git"),
 			IsPR:          isPR,
 			GitBranch:     gitBranch,
-			InstallScript: `make aws-ebs-csi-driver && sudo cp ./bin/aws-ebs-csi-driver /usr/local/bin/aws-ebs-csi-driver`,
+			InstallScript: `[[ "${CSI_GITHUB_ACCOUNT}" != "kubernetes-sigs" ]] && mv ../../${CSI_GITHUB_ACCOUNT}/ ../../kubernetes-sigs && cd ../../kubernetes-sigs/aws-ebs-csi-driver; make aws-ebs-csi-driver && sudo cp ./bin/aws-ebs-csi-driver /usr/local/bin/aws-ebs-csi-driver`,
 		})
 		if err != nil {
 			return script{}, err

--- a/ec2config/plugins/plugins.go
+++ b/ec2config/plugins/plugins.go
@@ -87,8 +87,8 @@ func convertToScript(userName, plugin string) (script, error) {
 		isPR := perr == nil
 		s, err := createInstallGit(gitInfo{
 			GitRepo:       "aws-ebs-csi-driver",
-			GitClonePath:  fmt.Sprintf("${GOPATH}/src/github.com/${CSI_GITHUB_ACCOUNT}"),
-			GitCloneURL:   fmt.Sprintf("https://github.com/${CSI_GITHUB_ACCOUNT}/aws-ebs-csi-driver.git"),
+			GitClonePath:  "${GOPATH}/src/github.com/${CSI_GITHUB_ACCOUNT}",
+			GitCloneURL:   "https://github.com/${CSI_GITHUB_ACCOUNT}/aws-ebs-csi-driver.git",
 			IsPR:          isPR,
 			GitBranch:     gitBranch,
 			InstallScript: `[[ "${CSI_GITHUB_ACCOUNT}" != "kubernetes-sigs" ]] && mv ../../${CSI_GITHUB_ACCOUNT}/ ../../kubernetes-sigs && cd ../../kubernetes-sigs/aws-ebs-csi-driver; make aws-ebs-csi-driver && sudo cp ./bin/aws-ebs-csi-driver /usr/local/bin/aws-ebs-csi-driver`,

--- a/ec2config/plugins/plugins_test.go
+++ b/ec2config/plugins/plugins_test.go
@@ -93,7 +93,7 @@ func TestPlugins(t *testing.T) {
 			GitCloneURL:   "https://github.com/${CSI_GITHUB_ACCOUNT}/aws-ebs-csi-driver.git",
 			IsPR:          isPR,
 			GitBranch:     testBranchOrPR,
-			InstallScript: `make aws-ebs-csi-driver && sudo cp ./bin/aws-ebs-csi-driver /usr/local/bin/aws-ebs-csi-driver`,
+			InstallScript: `[[ "${CSI_GITHUB_ACCOUNT}" != "kubernetes-sigs" ]] && mv ../../${CSI_GITHUB_ACCOUNT}/ ../../kubernetes-sigs && cd ../../kubernetes-sigs/aws-ebs-csi-driver; make aws-ebs-csi-driver && sudo cp ./bin/aws-ebs-csi-driver /usr/local/bin/aws-ebs-csi-driver`,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/internal/csi/csi.go
+++ b/internal/csi/csi.go
@@ -50,7 +50,7 @@ func NewTester(cfg *ec2config.Config, terminateOnExit, journalctlLogs bool) (tes
 	return tester, nil
 }
 
-func CreateConfig(vpcID, branchOrPR string) *ec2config.Config {
+func CreateConfig(vpcID, branchOrPR, githubAccount string) *ec2config.Config {
 	cfg := ec2config.NewDefault()
 	cfg.UploadTesterLogs = false
 	cfg.VPCID = vpcID
@@ -59,6 +59,7 @@ func CreateConfig(vpcID, branchOrPR string) *ec2config.Config {
 		"update-amazon-linux-2",
 		"install-go-1.11.3",
 		"install-csi-" + branchOrPR,
+		"install-csi-github-account-" + githubAccount,
 	}
 	cfg.Wait = true
 	return cfg


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/162#discussion_r244186061

*Description of changes:*
Creates a flag (`github-account`) that allows the user to specify which GitHub account's `aws-ebs-csi-driver` repo they want to for CSI tests

NOTE: this implementation DOES include using an env var.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
