### PR TITLE
Download kops v1.17.0

### DIFF
--- a/e2e/tester/pkg/kops.go
+++ b/e2e/tester/pkg/kops.go
@@ -104,7 +104,7 @@ func (c *KopsClusterCreator) clusterName() string {
 
 func (c *KopsClusterCreator) downloadKops() error {
 	osArch := fmt.Sprintf("%s-amd64", runtime.GOOS)
-	url := fmt.Sprintf("https://github.com/kubernetes/kops/releases/download/1.14.0-alpha.1/kops-%s", osArch)
+	url := fmt.Sprintf("https://github.com/kubernetes/kops/releases/download/v1.17.0/kops-%s", osArch)
 	log.Printf("Downloading KOPS from %s to %s", url, c.KopsBinaryPath)
 	resp, err := http.Get(url)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* don't download hardcoded kops 1.14 alpha. download hardcoded 1.17 instead. Probably this should be configurable but not interested in figuring out how to pipe it through at the moment ~.~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
