### PR TITLE
vendor: update modules.txt

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,6 +85,7 @@ github.com/armon/circbuf
 # github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
 github.com/asaskevich/govalidator
 # github.com/aws/aws-sdk-go v1.31.4
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr
@@ -168,6 +169,7 @@ github.com/checkpoint-restore/go-criu/rpc
 # github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 github.com/chzyer/readline
 # github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
+## explicit
 github.com/cihub/seelog
 github.com/cihub/seelog/archive
 github.com/cihub/seelog/archive/gzip
@@ -230,6 +232,7 @@ github.com/coreos/pkg/capnslog
 # github.com/cyphar/filepath-securejoin v0.2.2
 github.com/cyphar/filepath-securejoin
 # github.com/davecgh/go-spew v1.1.1
+## explicit
 github.com/davecgh/go-spew/spew
 # github.com/deislabs/oras v0.8.1
 github.com/deislabs/oras/pkg/artifact
@@ -317,6 +320,7 @@ github.com/dsnet/compress/internal
 github.com/dsnet/compress/internal/errors
 github.com/dsnet/compress/internal/prefix
 # github.com/dustin/go-humanize v1.0.0
+## explicit
 github.com/dustin/go-humanize
 # github.com/emicklei/go-restful v2.9.5+incompatible
 github.com/emicklei/go-restful
@@ -328,12 +332,14 @@ github.com/evanphx/json-patch
 # github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 github.com/exponent-io/jsonpath
 # github.com/fatih/color v1.9.0
+## explicit
 github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.7
 github.com/fsnotify/fsnotify
 # github.com/ghodss/yaml v1.0.0
 github.com/ghodss/yaml
 # github.com/go-ini/ini v1.55.0
+## explicit
 github.com/go-ini/ini
 # github.com/go-openapi/jsonpointer v0.19.3
 github.com/go-openapi/jsonpointer
@@ -358,6 +364,7 @@ github.com/gobwas/glob/util/strings
 # github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e
 github.com/godbus/dbus
 # github.com/gofrs/flock v0.7.1
+## explicit
 github.com/gofrs/flock
 # github.com/gogo/protobuf v1.3.1
 github.com/gogo/protobuf/gogoproto
@@ -550,6 +557,7 @@ github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
 # github.com/manifoldco/promptui v0.7.0
+## explicit
 github.com/manifoldco/promptui
 github.com/manifoldco/promptui/list
 github.com/manifoldco/promptui/screenbuf
@@ -558,12 +566,14 @@ github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.11
 github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.8
+## explicit
 github.com/mattn/go-runewidth
 # github.com/mattn/go-shellwords v1.0.10
 github.com/mattn/go-shellwords
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/mholt/archiver/v3 v3.3.0
+## explicit
 github.com/mholt/archiver/v3
 # github.com/miekg/dns v1.1.4
 github.com/miekg/dns
@@ -576,6 +586,7 @@ github.com/mitchellh/copystructure
 # github.com/mitchellh/go-wordwrap v1.0.0
 github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e
+## explicit
 github.com/mitchellh/ioprogress
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
@@ -598,8 +609,10 @@ github.com/mxk/go-flowrate/flowrate
 # github.com/nwaples/rardecode v1.0.0
 github.com/nwaples/rardecode
 # github.com/olekukonko/tablewriter v0.0.2
+## explicit
 github.com/olekukonko/tablewriter
 # github.com/onsi/ginkgo v1.11.0
+## explicit
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/internal/codelocation
@@ -619,6 +632,7 @@ github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
 # github.com/onsi/gomega v1.7.1
+## explicit
 github.com/onsi/gomega
 github.com/onsi/gomega/format
 github.com/onsi/gomega/internal/assertion
@@ -673,6 +687,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.6.0
+## explicit
 github.com/prometheus/client_golang/api
 github.com/prometheus/client_golang/api/prometheus/v1
 github.com/prometheus/client_golang/prometheus
