### PR TITLE
Add test framework for test orchestration

### DIFF
--- a/e2e/tester/framework.go
+++ b/e2e/tester/framework.go
@@ -1,0 +1,115 @@
+package tester
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+
+	"github.com/aws/aws-k8s-tester/e2e/tester/pkg"
+	yaml "gopkg.in/yaml.v2"
+)
+
+type Tester struct {
+	init      pkg.Step
+	build     pkg.Step
+	up        pkg.Step
+	install   pkg.Step
+	test      pkg.Step
+	uninstall pkg.Step
+	tearDown  pkg.Step
+}
+
+func NewTester(configPath string) *Tester {
+	if configPath == "" {
+		configPath = readTestConfigPath()
+	}
+	testConfig, err := os.Open(configPath)
+	if err != nil {
+		panic(err)
+	}
+	var config *pkg.TestConfig
+	err = yaml.NewDecoder(testConfig).Decode(&config)
+	if err != nil {
+		panic(err)
+	}
+
+	testId := fmt.Sprintf("%d", rand.Intn(10000))
+	clusterCreator, err := pkg.NewClusterCreator(config, "/tmp/tester-e2e-test", testId)
+	if err != nil {
+		panic(err)
+	}
+
+	return &Tester{
+		init:      createStepOrPanic(clusterCreator.Init),
+		build:     scriptStep(config.BuildScript, testId),
+		up:        createStepOrPanic(clusterCreator.Up),
+		install:   scriptStep(config.InstallScript, testId),
+		test:      scriptStep(config.TestScript, testId),
+		uninstall: scriptStep(config.UninstallScript, testId),
+		tearDown:  createStepOrPanic(clusterCreator.TearDown),
+	}
+}
+
+//TODO: catch SIGTERM and do clean up
+func (t *Tester) Start() error {
+	err := t.init.Run()
+	if err != nil {
+		return err
+	}
+
+	err = t.build.Run()
+	if err != nil {
+		return err
+	}
+
+	err = t.up.Run()
+	if err != nil {
+		log.Printf("Up failed: %s", err)
+		tErr := t.tearDown.Run()
+		if tErr != nil {
+			log.Printf("failed to tear down cluster %s", tErr)
+		}
+		return err
+	}
+
+	err = t.install.Run()
+	if err != nil {
+		tErr := t.tearDown.Run()
+		if tErr != nil {
+			log.Printf("failed to tear down cluster: %v", tErr)
+		}
+		return err
+	}
+
+	err = t.test.Run()
+	if uninstallErr := t.uninstall.Run(); uninstallErr != nil {
+		log.Printf("Failed to run install step: %s", uninstallErr)
+	}
+	if tearDownErr := t.tearDown.Run(); tearDownErr != nil {
+		log.Printf("Failed to run tear down step: %s", tearDownErr)
+	}
+
+	return err
+}
+
+func readTestConfigPath() string {
+	path := os.Getenv("TESTCONFIG")
+	if len(path) == 0 {
+		return "test-config.yaml"
+	}
+
+	return path
+}
+
+func createStepOrPanic(f func() (pkg.Step, error)) pkg.Step {
+	step, err := f()
+	if err != nil {
+		panic(err)
+	}
+	return step
+}
+
+func scriptStep(script string, testId string) pkg.Step {
+	return &pkg.TestStep{Script: script, TestId: testId}
+}

--- a/e2e/tester/go.mod
+++ b/e2e/tester/go.mod
@@ -1,0 +1,3 @@
+module github.com/aws/aws-k8s-tester/e2e/tester
+
+require gopkg.in/yaml.v2 v2.2.2

--- a/e2e/tester/go.sum
+++ b/e2e/tester/go.sum
@@ -1,0 +1,4 @@
+github.com/aws/aws-k8s-tester v0.0.0-20190829184027-9a2c913f3bd9 h1:9zFcgDhcxUfS2y3Grk61gnOTHnIdZYNS1sWXqW8Jrk0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/e2e/tester/pkg/cluster.go
+++ b/e2e/tester/pkg/cluster.go
@@ -1,0 +1,35 @@
+package pkg
+
+import (
+	"fmt"
+)
+
+type ClusterCreator interface {
+	// Initialize the creator such as downloading dependencies
+	Init() (Step, error)
+
+	// Create and wait for cluster creation
+	Up() (Step, error)
+
+	// Teardown the cluster
+	TearDown() (Step, error)
+}
+
+func NewClusterCreator(config *TestConfig, testDir string, testId string) (ClusterCreator, error) {
+	cluster := config.Cluster
+
+	if cluster.Kops == nil && cluster.Eks == nil {
+		return nil, fmt.Errorf("TestConfig.Cluster is not set")
+	}
+
+	if cluster.Kops != nil && cluster.Eks != nil {
+		return nil, fmt.Errorf("Both Kops and Eks cluster is set")
+	}
+
+	if cluster.Kops != nil {
+		return NewKopsClusterCreator(cluster.Kops, testDir, testId), nil
+	}
+
+	// TODO: add for EKS cluster
+	return nil, nil
+}

