### PR TITLE
Fix accidental reversal of colorized log messages

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -149,15 +149,14 @@ func New(cfg *ec2config.Config) (*Tester, error) {
 
 // Up should provision a new cluster for testing
 func (ts *Tester) Up() (err error) {
-	fmt.Printf(ts.color("[light_green]UP START (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]UP START (%q)\n"), ts.cfg.ConfigPath)
 
 	now := time.Now()
 
 	defer func() {
-		fmt.Printf(ts.color("[light_green]UP DEFER START (%q)\n"), ts.cfg.ConfigPath)
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
-		fmt.Printf("\n\n# to delete instances\nec2-utils delete instances --path %s\n\n", ts.cfg.ConfigPath)
+		fmt.Printf(ts.color("[light_green]UP DEFER START (%q)\n"), ts.cfg.ConfigPath)
 
 		if serr := ts.uploadToS3(); serr != nil {
 			ts.lg.Warn("failed to upload artifacts to S3", zap.Error(serr))
@@ -174,8 +173,8 @@ func (ts *Tester) Up() (err error) {
 				ts.lg.Info("Up succeeded",
 					zap.String("started", humanize.RelTime(now, time.Now(), "ago", "from now")),
 				)
-				fmt.Printf(ts.color("\n\n💯 😁 👍 :) [light_green]Up success\n\n\n"))
 				fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+				fmt.Printf(ts.color("\n\n💯 😁 👍 :) [light_green]Up success\n\n\n"))
 
 				ts.lg.Sugar().Infof("Up.defer end (%s)", ts.cfg.ConfigPath)
 				fmt.Printf("\n\n💯 😁 👍 :) Up success\n\n\n")
@@ -198,8 +197,8 @@ func (ts *Tester) Up() (err error) {
 				zap.String("started", humanize.RelTime(now, time.Now(), "ago", "from now")),
 				zap.Error(err),
 			)
-			fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]UP FAIL\n"))
 			fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+			fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]UP FAIL\n"))
 
 			fmt.Printf("\n\n# to delete instances\nec2-utils delete instances --path %s\n\n", ts.cfg.ConfigPath)
 			return
@@ -211,8 +210,8 @@ func (ts *Tester) Up() (err error) {
 			ts.lg.Sugar().Infof("SSH (%s)", ts.cfg.ConfigPath)
 			fmt.Println(ts.cfg.SSHCommands())
 		}
-		fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]UP FAIL\n"))
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]UP FAIL\n"))
 
 		ts.lg.Warn("Up failed; reverting resource creation",
 			zap.String("started", humanize.RelTime(now, time.Now(), "ago", "from now")),
@@ -235,8 +234,8 @@ func (ts *Tester) Up() (err error) {
 		} else {
 			ts.lg.Warn("reverted Up")
 		}
-		fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]UP FAIL\n"))
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]UP FAIL\n"))
 
 		fmt.Printf("\n\n# to delete instances\nec2-utils delete instances --path %s\n\n", ts.cfg.ConfigPath)
 	}()
@@ -246,8 +245,8 @@ func (ts *Tester) Up() (err error) {
 		zap.String("name", ts.cfg.Name),
 	)
 	defer ts.cfg.Sync()
