### PR TITLE
Reduced IRSA default replicas to something more reasonable

### DIFF
--- a/eksconfig/add-on-irsa.go
+++ b/eksconfig/add-on-irsa.go
@@ -82,7 +82,7 @@ func (cfg *Config) IsEnabledAddOnIRSA() bool {
 func getDefaultAddOnIRSA() *AddOnIRSA {
 	return &AddOnIRSA{
 		Enable:             false,
-		DeploymentReplicas: 10,
+		DeploymentReplicas: 1,
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
IRSA comes up with 10 replicas by default which uses significant resources. It should default to something smaller.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
