### PR TITLE
Allow priviliged port access for worker node groups

### DIFF
--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -104,6 +104,9 @@ type Config struct {
 	// EnableWorkerNodeHA is true to use all 3 subnets to create worker nodes.
 	// Note that at least 2 subnets are required for EKS cluster.
 	EnableWorkerNodeHA bool `json:"enable-worker-node-ha"`
+	// EnableWorkerNodePrivilegedPortAccess is true to allow control plane to
+	// talk to worker nodes through their privileged ports (i.e ports 1-1024).
+	EnableWorkerNodePrivilegedPortAccess bool `json:"enable-worker-node-privileged-port-access"`
 
 	// VPCID is the VPC ID.
 	VPCID string `json:"vpc-id"`
@@ -430,8 +433,9 @@ var defaultConfig = Config{
 	AWSRegion:                "us-west-2",
 	AWSCustomEndpoint:        "",
 
-	EnableWorkerNodeHA:  true,
-	EnableWorkerNodeSSH: true,
+	EnableWorkerNodeHA:                   true,
+	EnableWorkerNodeSSH:                  true,
+	EnableWorkerNodePrivilegedPortAccess: true,
 
 	// keep in-sync with the default value in https://godoc.org/k8s.io/kubernetes/test/e2e/framework#GetSigner
 	WorkerNodePrivateKeyPath: filepath.Join(homedir.HomeDir(), ".ssh", "kube_aws_rsa"),

--- a/eksconfig/config_test.go
+++ b/eksconfig/config_test.go
@@ -44,6 +44,7 @@ func TestEnv(t *testing.T) {
 	os.Setenv("AWS_K8S_TESTER_EKS_SECURITY_GROUP_ID", "my-security-id")
 	os.Setenv("AWS_K8S_TESTER_EKS_ENABLE_WORKER_NODE_HA", "false")
 	os.Setenv("AWS_K8S_TESTER_EKS_ENABLE_WORKER_NODE_SSH", "true")
+	os.Setenv("AWS_K8S_TESTER_EKS_ENABLE_WORKER_NODE_PRIVILEGED_PORT_ACCESS", "true")
 	os.Setenv("AWS_K8S_TESTER_EKS_CONFIG_PATH", "test-path")
 	os.Setenv("AWS_K8S_TESTER_EKS_DOWN", "false")
 	os.Setenv("AWS_K8S_TESTER_EKS_ALB_TARGET_TYPE", "ip")
@@ -83,6 +84,7 @@ func TestEnv(t *testing.T) {
 		os.Unsetenv("AWS_K8S_TESTER_EKS_SECURITY_GROUP_ID")
 		os.Unsetenv("AWS_K8S_TESTER_EKS_ENABLE_WORKER_NODE_HA")
 		os.Unsetenv("AWS_K8S_TESTER_EKS_ENABLE_WORKER_NODE_SSH")
+		os.Unsetenv("AWS_K8S_TESTER_EKS_ENABLE_WORKER_NODE_PRIVILEGED_PORT_ACCESS")
 		os.Unsetenv("AWS_K8S_TESTER_EKS_CONFIG_PATH")
 		os.Unsetenv("AWS_K8S_TESTER_EKS_DOWN")
 		os.Unsetenv("AWS_K8S_TESTER_EKS_ALB_TARGET_TYPE")
@@ -167,6 +169,9 @@ func TestEnv(t *testing.T) {
 	}
 	if !cfg.EnableWorkerNodeSSH {
 		t.Fatalf("cfg.EnableWorkerNodeSSH expected 'true', got %v", cfg.EnableWorkerNodeSSH)
+	}
+	if !cfg.EnableWorkerNodePrivilegedPortAccess {
+		t.Fatalf("cfg.EnableWorkerNodePrivilegedPortAccess expected 'true', got %v", cfg.EnableWorkerNodePrivilegedPortAccess)
 	}
 	if cfg.WorkerNodeASGMin != 10 {
 		t.Fatalf("worker nodes min expected 10, got %q", cfg.WorkerNodeASGMin)

--- a/internal/eks/worker_node_template.go
+++ b/internal/eks/worker_node_template.go
@@ -50,11 +50,12 @@ func _createWorkerNodeTemplate(v workerNodeStack) (string, error) {
 }
 
 type workerNodeStack struct {
-	Description         string
-	Tag                 string
-	TagValue            string
-	Hostname            string
-	EnableWorkerNodeSSH bool
+	Description                          string
+	Tag                                  string
+	TagValue                             string
+	Hostname                             string
+	EnableWorkerNodeSSH                  bool
+	EnableWorkerNodePrivilegedPortAccess bool
 }
 
 // TODO: this does not work...
@@ -293,7 +294,7 @@ Resources:
       GroupId: !Ref NodeSecurityGroup
       SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
       IpProtocol: tcp
-      FromPort: 1025
+      FromPort: {{ if .EnableWorkerNodePrivilegedPortAccess }} 1 {{else}} 1025 {{end}}
       ToPort: 65535
 
   ControlPlaneEgressToNodeSecurityGroup:
@@ -304,7 +305,7 @@ Resources:
       GroupId: !Ref ClusterControlPlaneSecurityGroup
       DestinationSecurityGroupId: !Ref NodeSecurityGroup
       IpProtocol: tcp
-      FromPort: 1025
+      FromPort: {{ if .EnableWorkerNodePrivilegedPortAccess }} 1 {{else}} 1025 {{end}}
       ToPort: 65535
 
   NodeSecurityGroupFromControlPlaneOn443Ingress:

--- a/internal/eks/worker_node_template_test.go
+++ b/internal/eks/worker_node_template_test.go
@@ -8,11 +8,12 @@ import (
 
 func TestWorkerNodeTemplate(t *testing.T) {
 	v := workerNodeStack{
-		Description:         "test",
-		Tag:                 "aws-k8s-tester",
-		TagValue:            "aws-k8s-tester",
-		Hostname:            "hostname",
-		EnableWorkerNodeSSH: true,
+		Description:                          "test",
+		Tag:                                  "aws-k8s-tester",
+		TagValue:                             "aws-k8s-tester",
+		Hostname:                             "hostname",
+		EnableWorkerNodeSSH:                  true,
+		EnableWorkerNodePrivilegedPortAccess: false,
 	}
 	s, err := _createWorkerNodeTemplate(v)
 	if err != nil {
@@ -20,6 +21,9 @@ func TestWorkerNodeTemplate(t *testing.T) {
 	}
 	if v.EnableWorkerNodeSSH && !strings.Contains(s, "ClusterControlPlaneSecurityGroupIngress22") {
 		t.Fatal("expected 'ClusterControlPlaneSecurityGroupIngress22'")
+	}
+	if v.EnableWorkerNodePrivilegedPortAccess && !strings.Contains(s, "FromPort: 1025") {
+		t.Fatal("expected 'NodeSecurityGroupFromControlPlaneIngress' and 'ControlPlaneEgressToNodeSecurityGroup' to have FromPort = 1025")
 	}
 	fmt.Println(s)
 }


### PR DESCRIPTION
This should hopefully help fix most of the failures with the EKS [conformance](https://testgrid.k8s.io/sig-aws-eks-periodics#ci-kubernetes-e2e-aws-eks-1-11-conformance) and [correctness](https://testgrid.k8s.io/sig-aws-eks-periodics#ci-kubernetes-e2e-aws-eks-1-11-correctness) jobs.

The default aws recommendation is not to expose these ports for security reasons. But some conformance tests need these to pass.

/cc @gyuho 