@@ -681,8 +696,10 @@ github.com/prometheus/client_golang/prometheus/promhttp
 github.com/prometheus/client_golang/prometheus/testutil
 github.com/prometheus/client_golang/prometheus/testutil/promlint
 # github.com/prometheus/client_model v0.2.0
+## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.9.1
+## explicit
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/model
@@ -711,8 +728,10 @@ github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.1
 github.com/spf13/cast
 # github.com/spf13/cobra v1.0.0
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 github.com/storageos/go-api
@@ -722,6 +741,7 @@ github.com/storageos/go-api/types
 # github.com/stretchr/objx v0.2.0
 github.com/stretchr/objx
 # github.com/stretchr/testify v1.5.1
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 # github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
@@ -775,6 +795,7 @@ github.com/xeipuuv/gojsonschema
 # github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 github.com/xi2/xz
 # go.etcd.io/etcd v0.5.0-alpha.5.0.20200520232829-54ba9589114f
+## explicit
 go.etcd.io/etcd/auth/authpb
 go.etcd.io/etcd/clientv3
 go.etcd.io/etcd/clientv3/balancer
@@ -819,6 +840,7 @@ go.uber.org/atomic
 # go.uber.org/multierr v1.5.0
 go.uber.org/multierr
 # go.uber.org/zap v1.15.0
+## explicit
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool
@@ -826,6 +848,7 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20200414173820-0848c9571904
+## explicit
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/cast5
@@ -870,6 +893,7 @@ golang.org/x/net/proxy
 golang.org/x/net/trace
 golang.org/x/net/websocket
 # golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
@@ -908,6 +932,7 @@ golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+## explicit
 golang.org/x/time/rate
 # google.golang.org/api v0.6.1-0.20190607001116-5213b8090861
 google.golang.org/api/compute/v0.alpha
@@ -1019,13 +1044,17 @@ gopkg.in/gcfg.v1/types
 gopkg.in/gorp.v1
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
+# gopkg.in/ini.v1 v1.46.0
+## explicit
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tomb.v1
 # gopkg.in/warnings.v0 v0.1.1
 gopkg.in/warnings.v0
 # gopkg.in/yaml.v2 v2.2.8
+## explicit
 gopkg.in/yaml.v2
 # helm.sh/helm/v3 v3.2.1
+## explicit
 helm.sh/helm/v3/internal/experimental/registry
 helm.sh/helm/v3/internal/fileutil
 helm.sh/helm/v3/internal/ignore
@@ -1061,6 +1090,7 @@ helm.sh/helm/v3/pkg/storage
 helm.sh/helm/v3/pkg/storage/driver
 helm.sh/helm/v3/pkg/time
 # k8s.io/api v0.18.3 => k8s.io/api v0.18.3
+## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -1109,6 +1139,7 @@ k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 # k8s.io/apimachinery v0.18.3 => k8s.io/apimachinery v0.18.3
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -1266,6 +1297,7 @@ k8s.io/apiserver/pkg/util/wsstream
 k8s.io/apiserver/plugin/pkg/authenticator/token/webhook
 k8s.io/apiserver/plugin/pkg/authorizer/webhook
 # k8s.io/cli-runtime v0.18.3 => k8s.io/cli-runtime v0.18.3
+## explicit
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/kustomize
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps
@@ -1279,6 +1311,7 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/validator
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v0.18.3 => k8s.io/client-go v0.18.3
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/fake
@@ -1559,6 +1592,7 @@ k8s.io/kubelet/config/v1beta1
 k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1
 k8s.io/kubelet/pkg/apis/pluginregistration/v1
 # k8s.io/kubernetes v1.13.0 => k8s.io/kubernetes v1.18.2
+## explicit
 k8s.io/kubernetes/cmd/kube-proxy/app
 k8s.io/kubernetes/cmd/kubelet/app
 k8s.io/kubernetes/cmd/kubelet/app/options
