### PR TITLE
Swtich to use vpc cni plugin

### DIFF
--- a/e2e/tester/pkg/kops.go
+++ b/e2e/tester/pkg/kops.go
@@ -146,6 +146,7 @@ func (c *KopsClusterCreator) createCluster(ctx context.Context) error {
 		"--node-count", fmt.Sprintf("%d", c.Kops.NodeCount),
 		"--node-size", c.Kops.NodeSize,
 		"--kubernetes-version", c.Kops.KubernetesVersion,
+		"--networking", "amazon-vpc-routed-eni",
 		"--ssh-public-key", fmt.Sprintf("%s.pub", sshKeyPath),
 		clusterName,
 	)


### PR DESCRIPTION
Alb ingress e2e test relies on eks vpc cni plugin to work.

@gyuho 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
