### PR TITLE
add cluster autoscaler addon

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -23,6 +23,10 @@ See [code changes](https://github.com/aws/aws-k8s-tester/compare/v1.3.9...v1.4.0
 
 - Clean up [`colorstring` printf](https://github.com/aws/aws-k8s-tester/pull/101).
 
+### `eksconfig`
+
+ - [`Add ClusterAutoScaler add-on per node-group using` AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS ='{"GetRef.Name-...":{..."cluster-autoscaler":{"enable":false}...}}`](https://github.com/aws/aws-k8s-tester/pull/99).
+
 ### `ssh`
 
 - Move [`"scp"` executable binary path check before creating context timeouts](https://github.com/aws/aws-k8s-tester/commit/4c3950e6582745684a9d628c5c0ea355e3f7edc1).
@@ -30,7 +34,6 @@ See [code changes](https://github.com/aws/aws-k8s-tester/compare/v1.3.9...v1.4.0
 ### Dependency
 
 - Upgrade [`github.com/aws/aws-sdk-go`](https://github.com/aws/aws-sdk-go/releases) from [`v1.32.2`](https://github.com/aws/aws-sdk-go/releases/tag/v1.32.2) to [`v1.32.3`](https://github.com/aws/aws-sdk-go/releases/tag/v1.32.3).
-
 
 <hr>
 

--- a/eks/ng/autoscaler/cluster-autoscaler.go
+++ b/eks/ng/autoscaler/cluster-autoscaler.go
@@ -1,0 +1,398 @@
+package autoscaler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/aws/aws-k8s-tester/eksconfig"
+	"github.com/aws/aws-k8s-tester/pkg/fileutil"
+	k8s_client "github.com/aws/aws-k8s-tester/pkg/k8s-client"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/eks/eksiface"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/exec"
+)
+
+// reference - https://raw.githubusercontent.com/kubernetes/autoscaler/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+const ClusterAutoscalerYAML = `
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "update"]
+  - apiGroups: [""]
+    resources:
+      - "pods"
+      - "services"
+      - "replicationcontrollers"
+      - "persistentvolumeclaims"
+      - "persistentvolumes"
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resourceNames: ["cluster-autoscaler"]
+    resources: ["leases"]
+    verbs: ["get", "update"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create","list","watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8085'
+        cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+    spec:
+      serviceAccountName: cluster-autoscaler
+      containers:
+{{ if ne .ImageURI "" }}{{.ImageURI}}{{ end }}
+          name: cluster-autoscaler
+          resources:
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --expander=least-waste
+{{ if ne .NodeGroupAutoDiscovery "" }}{{.NodeGroupAutoDiscovery}}{{ end }}
+            - --balance-similar-node-groups
+            - --skip-nodes-with-system-pods=false
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+          imagePullPolicy: "Always"
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-bundle.crt"
+`
+
+var images = map[string]string{
+	"1.17": `        - image: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.17.2`,
+	"1.16": `        - image: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.16.5`,
+}
+
+const (
+	nodeGroupAuotDiscoveryData      = `            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/`
+	clusterAutoScalerDeploymentName = "cluster-autoscaler"
+)
+
+type caSpecData struct {
+	ImageURI               string
+	NodeGroupAutoDiscovery string
+}
+
+// Config defines version upgrade configuration.
+type Config struct {
+	Logger    *zap.Logger
+	Stopc     chan struct{}
+	EKSConfig *eksconfig.Config
+	K8SClient k8s_client.EKS
+	EC2API    ec2iface.EC2API
+	ASGAPI    autoscalingiface.AutoScalingAPI
+	EKSAPI    eksiface.EKSAPI
+}
+
+// ClusterAutoScaler defines cluster autoscaler operation.
+type ClusterAutoscaler interface {
+	Create() error
+}
+
+// New creates a new cluster autoscaler.
+func New(cfg Config) ClusterAutoscaler {
+	cfg.Logger.Info("creating tester", zap.String("tester", reflect.TypeOf(tester{}).PkgPath()))
+	return &tester{cfg: cfg}
+}
+
+type tester struct {
+	cfg Config
+}
+
+func (ts *tester) Create() error {
+	needInstall := false
+	for _, cur := range ts.cfg.EKSConfig.AddOnNodeGroups.ASGs {
+		if cur.ClusterAutoScaler.Enable {
+			needInstall = true
+			break
+		}
+	}
+	if !needInstall {
+		ts.cfg.Logger.Info("no NG enables CA; skipping")
+		return nil
+	}
+	return ts.installCA()
+}
+
+func (ts *tester) installCA() error {
+	ts.cfg.Logger.Info("creating CA using kubectl", zap.String("name", ts.cfg.EKSConfig.Name))
+	var ok bool
+	var caData = caSpecData{}
+	caData.ImageURI, ok = images[ts.cfg.EKSConfig.Parameters.Version]
+	if !ok {
+		return fmt.Errorf("no CA found for %q", ts.cfg.EKSConfig.Parameters.Version)
+	}
+	caData.NodeGroupAutoDiscovery = nodeGroupAuotDiscoveryData + ts.cfg.EKSConfig.Name
+	tpl := template.Must(template.New("TemplateCA").Parse(ClusterAutoscalerYAML))
+	buf := bytes.NewBuffer(nil)
+	if err := tpl.Execute(buf, caData); err != nil {
+		return err
+	}
+	ts.cfg.Logger.Info("writing  cluster autoscaler YAML")
+	fpath, err := fileutil.WriteTempFile(buf.Bytes())
+	if err != nil {
+		ts.cfg.Logger.Warn("failed to write cluster-autoscaler YAML", zap.Error(err))
+		return err
+	}
+	ts.cfg.Logger.Info("applying cluster-autoscaler YAML", zap.String("path", fpath))
+
+	var output []byte
+	waitDur := 5 * time.Minute
+	retryStart := time.Now()
+	applyArgs := []string{
+		ts.cfg.EKSConfig.KubectlPath,
+		"--kubeconfig=" + ts.cfg.EKSConfig.KubeConfigPath,
+		"apply",
+		"-f",
+		fpath,
+	}
+	applyCmd := strings.Join(applyArgs, " ")
+	for time.Now().Sub(retryStart) < waitDur {
+		select {
+		case <-ts.cfg.Stopc:
+			return errors.New("create CA aborted")
+		case <-time.After(5 * time.Second):
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		output, err := exec.New().CommandContext(ctx, applyArgs[0], applyArgs[1:]...).CombinedOutput()
+		cancel()
+		out := string(output)
+		fmt.Printf("\n\n'%s' output:\n\n%s\n\n", applyCmd, out)
+		if err == nil {
+			break
+		}
+		if strings.Contains(out, " created") || strings.Contains(out, " unchanged") {
+			err = nil
+			break
+		}
+
+		ts.cfg.Logger.Warn("create CA failed", zap.Error(err))
+		ts.cfg.EKSConfig.RecordStatus(fmt.Sprintf("create CA failed (%v)", err))
+	}
+	if err != nil {
+		return fmt.Errorf("'kubectl apply' failed %v (output %q)", err, string(output))
+	}
+	ts.cfg.Logger.Info("created cluster autoscaler")
+
+	return ts.waitDeploymentCA()
+}
+
+func (ts *tester) waitDeploymentCA() error {
+	ts.cfg.Logger.Info("waiting for cluster autoscaler Deployment")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	output, err := exec.New().CommandContext(
+		ctx,
+		ts.cfg.EKSConfig.KubectlPath,
+		"--kubeconfig="+ts.cfg.EKSConfig.KubeConfigPath,
+		"--namespace=kube-system",
+		"describe",
+		"deployment",
+		clusterAutoScalerDeploymentName,
+	).CombinedOutput()
+	cancel()
+	if err != nil {
+		return fmt.Errorf("'kubectl describe deployment' failed %v", err)
+	}
+	out := string(output)
+	fmt.Printf("\n\n\"kubectl describe deployment\" output:\n%s\n\n", out)
+
+	ready := false
+	waitDur := 3 * time.Minute
+	retryStart := time.Now()
+	for time.Now().Sub(retryStart) < waitDur {
+		select {
+		case <-ts.cfg.Stopc:
+			return errors.New("check aborted")
+		case <-time.After(15 * time.Second):
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		dresp, err := ts.cfg.K8SClient.KubernetesClientSet().
+			AppsV1().
+			Deployments("kube-system").
+			Get(ctx, "cluster-autoscaler", metav1.GetOptions{})
+		cancel()
+		if err != nil {
+			return fmt.Errorf("failed to get Deployment (%v)", err)
+		}
+		ts.cfg.Logger.Info("get deployment",
+			zap.Int32("desired-replicas", dresp.Status.Replicas),
+			zap.Int32("available-replicas", dresp.Status.AvailableReplicas),
+			zap.Int32("unavailable-replicas", dresp.Status.UnavailableReplicas),
+			zap.Int32("ready-replicas", dresp.Status.ReadyReplicas),
+		)
+		available := false
+		for _, cond := range dresp.Status.Conditions {
+			ts.cfg.Logger.Info("condition",
+				zap.String("last-updated", cond.LastUpdateTime.String()),
+				zap.String("type", string(cond.Type)),
+				zap.String("status", string(cond.Status)),
+				zap.String("reason", cond.Reason),
+				zap.String("message", cond.Message),
+			)
+			if cond.Status != v1.ConditionTrue {
+				continue
+			}
+			if cond.Type == appsv1.DeploymentAvailable {
+				available = true
+				break
+			}
+		}
+		if available && dresp.Status.AvailableReplicas >= 1 {
+			ready = true
+			break
+		}
+	}
+	if !ready {
+		return errors.New("Deployment not ready")
+	}
+
+	ts.cfg.Logger.Info("waited for cluster autoscaler Deployment")
+	return ts.cfg.EKSConfig.Sync()
+}

--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -313,7 +313,6 @@ type Config struct {
 	// AddOnClusterVersionUpgrade defines parameters
 	// for EKS cluster version upgrade add-on.
 	AddOnClusterVersionUpgrade *AddOnClusterVersionUpgrade `json:"add-on-cluster-version-upgrade,omitempty"`
-
 	// Status represents the current status of AWS resources.
 	// Status is read-only.
 	// Status cannot be configured via environmental variables.

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -141,7 +141,7 @@ func TestEnv(t *testing.T) {
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_SERVICE_PRINCIPALS")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_MANAGED_POLICY_ARNS", "a,b,c")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_MANAGED_POLICY_ARNS")
-	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS", `{"ng-test-name-cpu":{"name":"ng-test-name-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.30/amazon-linux-2/recommended/image_id","asg-min-size":17,"kubelet-extra-args":"bbb qq","asg-max-size":99,"asg-desired-capacity":77,"instance-types":["type-cpu-2"],"volume-size":40},"ng-test-name-gpu":{"name":"ng-test-name-gpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64_GPU","asg-min-size":30,"asg-max-size":35,"asg-desired-capacity":34,"instance-types":["type-gpu-2"],"image-id":"my-gpu-ami","volume-size":500, "kubelet-extra-args":"aaa aa"}}`)
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS", `{"ng-test-name-cpu":{"name":"ng-test-name-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.30/amazon-linux-2/recommended/image_id","asg-min-size":17,"kubelet-extra-args":"bbb qq", "cluster-autoscaler" : {"enable" : false}, "asg-max-size":99,"asg-desired-capacity":77,"instance-types":["type-cpu-2"],"volume-size":40},"ng-test-name-gpu":{"name":"ng-test-name-gpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64_GPU","asg-min-size":30,"asg-max-size":35,"asg-desired-capacity":34,"instance-types":["type-gpu-2"],"image-id":"my-gpu-ami","volume-size":500, "cluster-autoscaler": {"enable":false},"kubelet-extra-args":"aaa aa"}}`)
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_LOGS_DIR", "a")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_LOGS_DIR")
@@ -705,7 +705,8 @@ func TestEnv(t *testing.T) {
 				InstanceTypes:        []string{"type-cpu-2"},
 				VolumeSize:           40,
 			},
-			KubeletExtraArgs: "bbb qq",
+			KubeletExtraArgs:  "bbb qq",
+			ClusterAutoScaler: &NGClusterAutoScaler{Enable: false},
 		},
 		gpuName: {
 			ASG: ec2config.ASG{
@@ -719,7 +720,8 @@ func TestEnv(t *testing.T) {
 				InstanceTypes:        []string{"type-gpu-2"},
 				VolumeSize:           500,
 			},
-			KubeletExtraArgs: "aaa aa",
+			KubeletExtraArgs:  "aaa aa",
+			ClusterAutoScaler: &NGClusterAutoScaler{Enable: false},
 		},
 	}
 	if !reflect.DeepEqual(cfg.AddOnNodeGroups.ASGs, expectedASGs) {
@@ -1352,7 +1354,7 @@ func TestEnvAddOnNodeGroupsGetRef(t *testing.T) {
 
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE", `true`)
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE")
-	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS", `{"GetRef.Name-ng-for-cni":{"name":"GetRef.Name-ng-for-cni","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","asg-min-size":30,"asg-max-size":35,"asg-desired-capacity":34,"image-id":"my-ami",  "ssm-document-create":true,   "instance-types":["type-2"],  "ssm-document-cfn-stack-name":"GetRef.Name-ssm", "ssm-document-name":"GetRef.Name-document",     "kubelet-extra-args":"aaa aa",  "volume-size":500}}`)
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS", `{"GetRef.Name-ng-for-cni":{"name":"GetRef.Name-ng-for-cni","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","asg-min-size":30,"asg-max-size":35,"asg-desired-capacity":34,"image-id":"my-ami",  "ssm-document-create":true,   "instance-types":["type-2"],  "ssm-document-cfn-stack-name":"GetRef.Name-ssm", "ssm-document-name":"GetRef.Name-document", "kubelet-extra-args":"aaa aa", "cluster-autoscaler": {"enable" : false}, "volume-size":500}}`)
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ENABLE", `true`)
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ENABLE")
@@ -1387,7 +1389,8 @@ func TestEnvAddOnNodeGroupsGetRef(t *testing.T) {
 				ASGMaxSize:                         35,
 				ASGDesiredCapacity:                 34,
 			},
-			KubeletExtraArgs: "aaa aa",
+			KubeletExtraArgs:  "aaa aa",
+			ClusterAutoScaler: &NGClusterAutoScaler{Enable: false},
 		},
 	}
 	if !reflect.DeepEqual(cfg.AddOnNodeGroups.ASGs, expectedNGs) {
@@ -1426,7 +1429,7 @@ func TestEnvAddOnConformance(t *testing.T) {
 
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE", `true`)
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE")
-	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS", `{"GetRef.Name-ng-for-cni":{"name":"GetRef.Name-ng-for-cni","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","asg-min-size":30,"asg-max-size":35,"asg-desired-capacity":34,"image-id":"my-ami",  "ssm-document-create":true,   "instance-types":["type-2"],  "ssm-document-cfn-stack-name":"GetRef.Name-ssm", "ssm-document-name":"GetRef.Name-document",     "kubelet-extra-args":"aaa aa",  "volume-size":500}}`)
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS", `{"GetRef.Name-ng-for-cni":{"name":"GetRef.Name-ng-for-cni","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","asg-min-size":30,"asg-max-size":35,"asg-desired-capacity":34,"image-id":"my-ami",  "ssm-document-create":true,   "instance-types":["type-2"],  "ssm-document-cfn-stack-name":"GetRef.Name-ssm", "ssm-document-name":"GetRef.Name-document", "cluster-autoscaler": {"enable" : false}, "kubelet-extra-args":"aaa aa",  "volume-size":500}}`)
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS")
 
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_ENABLE", "true")


### PR DESCRIPTION

*Description of changes:*
add cluster autoscaler addon.
Clusteraddon tests can be enabled like any other addon by setting env variable
It's disabled by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
