### PR TITLE
Allow create to use env overrides

### DIFF
--- a/cmd/aws-k8s-tester/eks/create.go
+++ b/cmd/aws-k8s-tester/eks/create.go
@@ -39,6 +39,11 @@ func configFunc(cmd *cobra.Command, args []string) {
 	cfg := eksconfig.NewDefault()
 	cfg.ConfigPath = path
 	cfg.Sync()
+	err := cfg.UpdateFromEnvs()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load configuration from environment variables: %s", err.Error())
+		os.Exit(1)
+	}
 	fmt.Fprintf(os.Stderr, "wrote aws-k8s-tester eks configuration to %q\n", cfg.ConfigPath)
 }
 
@@ -64,6 +69,11 @@ func createClusterFunc(cmd *cobra.Command, args []string) {
 	}
 	if err = cfg.ValidateAndSetDefaults(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to validate configuration %q (%v)\n", path, err)
+		os.Exit(1)
+	}
+	err = cfg.UpdateFromEnvs()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load configuration from environment variables: %s", err.Error())
 		os.Exit(1)
 	}
 

--- a/eks/eks.go
+++ b/eks/eks.go
@@ -81,10 +81,6 @@ type embedded struct {
 
 // NewTester returns a new EKS tester.
 func NewTester(cfg *eksconfig.Config) (ekstester.Tester, error) {
-	if err := cfg.ValidateAndSetDefaults(); err != nil {
-		return nil, err
-	}
-
 	now := time.Now().UTC()
 
 	lcfg := logutil.AddOutputPaths(logutil.DefaultZapLoggerConfig, cfg.LogOutputs, cfg.LogOutputs)


### PR DESCRIPTION
*Description of changes:*
- Create cluster and create config allows env var overrides.  Fixes: https://github.com/aws/aws-k8s-tester/issues/63
- Remove extra ValidateAndSetDefaults() which gets called twice
  in the current create cluster path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