--- a/e2e/tester/pkg/config.go
+++ b/e2e/tester/pkg/config.go
@@ -1,0 +1,28 @@
+package pkg
+
+type TestConfig struct {
+	Cluster         *Cluster `yaml:"cluster"`
+	Region          string   `yaml:"region"`
+	BuildScript     string   `yaml:"build"`
+	InstallScript   string   `yaml:"install"`
+	UninstallScript string   `yaml:"uninstall"`
+	TestScript      string   `yaml:"test"`
+}
+
+type Cluster struct {
+	Kops *KopsCluster `yaml:"kops"`
+	Eks  *EksCluster  `yaml:"eks"`
+}
+
+type KopsCluster struct {
+	Region            string `yaml:"region"`
+	Zones             string `yaml:"zones"`
+	NodeCount         int    `yaml:"nodeCount"`
+	NodeSize          string `yaml:"nodeSize"`
+	KubernetesVersion string `yaml:"kubernetesVersion"`
+	FeatureGates      string `yaml:"featureGates"`
+	IamPolicies       string `yaml:"iamPolicies"`
+}
+
+type EksCluster struct {
+}

--- a/e2e/tester/pkg/kops.go
+++ b/e2e/tester/pkg/kops.go
@@ -1,0 +1,247 @@
+package pkg
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+const (
+	// TODO: create a new s3 bucket for generatal usage
+	kopsStateFile = "s3://k8s-kops-csi-e2e"
+)
+
+type KopsClusterCreator struct {
+	// TestId is used as cluster name
+	TestId string
+
+	// Kops represents the configuration to create kops cluster
+	Kops *KopsCluster
+
+	// directory where tempory data is saved
+	TestDir string
+
+	// The path to Kops executable
+	KopsBinaryPath string
+}
+
+func NewKopsClusterCreator(kops *KopsCluster, dir string, testId string) *KopsClusterCreator {
+	binaryFilePath := filepath.Join(dir, "kops")
+	return &KopsClusterCreator{
+		Kops:           kops,
+		TestDir:        dir,
+		TestId:         testId,
+		KopsBinaryPath: binaryFilePath,
+	}
+}
+
+func (c *KopsClusterCreator) Init() (Step, error) {
+	f := func() error {
+		_, err := os.Stat(c.TestDir)
+		if os.IsNotExist(err) {
+			err := os.Mkdir(c.TestDir, 0777)
+			if err != nil {
+				return err
+			}
+		}
+
+		_, err = os.Stat(c.KopsBinaryPath)
+		if os.IsNotExist(err) {
+			return c.downloadKops()
+		}
+
+		return nil
+	}
+
+	return &FuncStep{f}, nil
+}
+
+func (c *KopsClusterCreator) Up() (Step, error) {
+	f := func() error {
+		// create cluster
+		err := c.createCluster()
+		if err != nil {
+			return err
+		}
+
+		// wait for cluster creation to success
+		// or return err if timedout
+		err = c.waitForCreation(15 * time.Minute)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return &FuncStep{f}, nil
+}
+
+func (c *KopsClusterCreator) TearDown() (Step, error) {
+	f := func() error {
+		clusterName := c.clusterName()
+		log.Printf("Deleting cluster %s", clusterName)
+
+		cmd := exec.Command(c.KopsBinaryPath, "delete", "cluster",
+			"--state", kopsStateFile,
+			"--name", clusterName, "--yes")
+
+		cmd.Stdout = os.Stdout
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+
+		return cmd.Run()
+	}
+
+	return &FuncStep{f}, nil
+}
+
+func (c *KopsClusterCreator) clusterName() string {
+	return fmt.Sprintf("test-cluster-%s.k8s.local", c.TestId)
+}
+
+func (c *KopsClusterCreator) downloadKops() error {
+	osArch := fmt.Sprintf("%s-amd64", runtime.GOOS)
+	url := fmt.Sprintf("https://github.com/kubernetes/kops/releases/download/1.14.0-alpha.1/kops-%s", osArch)
+	log.Printf("Downloading KOPS from %s to %s", url, c.KopsBinaryPath)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	payload, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(c.KopsBinaryPath, payload, 0777)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *KopsClusterCreator) createCluster() error {
+	clusterName := c.clusterName()
+	log.Printf("Creating Kops cluster %s", clusterName)
+
+	sshKeyPath := filepath.Join(c.TestDir, "id_rsa")
+
+	_, err := os.Stat(sshKeyPath)
+	// only generate SSH key if it is missing
+	if os.IsNotExist(err) {
+		err := c.generateSSHKey(sshKeyPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	cmd := exec.Command(c.KopsBinaryPath, "create", "cluster",
+		"--state", kopsStateFile,
+		"--zones", c.Kops.Zones,
+		"--node-count", fmt.Sprintf("%d", c.Kops.NodeCount),
+		"--node-size", c.Kops.NodeSize,
+		"--kubernetes-version", c.Kops.KubernetesVersion,
+		"--ssh-public-key", fmt.Sprintf("%s.pub", sshKeyPath),
+		clusterName,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+	clusterYamlPath := filepath.Join(c.TestDir, fmt.Sprintf("%s.yaml", c.TestId))
+
+	clusterYamlFile, err := os.Create(clusterYamlPath)
+	if err != nil {
+		return err
+	}
+	defer clusterYamlFile.Close()
+
+	cmd = exec.Command(c.KopsBinaryPath, "get", "cluster",
+		"--state", kopsStateFile, clusterName, "-o", "yaml")
+	cmd.Stdout = clusterYamlFile
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	_, err = clusterYamlFile.WriteString(c.Kops.FeatureGates)
+	if err != nil {
+		return err
+	}
+	_, err = clusterYamlFile.WriteString(c.Kops.IamPolicies)
+	if err != nil {
+		return err
+	}
+
+	cmd = exec.Command(c.KopsBinaryPath, "replace",
+		"--state", kopsStateFile, "-f", clusterYamlPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	cmd = exec.Command(c.KopsBinaryPath, "update", "cluster",
+		"--state", kopsStateFile, clusterName, "--yes")
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// waitForCreatoin waits for cluster creation and times out if it takes too long
+func (c *KopsClusterCreator) waitForCreation(timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	for {
+		select {
+		case <-timer.C:
+			return fmt.Errorf("cluster is not created after %v", timeout)
+		default:
+			cmd := exec.Command(c.KopsBinaryPath, "validate", "cluster",
+				"--state", kopsStateFile)
+			cmd.Stdout = os.Stdout
+			cmd.Stdin = os.Stdin
+			cmd.Stderr = os.Stderr
+			err := cmd.Run()
+			if err == nil {
+				timer.Stop()
+				return nil
+			}
+			time.Sleep(30 * time.Second)
+		}
+	}
+}
+
+func (c *KopsClusterCreator) generateSSHKey(keyPath string) error {
+	cmd := exec.Command("ssh-keygen", "-N", "", "-f", keyPath)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/e2e/tester/pkg/steps.go
+++ b/e2e/tester/pkg/steps.go
@@ -1,0 +1,43 @@
+package pkg
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Step interface {
+	Run() error
+}
+
+type TestStep struct {
+	Script string
+	TestId string
+}
+
+func (s *TestStep) Run() error {
+	script := strings.Replace(s.Script, "{{TEST_ID}}", s.TestId, -1)
+	testCmd := exec.Command("sh", "-c", script)
+	testCmd.Stdout = os.Stdout
+	testCmd.Stdin = os.Stdin
+	testCmd.Stderr = os.Stderr
+	err := testCmd.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type FuncStep struct {
+	f func() error
+}
+
+func (s *FuncStep) Run() error {
+	return s.f()
+}
+
+func EmptyStep() Step {
+	return &FuncStep{func() error {
+		return nil
+	}}
+}


### PR DESCRIPTION
*Issue #, if available:*
Fixes #49 

*Description of changes:*
Verified the POC through: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/359

Given the `test-config.yaml`, the framework can:
* create kops cluster
* run install script
* run test script
* run uninstall script
* teardown cluser
* be extensible to add eksctl support

Created this package as a sub go module so that whoever uses the tester framework don't need to bring in the whole dependencies of aws-k8s-tester. 

@wongma7 @nckturner @tiffanyfay @mogren

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
