### PR TITLE
Add context for test workflow cancellation

### DIFF
--- a/e2e/tester/pkg/steps.go
+++ b/e2e/tester/pkg/steps.go
@@ -1,13 +1,15 @@
 package pkg
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 )
 
 type Step interface {
-	Run() error
+	Run(ctx context.Context) error
 }
 
 type TestStep struct {
@@ -15,13 +17,34 @@ type TestStep struct {
 	TestId string
 }
 
-func (s *TestStep) Run() error {
+// TestStep run execute a user provided script using sh
+// It substitutes script variable TEST_ID and set `eu` flag
+// so that the script exits when the first error happens
+// or there is an undefined variable during execution.
+// When error occurs, it terminates all the processes within
+// the process group
+func (s *TestStep) Run(ctx context.Context) error {
 	script := strings.Replace(s.Script, "{{TEST_ID}}", s.TestId, -1)
-	testCmd := exec.Command("sh", "-eu", "-c", script)
-	testCmd.Stdout = os.Stdout
-	testCmd.Stdin = os.Stdin
-	testCmd.Stderr = os.Stderr
-	err := testCmd.Run()
+	cmd := exec.Command("sh", "-eu", "-c", script)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-done:
+			return
+		case <-ctx.Done():
+			if cmd.Process != nil {
+				syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			}
+		}
+	}()
+
+	err := cmd.Run()
 	if err != nil {
 		return err
 	}
@@ -29,15 +52,15 @@ func (s *TestStep) Run() error {
 }
 
 type FuncStep struct {
-	f func() error
+	f func(ctx context.Context) error
 }
 
-func (s *FuncStep) Run() error {
-	return s.f()
+func (s *FuncStep) Run(ctx context.Context) error {
+	return s.f(ctx)
 }
 
 func EmptyStep() Step {
-	return &FuncStep{func() error {
+	return &FuncStep{func(ctx context.Context) error {
 		return nil
 	}}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add context for test workflow cancellation so that:
* the test could be cancelled and cleaned up properly
* add SIGTERM, SIGINT signal handling to cancel the test
* add timeout to cancel the test

*Test:*
* tested cleanup after a short timeout (eg. 1 min)
* tested cleanup by sending SIGTERM to the main 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
