### PR TITLE
Don't sync default config before UpdateFromEnv()

### DIFF
--- a/cmd/aws-k8s-tester/eks/create.go
+++ b/cmd/aws-k8s-tester/eks/create.go
@@ -38,7 +38,6 @@ func configFunc(cmd *cobra.Command, args []string) {
 	}
 	cfg := eksconfig.NewDefault()
 	cfg.ConfigPath = path
-	cfg.Sync()
 
 	fmt.Printf("\n*********************************\n")
 	fmt.Printf("overwriting config file from environment variables...\n")


### PR DESCRIPTION
*Issue #, if available:*

fixes #82 

*Description of changes:*

Sync() will nil not-enabled addons and fail `UpdateFromEnv()`. However, it's not necessary to sync default config and we can remove it. At the end of the function, `cfg.ValidateAndSetDefaults` will sync configuration with overrides from environment variables to file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
