### PR TITLE
Upgrade golang version for CSI integ test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /*.log
 /bin
 /.idea
+*.swp

--- a/internal/csi/csi.go
+++ b/internal/csi/csi.go
@@ -62,7 +62,7 @@ func CreateConfig(vpcID, prNum, githubAccount, githubBranch string) (cfg *ec2con
 	cfg.IngressRulesTCP = map[string]string{"22": "0.0.0.0/0"}
 	cfg.Plugins = []string{
 		"update-amazon-linux-2",
-		"install-go-1.11.3",
+		"install-go-1.11.4",
 	}
 	// If prNum is set to an non-empty string, the master branch of kubernetes-sigs/aws-ebs-csi-driver is used,
 	// regardless of whether or not githubAccount and githubBranch have different values.


### PR DESCRIPTION
Fixing go mod checksum mismatch since EBS CSI is built using go 1.11.4. But the integration test instance is still using 1.11.3

Failed Prow Job link:
https://gubernator.k8s.io/build/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/198/pull-aws-ebs-csi-driver-integration/131