### PR TITLE
Fix null pointer bug with IAM resources

### DIFF
--- a/internal/csi/iam.go
+++ b/internal/csi/iam.go
@@ -89,8 +89,9 @@ func createIAM(awsRegion string) (*iam.IAM, error) {
 // awsRegion must be a valid AWS region for ec2 instances.
 // For a complete list, see entries under "Region" on the table "Amazon Elastic Compute Cloud (Amazon EC2)":
 // https://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region
-func createIAMResources(awsRegion string) (resources *iamResources, err error) {
-	resources = &iamResources{}
+func createIAMResources(awsRegion string) (*iamResources, error) {
+	resources := &iamResources{}
+	var err error
 
 	defer func() {
 		// Delay is needed to ensure that permissions have been propagated.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-k8s-tester/issues/29

*Description of changes:*
Fixed null pointer bug in createIAMResources() when attempting to delete IAM resources

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