@@ -1855,6 +1889,7 @@ k8s.io/legacy-cloud-providers/vsphere
 k8s.io/legacy-cloud-providers/vsphere/vclib
 k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers
 # k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/clock
 k8s.io/utils/exec
@@ -1870,6 +1905,8 @@ k8s.io/utils/path
 k8s.io/utils/pointer
 k8s.io/utils/strings
 k8s.io/utils/trace
+# rsc.io/letsencrypt v0.0.3
+## explicit
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
@@ -1903,4 +1940,30 @@ sigs.k8s.io/structured-merge-diff/v3/schema
 sigs.k8s.io/structured-merge-diff/v3/typed
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
+# github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.2.0+incompatible
+# github.com/containerd/containerd => github.com/containerd/containerd v1.3.4
+# github.com/google/cadvisor => github.com/google/cadvisor v0.36.0
+# k8s.io/api => k8s.io/api v0.18.3
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.3
+# k8s.io/apimachinery => k8s.io/apimachinery v0.18.3
+# k8s.io/apiserver => k8s.io/apiserver v0.18.3
+# k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.3
+# k8s.io/client-go => k8s.io/client-go v0.18.3
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.3
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.3
+# k8s.io/code-generator => k8s.io/code-generator v0.18.3
+# k8s.io/component-base => k8s.io/component-base v0.18.3
+# k8s.io/cri-api => k8s.io/cri-api v0.18.3
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.3
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.3
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.3
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.3
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.3
+# k8s.io/kubectl => k8s.io/kubectl v0.18.3
+# k8s.io/kubelet => k8s.io/kubelet v0.18.3
+# k8s.io/kubernetes => k8s.io/kubernetes v1.18.2
+# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.3
+# k8s.io/metrics => k8s.io/metrics v0.18.3
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.3


### PR DESCRIPTION
Fix

```
go: inconsistent vendoring in /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester:
        github.com/aws/aws-sdk-go@v1.31.4: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/cihub/seelog@v0.0.0-20170130134532-f561c5e57575: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/davecgh/go-spew@v1.1.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/dustin/go-humanize@v1.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/fatih/color@v1.9.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/go-ini/ini@v1.55.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/gofrs/flock@v0.7.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/manifoldco/promptui@v0.7.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/mattn/go-runewidth@v0.0.8: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/mholt/archiver/v3@v3.3.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/mitchellh/ioprogress@v0.0.0-20180201004757-6a23b12fa88e: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/olekukonko/tablewriter@v0.0.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/onsi/ginkgo@v1.11.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/onsi/gomega@v1.7.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/prometheus/client_golang@v1.6.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/prometheus/client_model@v0.2.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/prometheus/common@v0.9.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/spf13/cobra@v1.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/spf13/pflag@v1.0.5: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/stretchr/testify@v1.5.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.etcd.io/etcd@v0.5.0-alpha.5.0.20200520232829-54ba9589114f: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.uber.org/zap@v1.15.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/crypto@v0.0.0-20200414173820-0848c9571904: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/oauth2@v0.0.0-20190604053449-0f29369cfe45: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/time@v0.0.0-20191024005414-555d28b269f0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        gopkg.in/ini.v1@v1.46.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        gopkg.in/yaml.v2@v2.2.8: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        helm.sh/helm/v3@v3.2.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        k8s.io/api@v0.18.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        k8s.io/apimachinery@v0.18.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        k8s.io/cli-runtime@v0.18.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        k8s.io/client-go@v0.18.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        k8s.io/kubernetes@v1.13.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        k8s.io/utils@v0.0.0-20200324210504-a9aa75ae1b89: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        rsc.io/letsencrypt@v0.0.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        sigs.k8s.io/yaml@v1.2.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/Azure/go-autorest: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
        github.com/containerd/containerd: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
        github.com/google/cadvisor: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
        k8s.io/api: is replaced in go.mod, but not marked as replaced in vendor/modules.txt

```