### PR TITLE
ensure subtester jobs are torn down properly

### DIFF
--- a/eks/alb/alb.go
+++ b/eks/alb/alb.go
@@ -35,7 +35,11 @@ type Config struct {
 	Sig               chan os.Signal
 	EKSConfig         *eksconfig.Config
 	CloudFormationAPI cloudformationiface.CloudFormationAPI
-	K8SClient         *clientset.Clientset
+	K8SClient         k8sClientSetGetter
+}
+
+type k8sClientSetGetter interface {
+	KubernetesClientSet() *clientset.Clientset
 }
 
 // Tester defines Job tester.
@@ -395,7 +399,7 @@ func (ts *tester) deleteALBIngressControllerPolicy() error {
 // https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/examples/rbac-role.yaml
 func (ts *tester) createALBIngressControllerServiceAccount() error {
 	ts.cfg.Logger.Info("creating ALB Ingress Controller  ServiceAccount")
-	_, err := ts.cfg.K8SClient.
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
 		CoreV1().
 		ServiceAccounts(albIngressControllerServiceAccountNamespace).
 		Create(&v1.ServiceAccount{
@@ -424,7 +428,7 @@ func (ts *tester) createALBIngressControllerServiceAccount() error {
 func (ts *tester) deleteALBIngressControllerServiceAccount() error {
 	ts.cfg.Logger.Info("deleting ALB Ingress Controller ServiceAccount")
 	foreground := metav1.DeletePropagationForeground
-	err := ts.cfg.K8SClient.
+	err := ts.cfg.K8SClient.KubernetesClientSet().
 		CoreV1().
 		ServiceAccounts(albIngressControllerServiceAccountNamespace).
 		Delete(
@@ -446,7 +450,7 @@ func (ts *tester) deleteALBIngressControllerServiceAccount() error {
 // https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/examples/rbac-role.yaml
 func (ts *tester) createALBIngressControllerRBACClusterRole() error {
 	ts.cfg.Logger.Info("creating ALB Ingress Controller RBAC ClusterRole")
-	_, err := ts.cfg.K8SClient.
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
 		RbacV1().
 		ClusterRoles().
 		Create(&rbacv1.ClusterRole{
@@ -517,7 +521,7 @@ func (ts *tester) createALBIngressControllerRBACClusterRole() error {
 func (ts *tester) deleteALBIngressControllerRBACClusterRole() error {
 	ts.cfg.Logger.Info("deleting ALB Ingress Controller RBAC ClusterRole")
 	foreground := metav1.DeletePropagationForeground
-	err := ts.cfg.K8SClient.
+	err := ts.cfg.K8SClient.KubernetesClientSet().
 		RbacV1().
 		ClusterRoles().
 		Delete(
@@ -539,7 +543,7 @@ func (ts *tester) deleteALBIngressControllerRBACClusterRole() error {
 // https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/examples/rbac-role.yaml
 func (ts *tester) createALBIngressControllerRBACClusterRoleBinding() error {
 	ts.cfg.Logger.Info("creating ALB Ingress Controller RBAC ClusterRoleBinding")
-	_, err := ts.cfg.K8SClient.
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
 		RbacV1().
 		ClusterRoleBindings().
 		Create(&rbacv1.ClusterRoleBinding{
@@ -580,7 +584,7 @@ func (ts *tester) createALBIngressControllerRBACClusterRoleBinding() error {
 func (ts *tester) deleteALBIngressControllerRBACClusterRoleBinding() error {
 	ts.cfg.Logger.Info("deleting ALB Ingress Controller RBAC ClusterRoleBinding")
 	foreground := metav1.DeletePropagationForeground
-	err := ts.cfg.K8SClient.
+	err := ts.cfg.K8SClient.KubernetesClientSet().
 		RbacV1().
 		ClusterRoleBindings().
 		Delete(
@@ -602,7 +606,7 @@ func (ts *tester) deleteALBIngressControllerRBACClusterRoleBinding() error {
 // https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/examples/alb-ingress-controller.yaml
 func (ts *tester) createALBIngressControllerDeployment() error {
 	ts.cfg.Logger.Info("creating ALB Ingress Controller Deployment")
-	_, err := ts.cfg.K8SClient.
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
 		AppsV1().
 		Deployments(albIngressControllerDeploymentNamespace).
 		Create(&appsv1.Deployment{
@@ -662,7 +666,7 @@ func (ts *tester) createALBIngressControllerDeployment() error {
 func (ts *tester) deleteALBIngressControllerDeployment() error {
 	ts.cfg.Logger.Info("deleting ALB Ingress Controller Deployment")
 	foreground := metav1.DeletePropagationForeground
-	err := ts.cfg.K8SClient.
+	err := ts.cfg.K8SClient.KubernetesClientSet().
 		AppsV1().
 		Deployments(albIngressControllerDeploymentNamespace).
 		Delete(
@@ -684,7 +688,7 @@ func (ts *tester) deleteALBIngressControllerDeployment() error {
 // https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/examples/2048/2048-deployment.yaml
 func (ts *tester) createDeployment() error {
 	ts.cfg.Logger.Info("creating ALB 2048 Deployment")
-	_, err := ts.cfg.K8SClient.
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
 		AppsV1().
 		Deployments(ts.cfg.EKSConfig.Name).
 		Create(&appsv1.Deployment{
@@ -743,7 +747,7 @@ func (ts *tester) createDeployment() error {
 func (ts *tester) deleteDeployment() error {
 	ts.cfg.Logger.Info("deleting ALB 2048 Deployment")
 	foreground := metav1.DeletePropagationForeground
-	err := ts.cfg.K8SClient.
+	err := ts.cfg.K8SClient.KubernetesClientSet().
 		AppsV1().
 		Deployments(ts.cfg.EKSConfig.Name).
 		Delete(
@@ -765,7 +769,7 @@ func (ts *tester) deleteDeployment() error {
 // https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/examples/2048/2048-service.yaml
 func (ts *tester) createService() error {
 	ts.cfg.Logger.Info("creating ALB 2048 Service")
-	_, err := ts.cfg.K8SClient.
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
 		CoreV1().
 		Services(ts.cfg.EKSConfig.Name).
 		Create(&v1.Service{
@@ -804,7 +808,7 @@ func (ts *tester) createService() error {
 func (ts *tester) deleteService() error {
 	ts.cfg.Logger.Info("deleting ALB 2048 Service")
 	foreground := metav1.DeletePropagationForeground
-	err := ts.cfg.K8SClient.
+	err := ts.cfg.K8SClient.KubernetesClientSet().
 		CoreV1().
 		Services(ts.cfg.EKSConfig.Name).
 		Delete(
@@ -826,7 +830,7 @@ func (ts *tester) deleteService() error {
 // https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/examples/2048/2048-ingress.yaml
 func (ts *tester) createIngress() error {
 	ts.cfg.Logger.Info("creating ALB 2048 Ingress")
-	_, err := ts.cfg.K8SClient.
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
 		ExtensionsV1beta1().
 		Ingresses(ts.cfg.EKSConfig.Name).
 		Create(&v1beta1.Ingress{
@@ -891,7 +895,7 @@ func (ts *tester) createIngress() error {
 		case <-time.After(5 * time.Second):
 		}
 		ts.cfg.Logger.Info("querying ALB 2048 Ingress for HTTP endpoint")
-		so, err := ts.cfg.K8SClient.
+		so, err := ts.cfg.K8SClient.KubernetesClientSet().
 			ExtensionsV1beta1().
 			Ingresses(ts.cfg.EKSConfig.Name).
 			Get(alb2048IngressName, metav1.GetOptions{})
@@ -970,7 +974,7 @@ func (ts *tester) createIngress() error {
 func (ts *tester) deleteIngress() error {
 	ts.cfg.Logger.Info("deleting ALB 2048 Ingress")
 	foreground := metav1.DeletePropagationForeground
-	err := ts.cfg.K8SClient.
+	err := ts.cfg.K8SClient.KubernetesClientSet().
 		ExtensionsV1beta1().
 		Ingresses(ts.cfg.EKSConfig.Name).
 		Delete(

--- a/eks/eks.go
+++ b/eks/eks.go
@@ -262,7 +262,7 @@ func (ts *Tester) createSubTesters() (err error) {
 			Logger:    ts.lg,
 			Stopc:     ts.stopCreationCh,
 			Sig:       ts.interruptSig,
-			K8SClient: ts.k8sClientSet,
+			K8SClient: ts,
 			EKSConfig: ts.cfg,
 		})
 		if err != nil {
@@ -273,7 +273,7 @@ func (ts *Tester) createSubTesters() (err error) {
 			Stopc:             ts.stopCreationCh,
 			Sig:               ts.interruptSig,
 			CloudFormationAPI: ts.cfnAPI,
-			K8SClient:         ts.k8sClientSet,
+			K8SClient:         ts,
 			EKSConfig:         ts.cfg,
 		})
 		if err != nil {
@@ -283,7 +283,7 @@ func (ts *Tester) createSubTesters() (err error) {
 			Logger:    ts.lg,
 			Stopc:     ts.stopCreationCh,
 			Sig:       ts.interruptSig,
-			K8SClient: ts.k8sClientSet,
+			K8SClient: ts,
 			Namespace: ts.cfg.Name,
 			JobName:   jobs.JobNamePi,
 			Completes: ts.cfg.AddOnJobPerl.Completes,
@@ -296,7 +296,7 @@ func (ts *Tester) createSubTesters() (err error) {
 			Logger:    ts.lg,
 			Stopc:     ts.stopCreationCh,
 			Sig:       ts.interruptSig,
-			K8SClient: ts.k8sClientSet,
+			K8SClient: ts,
 			Namespace: ts.cfg.Name,
 			JobName:   jobs.JobNameEcho,
 			Completes: ts.cfg.AddOnJobEcho.Completes,
@@ -645,6 +645,12 @@ func (ts *Tester) KubectlCommand() (*osexec.Cmd, error) {
 
 // KubernetesClientSet returns Kubernetes Go client.
 func (ts *Tester) KubernetesClientSet() *kubernetes.Clientset {
+	if ts.k8sClientSet == nil {
+		if err := ts.updateK8sClientSet(); err != nil {
+			ts.lg.Warn("failed to update k8s client set", zap.Error(err))
+			return nil
+		}
+	}
 	return ts.k8sClientSet
 }
 

--- a/eks/nlb/nlb.go
+++ b/eks/nlb/nlb.go
@@ -28,7 +28,11 @@ type Config struct {
 	Stopc     chan struct{}
 	Sig       chan os.Signal
 	EKSConfig *eksconfig.Config
-	K8SClient *clientset.Clientset
+	K8SClient k8sClientSetGetter
+}
+
+type k8sClientSetGetter interface {
+	KubernetesClientSet() *clientset.Clientset
 }
 
 // Tester defines Job tester.
@@ -81,7 +85,7 @@ func (ts *tester) Delete() error {
 
 func (ts *tester) createDeployment() error {
 	ts.cfg.Logger.Info("creating NLB hello-world Deployment")
-	_, err := ts.cfg.K8SClient.
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
 		AppsV1().
 		Deployments(ts.cfg.EKSConfig.Name).
 		Create(&appsv1.Deployment{
@@ -138,7 +142,7 @@ func (ts *tester) createDeployment() error {
 func (ts *tester) deleteDeployment() error {
 	ts.cfg.Logger.Info("deleting NLB hello-world Deployment")
 	foreground := metav1.DeletePropagationForeground
-	err := ts.cfg.K8SClient.
+	err := ts.cfg.K8SClient.KubernetesClientSet().
 		AppsV1().
 		Deployments(ts.cfg.EKSConfig.Name).
 		Delete(
@@ -158,7 +162,7 @@ func (ts *tester) deleteDeployment() error {
 
 func (ts *tester) createService() error {
 	ts.cfg.Logger.Info("creating NLB hello-world Service")
-	_, err := ts.cfg.K8SClient.
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
 		CoreV1().
 		Services(ts.cfg.EKSConfig.Name).
 		Create(&v1.Service{
@@ -213,7 +217,7 @@ func (ts *tester) createService() error {
 		case <-time.After(5 * time.Second):
 		}
 		ts.cfg.Logger.Info("querying NLB hello-world Service for HTTP endpoint")
-		so, err := ts.cfg.K8SClient.
+		so, err := ts.cfg.K8SClient.KubernetesClientSet().
 			CoreV1().
 			Services(ts.cfg.EKSConfig.Name).
 			Get(nlbHelloWorldServiceName, metav1.GetOptions{})
@@ -290,7 +294,7 @@ func (ts *tester) createService() error {
 func (ts *tester) deleteService() error {
 	ts.cfg.Logger.Info("deleting NLB hello-world Service")
 	foreground := metav1.DeletePropagationForeground
-	err := ts.cfg.K8SClient.
+	err := ts.cfg.K8SClient.KubernetesClientSet().
 		CoreV1().
 		Services(ts.cfg.EKSConfig.Name).
 		Delete(


### PR DESCRIPTION
There was a problem with ALB/NLB resources not being cleaned up
when an EKS cluster was deleted by aws-k8s-tester. It turned out that
the subtester objects that create/delete resources like the ALB2048
Deployment were not being constructed properly if the
`aws-k8s-tester delete cluster` command was run. Previously, these
subtester objects were only created in `Tester.up()` which is not called
when `Tester.down()` is called.

This commit moves construction of these subtester objects into the
construction of the primary Tester object, which alleviates the issue
with non-initialized subtesters in `Tester.down()`. In doing so, I've
changed the construction of the subtester objects to take a pointer
to the `Tester` instance and grab their K8sClientSets from that
instance.

Issue #70 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
