### PR TITLE
use 1.17 kubectl and add 1.17 deprecated apis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN rm -rf /go/src/github.com/aws/aws-k8s-tester
 RUN chmod +x /aws-k8s-tester /ec2-utils /eks-utils /etcd-utils /cw-utils /clusterloader2
 WORKDIR /
 
-RUN curl -o /kubectl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.9/bin/linux/amd64/kubectl && chmod +x /kubectl && cp /kubectl /usr/local/bin/kubectl
+RUN curl -o /kubectl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.6/bin/linux/amd64/kubectl && chmod +x /kubectl && cp /kubectl /usr/local/bin/kubectl
 RUN ls /
 RUN ls /*.yaml
 RUN aws --version

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ AWS_K8S_TESTER_EKS_COMMAND_AFTER_CREATE_CLUSTER="aws eks describe-cluster --name
 AWS_K8S_TESTER_EKS_COMMAND_AFTER_CREATE_ADD_ONS="aws eks describe-cluster --name GetRef.Name" \
 AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_CREATE=true \
 AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_CREATE=true \
-AWS_K8S_TESTER_EKS_PARAMETERS_VERSION=1.16 \
+AWS_K8S_TESTER_EKS_PARAMETERS_VERSION=1.17 \
 AWS_K8S_TESTER_EKS_PARAMETERS_VPC_CREATE=true \
 AWS_K8S_TESTER_EKS_CLIENTS=5 \
 AWS_K8S_TESTER_EKS_CLIENT_QPS=30 \
 AWS_K8S_TESTER_EKS_CLIENT_BURST=20 \
 AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_CREATE=true \
-AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS='{"GetRef.Name-ng-al2-cpu":{"name":"GetRef.Name-ng-al2-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id":"","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.16/amazon-linux-2/recommended/image_id","instance-types":["c5.xlarge"],"volume-size":40,"asg-min-size":2,"asg-max-size":2,"asg-desired-capacity":2,"kubelet-extra-args":""},"GetRef.Name-ng-al2-gpu":{"name":"GetRef.Name-ng-al2-gpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64_GPU","image-id":"","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.16/amazon-linux-2-gpu/recommended/image_id","instance-types":["p3.8xlarge"],"volume-size":40,"asg-min-size":1,"asg-max-size":1,"asg-desired-capacity":1,"kubelet-extra-args":""},"GetRef.Name-ng-bottlerocket":{"name":"GetRef.Name-ng-bottlerocket","remote-access-user-name":"ec2-user","ami-type":"BOTTLEROCKET_x86_64","image-id":"","image-id-ssm-parameter":"/aws/service/bottlerocket/aws-k8s-1.15/x86_64/latest/image_id","ssm-document-cfn-stack-name":"GetRef.Name-install-bottlerocket","ssm-document-name":"GetRef.Name-InstallBottlerocket","ssm-document-create":true,"ssm-document-commands":"enable-admin-container","ssm-document-execution-timeout-seconds":3600,"instance-types":["c5.xlarge"],"volume-size":40,"asg-min-size":2,"asg-max-size":2,"asg-desired-capacity":2}}' \
+AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS='{"GetRef.Name-ng-al2-cpu":{"name":"GetRef.Name-ng-al2-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id":"","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.17/amazon-linux-2/recommended/image_id","instance-types":["c5.xlarge"],"volume-size":40,"asg-min-size":2,"asg-max-size":2,"asg-desired-capacity":2,"kubelet-extra-args":""},"GetRef.Name-ng-al2-gpu":{"name":"GetRef.Name-ng-al2-gpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64_GPU","image-id":"","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.17/amazon-linux-2-gpu/recommended/image_id","instance-types":["p3.8xlarge"],"volume-size":40,"asg-min-size":1,"asg-max-size":1,"asg-desired-capacity":1,"kubelet-extra-args":""},"GetRef.Name-ng-bottlerocket":{"name":"GetRef.Name-ng-bottlerocket","remote-access-user-name":"ec2-user","ami-type":"BOTTLEROCKET_x86_64","image-id":"","image-id-ssm-parameter":"/aws/service/bottlerocket/aws-k8s-1.15/x86_64/latest/image_id","ssm-document-cfn-stack-name":"GetRef.Name-install-bottlerocket","ssm-document-name":"GetRef.Name-InstallBottlerocket","ssm-document-create":true,"ssm-document-commands":"enable-admin-container","ssm-document-execution-timeout-seconds":3600,"instance-types":["c5.xlarge"],"volume-size":40,"asg-min-size":2,"asg-max-size":2,"asg-desired-capacity":2}}' \
 AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ROLE_CREATE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_MNGS='{"GetRef.Name-mng-al2-cpu":{"name":"GetRef.Name-mng-al2-cpu","remote-access-user-name":"ec2-user","release-version":"","ami-type":"AL2_x86_64","instance-types":["c5.xlarge"],"volume-size":40,"asg-min-size":2,"asg-max-size":2,"asg-desired-capacity":2},"GetRef.Name-mng-al2-gpu":{"name":"GetRef.Name-mng-al2-gpu","remote-access-user-name":"ec2-user","release-version":"","ami-type":"AL2_x86_64_GPU","instance-types":["p3.8xlarge"],"volume-size":40,"asg-min-size":1,"asg-max-size":1,"asg-desired-capacity":1}}' \
@@ -334,7 +334,7 @@ chmod +x /tmp/eks-utils
 }
 ```
 
-`eks-utils apis` helps with API deprecation (e.g. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals).
+`eks-utils apis` helps with API deprecation (e.g. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md#deprecations-and-removals).
 
 **WARNING**: `kubectl` internally converts API versions in the response (see [`kubernetes/issues#58131`](https://github.com/kubernetes/kubernetes/issues/58131#issuecomment-403829566)). Which means `kubectl get` output may have different API versions than the one persisted in `etcd` . Upstream Kubernetes recommends upgrading deprecated API with *get and put*:
 
@@ -375,7 +375,7 @@ find /tmp/eks-utils-resources
 
 ## `etcd-utils k8s list`
 
-`etcd-utils k8s list` helps with API deprecation (e.g. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals).
+`etcd-utils k8s list` helps with API deprecation (e.g. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md#deprecations-and-removals).
 
 **WARNING**: `kubectl` internally converts API versions in the response (see [`kubernetes/issues#58131`](https://github.com/kubernetes/kubernetes/issues/58131#issuecomment-403829566)). Which means `kubectl get` output may have different API versions than the one persisted in `etcd` . Upstream Kubernetes recommends upgrading deprecated API with *get and put*:
 

--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -611,8 +611,8 @@ func NewDefault() *Config {
 		// https://github.com/kubernetes/kubernetes/tags
 		// https://kubernetes.io/docs/tasks/tools/install-kubectl/
 		// https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
-		KubectlPath:        "/tmp/kubectl-test-v1.16.9",
-		KubectlDownloadURL: "https://storage.googleapis.com/kubernetes-release/release/v1.16.9/bin/linux/amd64/kubectl",
+		KubectlPath:        "/tmp/kubectl-test-v1.17.6",
+		KubectlDownloadURL: "https://storage.googleapis.com/kubernetes-release/release/v1.17.6/bin/linux/amd64/kubectl",
 
 		OnFailureDelete:            true,
 		OnFailureDeleteWaitSeconds: 120,

--- a/eksconfig/default.yaml
+++ b/eksconfig/default.yaml
@@ -15,8 +15,8 @@ command-after-create-cluster-timeout-string: 3m0s
 config-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.yaml
 kubeconfig-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.kubeconfig.yaml
 kubectl-commands-output-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.kubectl.sh
-kubectl-download-url: https://storage.googleapis.com/kubernetes-release/release/v1.16.9/bin/linux/amd64/kubectl
-kubectl-path: /tmp/kubectl-test-v1.16.9
+kubectl-download-url: https://storage.googleapis.com/kubernetes-release/release/v1.17.6/bin/linux/amd64/kubectl
+kubectl-path: /tmp/kubectl-test-v1.17.6
 log-color: true
 log-level: info
 log-outputs:
@@ -43,8 +43,8 @@ parameters:
   role-service-principals: null
   signing-name: eks
   tags: null
-  version: "1.16"
-  version-value: 1.16
+  version: "1.17"
+  version-value: 1.17
   vpc-cfn-stack-id: ""
   vpc-create: true
   vpc-id: ""

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -106,7 +106,7 @@ func TestEnv(t *testing.T) {
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_SERVICE_PRINCIPALS")
 	os.Setenv("AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_MANAGED_POLICY_ARNS", "arn:aws:iam::aws:policy/AmazonEKSServicePolicy,arn:aws:iam::aws:policy/AmazonEKSClusterPolicy,arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_MANAGED_POLICY_ARNS")
-	os.Setenv("AWS_K8S_TESTER_EKS_PARAMETERS_VERSION", "1.16")
+	os.Setenv("AWS_K8S_TESTER_EKS_PARAMETERS_VERSION", "1.17")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_PARAMETERS_VERSION")
 	os.Setenv("AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_CREATE", "false")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_CREATE")
@@ -614,7 +614,7 @@ func TestEnv(t *testing.T) {
 	if !reflect.DeepEqual(expectedRoleManagedPolicyARNs, cfg.Parameters.RoleManagedPolicyARNs) {
 		t.Fatalf("unexpected Parameters.RoleManagedPolicyARNs %+v", cfg.Parameters.RoleManagedPolicyARNs)
 	}
-	if cfg.Parameters.Version != "1.16" {
+	if cfg.Parameters.Version != "1.17" {
 		t.Fatalf("unexpected Parameters.Version %q", cfg.Parameters.Version)
 	}
 	if cfg.Parameters.EncryptionCMKCreate {

--- a/pkg/k8s-client/eks-deprecate/deprecate.go
+++ b/pkg/k8s-client/eks-deprecate/deprecate.go
@@ -15,7 +15,7 @@ import (
 
 var deprecates = map[float64]map[metav1.TypeMeta]metav1.TypeMeta{
 
-	// https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals
+	// https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md#deprecations-and-removals
 	// "kubectl convert" is deprecated
 	// https://github.com/kubernetes/kubectl/issues/725
 	//
@@ -38,6 +38,13 @@ var deprecates = map[float64]map[metav1.TypeMeta]metav1.TypeMeta{
 		metav1.TypeMeta{APIVersion: "extensions/v1beta1", Kind: "ReplicaSet"}:        metav1.TypeMeta{APIVersion: "apps/v1", Kind: "ReplicaSet"},
 		metav1.TypeMeta{APIVersion: "extensions/v1beta1", Kind: "NetworkPolicy"}:     metav1.TypeMeta{APIVersion: "networking.k8s.io/v1", Kind: "NetworkPolicy"},
 		metav1.TypeMeta{APIVersion: "extensions/v1beta1", Kind: "PodSecurityPolicy"}: metav1.TypeMeta{APIVersion: "policy/v1beta1", Kind: "PodSecurityPolicy"},
+
+	},
+	1.17: {
+		metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1alpha1", Kind: "ClusterRole"}: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
+		metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1beta1", Kind: "ClusterRole"}: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
+		metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1alpha1", Kind: "ClusterRoleBinding"}: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"},
+		metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1beta1", Kind: "ClusterRoleBinding"}: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"},
 	},
 }
 

--- a/pkg/k8s-client/eks_test.go
+++ b/pkg/k8s-client/eks_test.go
@@ -10,12 +10,12 @@ import (
 func TestParseVersion(t *testing.T) {
 	body := []byte(`	{
 				"major": "1",
-				"minor": "16+",
-				"gitVersion": "v1.16.8-eks-e16311",
-				"gitCommit": "e163110a04dcb2f39c3325af96d019b4925419eb",
+				"minor": "17+",
+				"gitVersion": "v1.17.6-eks-db76ccf",
+				"gitCommit": "db76ccfa14cf55a34024a0a573ed3f8631f40aad",
 				"gitTreeState": "clean",
-				"buildDate": "2020-03-27T22:37:12Z",
-				"goVersion": "go1.13.8",
+				"buildDate": "2020-05-21T23:51:40Z",
+				"goVersion": "go1.13.9",
 				"compiler": "gc",
 				"platform": "linux/amd64"
 			}`)

--- a/pkg/k8s-object/node_test.go
+++ b/pkg/k8s-object/node_test.go
@@ -39,7 +39,23 @@ func TestParseNode(t *testing.T) {
 	if !reflect.DeepEqual(np2, exp2) {
 		t.Fatalf("expected %+v, got %+v", exp2, np2)
 	}
+	np3 := ParseNodeInfo(v1.NodeSystemInfo{
+		KubeletVersion:   "v1.17.6-eks-db76ccf",
+		KubeProxyVersion: "v1.17.6-eks-db76ccf",
+	})
+	exp3 := NodeInfo{
+		NodeSystemInfo: v1.NodeSystemInfo{
+			KubeletVersion:   "v1.17.6-eks-db76ccf",
+			KubeProxyVersion: "v1.17.6-eks-db76ccf",
+		},
+		KubeletMinorVersionValue:   1.17,
+		KubeProxyMinorVersionValue: 1.17,
+	}
+	if !reflect.DeepEqual(np3, exp3) {
+		t.Fatalf("expected %+v, got %+v", exp3, np3)
+	}
 
 	fmt.Printf("%+v\n", np1)
 	fmt.Printf("%+v\n", np2)
+	fmt.Printf("%+v\n", np3)
 }


### PR DESCRIPTION

*Description of changes:*
- use 1.17 kubectl 
-  watch out for 1.17 deprecated apis

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
