### PR TITLE
Add main to e2e tester

### DIFF
--- a/e2e/tester/cmd/k8s-e2e-tester/main.go
+++ b/e2e/tester/cmd/k8s-e2e-tester/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/aws/aws-k8s-tester/e2e/tester"
+)
+
+func main() {
+	tester.Start()
+}

--- a/e2e/tester/go.mod
+++ b/e2e/tester/go.mod
@@ -1,3 +1,5 @@
 module github.com/aws/aws-k8s-tester/e2e/tester
 
 require gopkg.in/yaml.v2 v2.2.2
+
+go 1.13


### PR DESCRIPTION
This helps removing the main function in each individual projects. For each consuming project, it should just need to do:

```sh
GO111MODULE="on" go get github.com/aws/aws-k8s-tester/e2e/tester/cmd/k8s-e2e-tester@master
TESTCONFIG=./tester/single-az-config.yaml ${GOPATAH}/bin/k8s-e2e-tester
```
I'm using master branch as an example. In practice, the `@v1.x.y` suffix should be used to pin the released version of the e2e tester

/cc @M00nF1sh @gyuho 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
