### PR TITLE
Set -eu flag for sh so that shell exit with 1 when command fails in the middle

### DIFF
--- a/e2e/tester/pkg/steps.go
+++ b/e2e/tester/pkg/steps.go
@@ -17,7 +17,7 @@ type TestStep struct {
 
 func (s *TestStep) Run() error {
 	script := strings.Replace(s.Script, "{{TEST_ID}}", s.TestId, -1)
-	testCmd := exec.Command("sh", "-c", script)
+	testCmd := exec.Command("sh", "-eu", "-c", script)
 	testCmd.Stdout = os.Stdout
 	testCmd.Stdin = os.Stdin
 	testCmd.Stderr = os.Stderr


### PR DESCRIPTION
Set -eu flag for sh so that shell exit with 1 when command fails in the middle

@gyuho @wongma7

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