-	fmt.Printf(ts.color("[light_green]createS3 (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]createS3 (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := catchInterrupt(
 		ts.lg,
@@ -258,8 +257,8 @@ func (ts *Tester) Up() (err error) {
 	); err != nil {
 		return err
 	}
-	fmt.Printf(ts.color("[light_green]createRole (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]createRole (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := catchInterrupt(
 		ts.lg,
@@ -270,8 +269,8 @@ func (ts *Tester) Up() (err error) {
 	); err != nil {
 		return err
 	}
-	fmt.Printf(ts.color("[light_green]createVPC (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]createVPC (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := catchInterrupt(
 		ts.lg,
@@ -282,8 +281,8 @@ func (ts *Tester) Up() (err error) {
 	); err != nil {
 		return err
 	}
-	fmt.Printf(ts.color("[light_green]createKeyPair (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]createKeyPair (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := catchInterrupt(
 		ts.lg,
@@ -294,8 +293,8 @@ func (ts *Tester) Up() (err error) {
 	); err != nil {
 		return err
 	}
-	fmt.Printf(ts.color("[light_green]createASGs (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]createASGs (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := catchInterrupt(
 		ts.lg,
@@ -306,8 +305,8 @@ func (ts *Tester) Up() (err error) {
 	); err != nil {
 		return err
 	}
-	fmt.Printf(ts.color("[light_green]createSSM (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]createSSM (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := catchInterrupt(
 		ts.lg,
@@ -320,8 +319,8 @@ func (ts *Tester) Up() (err error) {
 	}
 
 	if ts.cfg.ASGsFetchLogs {
-		fmt.Printf(ts.color("[light_green]FetchLogs (%q)\n"), ts.cfg.ConfigPath)
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]FetchLogs (%q)\n"), ts.cfg.ConfigPath)
 
 		waitDur := 20 * time.Second
 		ts.lg.Info("sleeping before FetchLogs", zap.Duration("wait", waitDur))
@@ -348,8 +347,8 @@ func (ts *Tester) Down() error {
 }
 
 func (ts *Tester) down() (err error) {
-	fmt.Printf(ts.color("[light_blue]DOWN START (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_blue]DOWN START (%q)\n"), ts.cfg.ConfigPath)
 
 	now := time.Now()
 	ts.lg.Warn("starting Down",
@@ -362,18 +361,18 @@ func (ts *Tester) down() (err error) {
 	defer func() {
 		ts.cfg.Sync()
 		if err == nil {
-			fmt.Printf(ts.color("\n\n💯 😁 👍 :)  [light_blue]DOWN SUCCESS\n\n\n"))
-			fmt.Printf(ts.color("[light_blue]DOWN DEFER START (%q)\n"), ts.cfg.ConfigPath)
 			fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+			fmt.Printf(ts.color("[light_blue]DOWN DEFER START (%q)\n"), ts.cfg.ConfigPath)
+			fmt.Printf(ts.color("\n\n💯 😁 👍 :)  [light_blue]DOWN SUCCESS\n\n\n"))
 
 			ts.lg.Info("successfully finished Down",
 				zap.String("started", humanize.RelTime(now, time.Now(), "ago", "from now")),
 			)
 
 		} else {
-			fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]DOWN FAIL\n"))
-			fmt.Printf(ts.color("[light_blue]DOWN DEFER START (%q)\n"), ts.cfg.ConfigPath)
 			fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+			fmt.Printf(ts.color("[light_blue]DOWN DEFER START (%q)\n"), ts.cfg.ConfigPath)
+			fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]DOWN FAIL\n"))
 
 			ts.lg.Info("failed Down",
 				zap.Error(err),
@@ -383,29 +382,29 @@ func (ts *Tester) down() (err error) {
 	}()
 
 	var errs []string
-	fmt.Printf(ts.color("[light_blue]deleteSSM (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_blue]deleteSSM (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := ts.deleteSSM(); err != nil {
 		ts.lg.Warn("deleteSSM failed", zap.Error(err))
 		errs = append(errs, err.Error())
 	}
-	fmt.Printf(ts.color("[light_blue]deleteASGs (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_blue]deleteASGs (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := ts.deleteASGs(); err != nil {
 		ts.lg.Warn("deleteASGs failed", zap.Error(err))
 		errs = append(errs, err.Error())
 	}
-	fmt.Printf(ts.color("[light_blue]deleteKeyPair (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_blue]deleteKeyPair (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := ts.deleteKeyPair(); err != nil {
 		ts.lg.Warn("deleteKeyPair failed", zap.Error(err))
 		errs = append(errs, err.Error())
 	}
-	fmt.Printf(ts.color("[light_blue]deleteRole (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_blue]deleteRole (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := ts.deleteRole(); err != nil {
 		ts.lg.Warn("deleteRole failed", zap.Error(err))
@@ -417,15 +416,15 @@ func (ts *Tester) down() (err error) {
 		ts.lg.Info("sleeping before VPC deletion", zap.Duration("wait", waitDur))
 		time.Sleep(waitDur)
 	}
-	fmt.Printf(ts.color("[light_blue]deleteVPC (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_blue]deleteVPC (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := ts.deleteVPC(); err != nil {
 		ts.lg.Warn("deleteVPC failed", zap.Error(err))
 		errs = append(errs, err.Error())
 	}
-	fmt.Printf(ts.color("[light_blue]deleteS3 (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_blue]deleteS3 (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := ts.deleteS3(); err != nil {
 		ts.lg.Warn("deleteS3 failed", zap.Error(err))

--- a/eks/cluster/cluster.go
+++ b/eks/cluster/cluster.go
@@ -110,8 +110,8 @@ func (ts *tester) CheckHealth() (err error) {
 }
 
 func (ts *tester) checkHealth() (err error) {
-	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]checkHealth (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 	fmt.Printf(ts.cfg.EKSConfig.Colorize("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]checkHealth (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 
 	defer func() {
 		if err == nil {
@@ -258,8 +258,8 @@ const (
 )
 
 func (ts *tester) createEKS() (err error) {
-	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]createEKS (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 	fmt.Printf(ts.cfg.EKSConfig.Colorize("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]createEKS (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 
 	if ts.cfg.EKSConfig.Status.ClusterCFNStackID != "" ||
 		ts.cfg.EKSConfig.Status.ClusterARN != "" ||
@@ -508,8 +508,8 @@ func (ts *tester) createEKS() (err error) {
 }
 
 func (ts *tester) deleteEKS() error {
-	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_blue]deleteEKS (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 	fmt.Printf(ts.cfg.EKSConfig.Colorize("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_blue]deleteEKS (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 
 	ts.describeCluster()
 	if ts.cfg.EKSConfig.Status.ClusterStatusCurrent == "" || ts.cfg.EKSConfig.Status.ClusterStatusCurrent == eksconfig.ClusterStatusDELETEDORNOTEXIST {
@@ -757,8 +757,8 @@ users:
 // https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
 // "aws eks update-kubeconfig --name --role-arn --kubeconfig"
 func (ts *tester) createClient() (cli k8s_client.EKS, err error) {
-	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]createClient (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 	fmt.Printf(ts.cfg.EKSConfig.Colorize("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]createClient (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 
 	if ts.cfg.EKSConfig.AWSIAMAuthenticatorPath != "" && ts.cfg.EKSConfig.AWSIAMAuthenticatorDownloadURL != "" {
 		tpl := template.Must(template.New("tmplKUBECONFIG").Parse(tmplKUBECONFIG))

--- a/eks/cluster/encryption.go
+++ b/eks/cluster/encryption.go
@@ -12,8 +12,8 @@ import (
 )
 
 func (ts *tester) createEncryption() error {
-	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]createEncryption (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 	fmt.Printf(ts.cfg.EKSConfig.Colorize("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]createEncryption (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 
 	if !ts.cfg.EKSConfig.Parameters.EncryptionCMKCreate {
 		ts.cfg.Logger.Info("Parameters.EncryptionCMKCreate false; no need to create a new one")
@@ -77,8 +77,8 @@ func (ts *tester) createEncryption() error {
 }
 
 func (ts *tester) deleteEncryption() error {
-	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_blue]deleteEncryption (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 	fmt.Printf(ts.cfg.EKSConfig.Colorize("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_blue]deleteEncryption (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 
 	if !ts.cfg.EKSConfig.Parameters.EncryptionCMKCreate {
 		ts.cfg.Logger.Info("Parameters.EncryptionCMKCreate false; no need to delete one")

--- a/eks/cluster/role.go
+++ b/eks/cluster/role.go
@@ -208,8 +208,8 @@ Outputs:
 `
 
 func (ts *tester) createClusterRole() error {
-	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]createClusterRole (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 	fmt.Printf(ts.cfg.EKSConfig.Colorize("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]createClusterRole (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 
 	if !ts.cfg.EKSConfig.Parameters.RoleCreate {
 		ts.cfg.Logger.Info("Parameters.RoleCreate false; skipping creation")
@@ -323,8 +323,8 @@ func (ts *tester) createClusterRole() error {
 }
 
 func (ts *tester) deleteClusterRole() error {
-	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_blue]deleteClusterRole (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 	fmt.Printf(ts.cfg.EKSConfig.Colorize("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_blue]deleteClusterRole (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 
 	if !ts.cfg.EKSConfig.Parameters.RoleCreate {
 		ts.cfg.Logger.Info("Parameters.RoleCreate false; skipping deletion")

--- a/eks/cluster/vpc.go
+++ b/eks/cluster/vpc.go
@@ -582,8 +582,8 @@ Outputs:
 `
 
 func (ts *tester) createVPC() error {
-	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]createVPC (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 	fmt.Printf(ts.cfg.EKSConfig.Colorize("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]createVPC (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 
 	if ts.cfg.EKSConfig.Parameters.VPCID != "" {
 		ts.cfg.Logger.Info("querying ELBv2", zap.String("vpc-id", ts.cfg.EKSConfig.Parameters.VPCID))
@@ -836,8 +836,8 @@ func (ts *tester) createVPC() error {
 }
 
 func (ts *tester) deleteVPC() error {
-	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_blue]deleteVPC (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 	fmt.Printf(ts.cfg.EKSConfig.Colorize("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_blue]deleteVPC (%q)\n"), ts.cfg.EKSConfig.ConfigPath)
 
 	if !ts.cfg.EKSConfig.Parameters.VPCCreate {
 		ts.cfg.Logger.Info("Parameters.VPCCreate false; skipping deletion")

--- a/eks/eks.go
+++ b/eks/eks.go
@@ -394,8 +394,8 @@ func New(cfg *eksconfig.Config) (ts *Tester, err error) {
 }
 
 func (ts *Tester) createTesters() (err error) {
-	fmt.Printf(ts.color("[light_green]createTesters (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]createTesters (%q)\n"), ts.cfg.ConfigPath)
 
 	ts.clusterTester = cluster.New(cluster.Config{
 		Logger:    ts.lg,
@@ -667,31 +667,29 @@ func (ts *Tester) createTesters() (err error) {
 // ref. https://pkg.go.dev/k8s.io/test-infra/kubetest2/pkg/types?tab=doc#Deployer
 // ref. https://pkg.go.dev/k8s.io/test-infra/kubetest2/pkg/types?tab=doc#Options
 func (ts *Tester) Up() (err error) {
-	fmt.Printf(ts.color("[light_green]UP START (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]UP START (%q)\n"), ts.cfg.ConfigPath)
 
 	now := time.Now()
 
 	defer func() {
-		fmt.Printf(ts.color("[light_green]UP DEFER START (%q)\n"), ts.cfg.ConfigPath)
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
-		fmt.Printf("\n\n# to delete cluster\naws-k8s-tester eks delete cluster --path %s\n\n", ts.cfg.ConfigPath)
+		fmt.Printf(ts.color("[light_green]UP DEFER START (%q)\n"), ts.cfg.ConfigPath)
 
 		if serr := ts.uploadToS3(); serr != nil {
 			ts.lg.Warn("failed to upload artifacts to S3", zap.Error(serr))
 		} else {
 			ts.s3Uploaded = true
 		}
-		fmt.Printf("\n\n# to delete cluster\naws-k8s-tester eks delete cluster --path %s\n\n", ts.cfg.ConfigPath)
 
 		if err == nil {
 			if ts.cfg.Status.Up {
-				fmt.Printf(ts.color("[light_green]SSH (%q)\n"), ts.cfg.ConfigPath)
 				fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+				fmt.Printf(ts.color("[light_green]SSH (%q)\n"), ts.cfg.ConfigPath)
 
 				fmt.Println(ts.cfg.SSHCommands())
-				fmt.Printf(ts.color("[light_green]kubectl (%q)\n"), ts.cfg.ConfigPath)
 				fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+				fmt.Printf(ts.color("[light_green]kubectl (%q)\n"), ts.cfg.ConfigPath)
 
 				fmt.Println(ts.cfg.KubectlCommands())
 
@@ -700,12 +698,12 @@ func (ts *Tester) Up() (err error) {
 				)
 
 				ts.lg.Sugar().Infof("Up.defer end (%s, %s)", ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
-				fmt.Printf(ts.color("\n\n💯 😁 👍 :) [light_green]UP SUCCESS\n\n\n"))
 				fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+				fmt.Printf(ts.color("\n\n💯 😁 👍 :) [light_green]UP SUCCESS\n\n\n"))
 
 			} else {
-				fmt.Printf(ts.color("\n\n😲 😲 😲  [light_magenta]UP ABORTED ???\n\n\n"))
 				fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+				fmt.Printf(ts.color("\n\n😲 😲 😲  [light_magenta]UP ABORTED ???\n\n\n"))
 
 			}
 			fmt.Printf("\n\n# to delete cluster\naws-k8s-tester eks delete cluster --path %s\n\n", ts.cfg.ConfigPath)
@@ -714,12 +712,12 @@ func (ts *Tester) Up() (err error) {
 
 		if !ts.cfg.OnFailureDelete {
 			if ts.cfg.Status.Up {
-				fmt.Printf(ts.color("[light_green]SSH (%q)\n"), ts.cfg.ConfigPath)
 				fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+				fmt.Printf(ts.color("[light_green]SSH (%q)\n"), ts.cfg.ConfigPath)
 
 				fmt.Println(ts.cfg.SSHCommands())
-				fmt.Printf(ts.color("[light_green]kubectl (%q)\n"), ts.cfg.ConfigPath)
 				fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+				fmt.Printf(ts.color("[light_green]kubectl (%q)\n"), ts.cfg.ConfigPath)
 
 				fmt.Println(ts.cfg.KubectlCommands())
 			}
@@ -738,18 +736,18 @@ func (ts *Tester) Up() (err error) {
 		}
 
 		if ts.cfg.Status.Up {
-			fmt.Printf(ts.color("[light_green]SSH (%q)\n"), ts.cfg.ConfigPath)
 			fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+			fmt.Printf(ts.color("[light_green]SSH (%q)\n"), ts.cfg.ConfigPath)
 
 			fmt.Println(ts.cfg.SSHCommands())
-			fmt.Printf(ts.color("[light_green]kubectl (%q)\n"), ts.cfg.ConfigPath)
 			fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+			fmt.Printf(ts.color("[light_green]kubectl (%q)\n"), ts.cfg.ConfigPath)
 
 			fmt.Println(ts.cfg.KubectlCommands())
 		}
 		fmt.Printf(ts.color("\n\n\n[light_magenta]UP FAIL ERROR:\n\n%v\n\n\n"), err)
-		fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]UP FAIL\n"))
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]UP FAIL\n"))
 
 		ts.lg.Warn("Up failed; reverting resource creation",
 			zap.String("started", humanize.RelTime(now, time.Now(), "ago", "from now")),
@@ -773,17 +771,16 @@ func (ts *Tester) Up() (err error) {
 			ts.lg.Warn("reverted Up")
 		}
 		fmt.Printf(ts.color("\n\n\n[light_magenta]UP FAIL ERROR:\n\n%v\n\n\n"), err)
-		fmt.Printf(ts.color("\n\n🔥 💀 👽 😱 😡 (-_-) [light_magenta]UP FAIL\n\n\n"))
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("\n\n🔥 💀 👽 😱 😡 (-_-) [light_magenta]UP FAIL\n\n\n"))
 
 		ts.lg.Sugar().Infof("Up.defer end (%s, %s)", ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
-		fmt.Printf("\n\n# to delete cluster\naws-k8s-tester eks delete cluster --path %s\n\n", ts.cfg.ConfigPath)
 	}()
 
 	ts.lg.Info("Up started", zap.String("version", version.Version()), zap.String("name", ts.cfg.Name))
 	defer ts.cfg.Sync()
-	fmt.Printf(ts.color("[light_green]createS3 (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]createS3 (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := catchInterrupt(
 		ts.lg,
@@ -794,8 +791,8 @@ func (ts *Tester) Up() (err error) {
 	); err != nil {
 		return err
 	}
-	fmt.Printf(ts.color("[light_green]createKeyPair (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]createKeyPair (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := catchInterrupt(
 		ts.lg,
@@ -806,8 +803,8 @@ func (ts *Tester) Up() (err error) {
 	); err != nil {
 		return err
 	}
-	fmt.Printf(ts.color("[light_green]createCluster (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]createCluster (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 	if err := catchInterrupt(
 		ts.lg,
@@ -827,8 +824,8 @@ func (ts *Tester) Up() (err error) {
 		if err := ts.cfg.EvaluateCommandRefs(); err != nil {
 			return err
 		}
-		fmt.Printf(ts.color("[light_green]runCommand.CommandAfterCreateCluster (%q)\n"), ts.cfg.CommandAfterCreateCluster)
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]runCommand.CommandAfterCreateCluster (%q)\n"), ts.cfg.CommandAfterCreateCluster)
 
 		out, err := runCommand(ts.lg, ts.cfg.CommandAfterCreateCluster, ts.cfg.CommandAfterCreateClusterTimeout)
 		if err != nil {
@@ -852,10 +849,9 @@ func (ts *Tester) Up() (err error) {
 		if ts.ngTester == nil {
 			return errors.New("ts.ngTester == nil when AddOnNodeGroups.Enable == true")
 		}
-		fmt.
-			// create NG first, so MNG configmap update can be called afterwards
-			Printf(ts.color("[light_green]ngTester.Create (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
+		// create NG first, so MNG configmap update can be called afterwards
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]ngTester.Create (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 		if err := catchInterrupt(
 			ts.lg,
@@ -872,8 +868,8 @@ func (ts *Tester) Up() (err error) {
 		if ts.mngTester == nil {
 			return errors.New("ts.mngTester == nil when AddOnManagedNodeGroups.Enable == true")
 		}
-		fmt.Printf(ts.color("[light_green]mngTester.Create (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]mngTester.Create (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 		if err := catchInterrupt(
 			ts.lg,
@@ -908,8 +904,8 @@ func (ts *Tester) Up() (err error) {
 		}
 	}
 	if needGPU {
-		fmt.Printf(ts.color("[light_green]gpuTester.InstallNvidiaDriver (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]gpuTester.InstallNvidiaDriver (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 		if err := catchInterrupt(
 			ts.lg,
@@ -921,8 +917,8 @@ func (ts *Tester) Up() (err error) {
 			ts.lg.Warn("failed to install nvidia driver", zap.Error(err))
 			return err
 		}
-		fmt.Printf(ts.color("[light_green]gpuTester.CreateNvidiaSMI (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]gpuTester.CreateNvidiaSMI (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 		if err := catchInterrupt(
 			ts.lg,
@@ -940,8 +936,8 @@ func (ts *Tester) Up() (err error) {
 	}
 
 	for idx, tss := range ts.testers {
-		fmt.Printf(ts.color("[light_green]testers[%02d].Create [cyan]%q (%q, %q)\n"), idx, reflect.TypeOf(tss), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]testers[%02d].Create [cyan]%q (%q, %q)\n"), idx, reflect.TypeOf(tss), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 		err := catchInterrupt(
 			ts.lg,
@@ -952,8 +948,8 @@ func (ts *Tester) Up() (err error) {
 		)
 
 		if idx%5 == 0 {
-			fmt.Printf(ts.color("[light_green]testers[%02d] uploadToS3 [cyan]%q (%q, %q)\n"), idx, reflect.TypeOf(tss), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 			fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+			fmt.Printf(ts.color("[light_green]testers[%02d] uploadToS3 [cyan]%q (%q, %q)\n"), idx, reflect.TypeOf(tss), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 			if serr := ts.uploadToS3(); serr != nil {
 				ts.lg.Warn("failed to upload artifacts to S3", zap.Error(serr))
@@ -969,8 +965,8 @@ func (ts *Tester) Up() (err error) {
 		if ts.ngTester == nil {
 			return errors.New("ts.ngTester == nil when AddOnNodeGroups.Enable == true")
 		}
-		fmt.Printf(ts.color("[light_green]ngTester.FetchLogs (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]ngTester.FetchLogs (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 		waitDur := 15 * time.Second
 		ts.lg.Info("sleeping before ngTester.FetchLogs", zap.Duration("wait", waitDur))
@@ -991,8 +987,8 @@ func (ts *Tester) Up() (err error) {
 		if ts.mngTester == nil {
 			return errors.New("ts.mngTester == nil when AddOnManagedNodeGroups.Enable == true")
 		}
-		fmt.Printf(ts.color("[light_green]mngTester.FetchLogs (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]mngTester.FetchLogs (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 		waitDur := 15 * time.Second
 		ts.lg.Info("sleeping before mngTester.FetchLogs", zap.Duration("wait", waitDur))
@@ -1012,8 +1008,8 @@ func (ts *Tester) Up() (err error) {
 	if (ts.cfg.IsEnabledAddOnNodeGroups() && ts.cfg.AddOnNodeGroups.Created && ts.cfg.AddOnNodeGroups.FetchLogs) ||
 		(ts.cfg.IsEnabledAddOnManagedNodeGroups() && ts.cfg.AddOnManagedNodeGroups.Created && ts.cfg.AddOnManagedNodeGroups.FetchLogs) {
 		for idx, tss := range ts.testers {
-			fmt.Printf(ts.color("[light_green]testers[%02d].AggregateResults [cyan]%q (%q, %q)\n"), idx, reflect.TypeOf(tss), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 			fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+			fmt.Printf(ts.color("[light_green]testers[%02d].AggregateResults [cyan]%q (%q, %q)\n"), idx, reflect.TypeOf(tss), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 			err := catchInterrupt(
 				ts.lg,
@@ -1027,8 +1023,8 @@ func (ts *Tester) Up() (err error) {
 			}
 		}
 	}
-	fmt.Printf(ts.color("[light_green]clusterTester.CheckHealth (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_green]clusterTester.CheckHealth (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 	// TODO: investigate why "ts.k8sClient == nil"
 	if ts.k8sClient == nil {
@@ -1048,8 +1044,8 @@ func (ts *Tester) Up() (err error) {
 		if err := ts.cfg.EvaluateCommandRefs(); err != nil {
 			return err
 		}
-		fmt.Printf(ts.color("[light_green]runCommand.CommandAfterCreateAddOns (%q)\n"), ts.cfg.CommandAfterCreateAddOns)
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]runCommand.CommandAfterCreateAddOns (%q)\n"), ts.cfg.CommandAfterCreateAddOns)
 
 		out, err := runCommand(ts.lg, ts.cfg.CommandAfterCreateAddOns, ts.cfg.CommandAfterCreateAddOnsTimeout)
 		if err != nil {
@@ -1078,8 +1074,8 @@ func (ts *Tester) Up() (err error) {
 				break
 			}
 		}
-		fmt.Printf(ts.color("[light_green]mngTester.UpgradeVersion (%q, upgradeRun %v)\n"), ts.cfg.ConfigPath, upgradeRun)
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]mngTester.UpgradeVersion (%q, upgradeRun %v)\n"), ts.cfg.ConfigPath, upgradeRun)
 
 		if err := catchInterrupt(
 			ts.lg,
@@ -1096,8 +1092,8 @@ func (ts *Tester) Up() (err error) {
 		if ts.mngTester == nil {
 			return errors.New("ts.mngTester == nil when AddOnManagedNodeGroups.Enable == true")
 		}
-		fmt.Printf(ts.color("[light_green]mngTester.FetchLogs after upgrade (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]mngTester.FetchLogs after upgrade (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 		waitDur := 15 * time.Second
 		ts.lg.Info("sleeping before mngTester.FetchLogs", zap.Duration("wait", waitDur))
@@ -1118,8 +1114,8 @@ func (ts *Tester) Up() (err error) {
 		if err := ts.cfg.EvaluateCommandRefs(); err != nil {
 			return err
 		}
-		fmt.Printf(ts.color("[light_green]runCommand.CommandAfterCreateAddOns (%q)\n"), ts.cfg.CommandAfterCreateAddOns)
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_green]runCommand.CommandAfterCreateAddOns (%q)\n"), ts.cfg.CommandAfterCreateAddOns)
 
 		out, err := runCommand(ts.lg, ts.cfg.CommandAfterCreateAddOns, ts.cfg.CommandAfterCreateAddOnsTimeout)
 		if err != nil {
@@ -1149,8 +1145,8 @@ func (ts *Tester) Down() error {
 }
 
 func (ts *Tester) down() (err error) {
-	fmt.Printf(ts.color("[light_blue]DOWN START (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_blue]DOWN START (%q, %q)\n"), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 	now := time.Now()
 	ts.lg.Warn("starting Down",
@@ -1167,18 +1163,18 @@ func (ts *Tester) down() (err error) {
 		ts.cfg.Sync()
 
 		if err == nil {
-			fmt.Printf(ts.color("\n\n💯 😁 👍 :) [light_blue]DOWN SUCCESS\n\n\n"))
-			fmt.Printf(ts.color("[light_blue]DOWN DEFER START (%q)\n"), ts.cfg.ConfigPath)
 			fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+			fmt.Printf(ts.color("[light_blue]DOWN DEFER START (%q)\n"), ts.cfg.ConfigPath)
+			fmt.Printf(ts.color("\n\n💯 😁 👍 :) [light_blue]DOWN SUCCESS\n\n\n"))
 
 			ts.lg.Info("successfully finished Down",
 				zap.String("started", humanize.RelTime(now, time.Now(), "ago", "from now")),
 			)
 
 		} else {
-			fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]DOWN FAIL\n"))
-			fmt.Printf(ts.color("[light_blue]DOWN DEFER START (%q)\n"), ts.cfg.ConfigPath)
 			fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+			fmt.Printf(ts.color("[light_blue]DOWN DEFER START (%q)\n"), ts.cfg.ConfigPath)
+			fmt.Printf(ts.color("🔥 💀 👽 😱 😡 (-_-) [light_magenta]DOWN FAIL\n"))
 
 			ts.lg.Info("failed Down",
 				zap.Error(err),
@@ -1188,8 +1184,8 @@ func (ts *Tester) down() (err error) {
 	}()
 
 	var errs []string
-	fmt.Printf(ts.color("[light_blue]deleteKeyPair (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_blue]deleteKeyPair (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := ts.deleteKeyPair(); err != nil {
 		ts.lg.Warn("failed to delete key pair", zap.Error(err))
@@ -1200,8 +1196,8 @@ func (ts *Tester) down() (err error) {
 	for idx := range ts.testers {
 		idx = testersN - idx - 1
 		tss := ts.testers[idx]
-		fmt.Printf(ts.color("[light_blue]testers[%02d].Delete [cyan]%q (%q, %q)\n"), idx, reflect.TypeOf(tss), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_blue]testers[%02d].Delete [cyan]%q (%q, %q)\n"), idx, reflect.TypeOf(tss), ts.cfg.ConfigPath, ts.cfg.KubectlCommand())
 
 		if err := tss.Delete(); err != nil {
 			ts.lg.Warn("failed tester.Delete", zap.Error(err))
@@ -1235,8 +1231,8 @@ func (ts *Tester) down() (err error) {
 	// following need to be run in order to resolve delete dependency
 	// e.g. cluster must be deleted before VPC delete
 	if ts.cfg.IsEnabledAddOnManagedNodeGroups() && ts.mngTester != nil {
-		fmt.Printf(ts.color("[light_blue]mngTester.Delete (%q)\n"), ts.cfg.ConfigPath)
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_blue]mngTester.Delete (%q)\n"), ts.cfg.ConfigPath)
 
 		if err := ts.mngTester.Delete(); err != nil {
 			ts.lg.Warn("failed mngTester.Delete", zap.Error(err))
@@ -1249,8 +1245,8 @@ func (ts *Tester) down() (err error) {
 	}
 
 	if ts.cfg.IsEnabledAddOnNodeGroups() && ts.ngTester != nil {
-		fmt.Printf(ts.color("[light_blue]ngTester.Delete (%q)\n"), ts.cfg.ConfigPath)
 		fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+		fmt.Printf(ts.color("[light_blue]ngTester.Delete (%q)\n"), ts.cfg.ConfigPath)
 
 		if err := ts.ngTester.Delete(); err != nil {
 			ts.lg.Warn("failed ngTester.Delete", zap.Error(err))
@@ -1261,15 +1257,15 @@ func (ts *Tester) down() (err error) {
 		ts.lg.Info("sleeping before cluster deletion", zap.Duration("wait", waitDur))
 		time.Sleep(waitDur)
 	}
-	fmt.Printf(ts.color("[light_blue]clusterTester.Delete (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_blue]clusterTester.Delete (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := ts.clusterTester.Delete(); err != nil {
 		ts.lg.Warn("failed clusterTester.Delete", zap.Error(err))
 		errs = append(errs, err.Error())
 	}
-	fmt.Printf(ts.color("[light_blue]deleteS3 (%q)\n"), ts.cfg.ConfigPath)
 	fmt.Printf(ts.color("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.color("[light_blue]deleteS3 (%q)\n"), ts.cfg.ConfigPath)
 
 	if err := ts.deleteS3(); err != nil {
 		ts.lg.Warn("failed deleteS3", zap.Error(err))

--- a/eks/mng/version-upgrade/version-upgrade.go
+++ b/eks/mng/version-upgrade/version-upgrade.go
@@ -59,8 +59,8 @@ func (ts *tester) Upgrade(mngName string) (err error) {
 		ts.cfg.Logger.Info("MNG version upgrade is already completed; skipping upgrade", zap.String("mng-name", mngName))
 		return nil
 	}
-	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]MNGs[%q].Upgrade\n"), mngName)
 	fmt.Printf(ts.cfg.EKSConfig.Colorize("\n\n[yellow]*********************************\n"))
+	fmt.Printf(ts.cfg.EKSConfig.Colorize("[light_green]MNGs[%q].Upgrade\n"), mngName)
 
 	ts.cfg.Logger.Info("starting tester.Upgrade", zap.String("tester", reflect.TypeOf(tester{}).PkgPath()))
 	cur.VersionUpgrade.Created = true


### PR DESCRIPTION
The mechanical process used to create #101 accidentally reversed the
order of log messages.  Oops.  This change restores the
correct (original) order.

Fixes PR #101

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
