### PR TITLE
Add Fluentd add-on

### DIFF
--- a/eks/cw-agent/cw-agent.go
+++ b/eks/cw-agent/cw-agent.go
@@ -1,0 +1,760 @@
+package cwagent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"html/template"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/exec"
+)
+
+const (
+	cwAgentServiceAccountName         = "amazon-cloudwatch-agent-service-account"
+	cwAgentRBACRoleName               = "amazon-cloudwatch-agent-rbac-role"
+	cwAgentRBACClusterRoleBindingName = "amazon-cloudwatch-agent-rbac-role-binding"
+	cwAgentConfigMapNameConfig        = "amazon-cloudwatch-configmap-config"
+	cwAgentConfigMapFileNameConfig    = "cwagentconfig.json"
+	cwAgentAppName                    = "amazon-cloudwatch"
+	cwAgentDaemonSetName              = "amazon-cloudwatch"
+)
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) createCWAgentServiceAccount() error {
+	ts.cfg.Logger.Info("creating cw agent ServiceAccount")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ServiceAccounts(ts.cfg.EKSConfig.AddOnCWAgent.Namespace).
+		Create(
+			ctx,
+			&v1.ServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cwAgentServiceAccountName,
+					Namespace: ts.cfg.EKSConfig.AddOnCWAgent.Namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": cwAgentAppName,
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create cw agent ServiceAccount (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created cw agent ServiceAccount")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) deleteCWAgentServiceAccount() error {
+	ts.cfg.Logger.Info("deleting cw agent ServiceAccount")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err := ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ServiceAccounts(ts.cfg.EKSConfig.AddOnCWAgent.Namespace).
+		Delete(
+			ctx,
+			cwAgentServiceAccountName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete", zap.Error(err))
+		return fmt.Errorf("failed to delete cw agent ServiceAccount (%v)", err)
+	}
+	ts.cfg.Logger.Info("deleted cw agent ServiceAccount", zap.Error(err))
+
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) createCWAgentRBACClusterRole() error {
+	ts.cfg.Logger.Info("creating cw agent RBAC ClusterRole")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoles().
+		Create(
+			ctx,
+			&rbacv1.ClusterRole{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "ClusterRole",
+				},
+				// "ClusterRole" is a non-namespaced resource.
+				// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cwAgentRBACRoleName,
+					Namespace: "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name": cwAgentAppName,
+					},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						// "" indicates the core API group
+						// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole
+						APIGroups: []string{
+							"",
+						},
+						Resources: []string{
+							"pods",
+							"nodes",
+							"endpoints",
+						},
+						Verbs: []string{
+							"list",
+							"watch",
+						},
+					},
+					{
+						APIGroups: []string{
+							"apps",
+						},
+						Resources: []string{
+							"replicasets",
+						},
+						Verbs: []string{
+							"list",
+							"watch",
+						},
+					},
+					{
+						APIGroups: []string{
+							"batch",
+						},
+						Resources: []string{
+							"jobs",
+						},
+						Verbs: []string{
+							"list",
+							"watch",
+						},
+					},
+					{
+						// "" indicates the core API group
+						// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole
+						APIGroups: []string{
+							"",
+						},
+						Resources: []string{
+							"nodes/stats",
+							"configmaps",
+							"events",
+						},
+						Verbs: []string{
+							"create",
+						},
+					},
+					{
+						// "" indicates the core API group
+						// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole
+						APIGroups: []string{
+							"",
+						},
+						Resources: []string{
+							"configmaps",
+						},
+						ResourceNames: []string{
+							"cwagent-clusterleader",
+						},
+						Verbs: []string{
+							"get",
+							"update",
+						},
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create cw agent RBAC ClusterRole (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created cw agent RBAC ClusterRole")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) deleteCWAgentRBACClusterRole() error {
+	ts.cfg.Logger.Info("deleting cw agent RBAC ClusterRole")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err := ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoles().
+		Delete(
+			ctx,
+			cwAgentRBACRoleName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete", zap.Error(err))
+		return fmt.Errorf("failed to delete cw agent RBAC ClusterRole (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("deleted cw agent RBAC ClusterRole", zap.Error(err))
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) createCWAgentRBACClusterRoleBinding() error {
+	ts.cfg.Logger.Info("creating cw agent RBAC ClusterRoleBinding")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoleBindings().
+		Create(
+			ctx,
+			&rbacv1.ClusterRoleBinding{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "ClusterRoleBinding",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cwAgentRBACClusterRoleBindingName,
+					Namespace: "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name": cwAgentAppName,
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     cwAgentRBACRoleName,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						APIGroup:  "",
+						Kind:      "ServiceAccount",
+						Name:      cwAgentServiceAccountName,
+						Namespace: ts.cfg.EKSConfig.AddOnCWAgent.Namespace,
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create cw agent RBAC ClusterRoleBinding (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created cw agent RBAC ClusterRoleBinding")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) deleteCWAgentRBACClusterRoleBinding() error {
+	ts.cfg.Logger.Info("deleting cw agent RBAC ClusterRoleBinding")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err := ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoleBindings().
+		Delete(
+			ctx,
+			cwAgentRBACClusterRoleBindingName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete", zap.Error(err))
+		return fmt.Errorf("failed to delete cw agent RBAC ClusterRoleBinding (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("deleted cw agent RBAC ClusterRoleBinding", zap.Error(err))
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-metrics.html
+const TemplateCWAgentConf = `{
+  "agent": {
+    "region": "{{.RegionName}}"
+  },
+  "logs": {
+    "metrics_collected": {
+      "kubernetes": {
+        "cluster_name": "{{.ClusterName}}",
+        "metrics_collection_interval": 60
+      }
+    },
+    "force_flush_interval": 5
+  }
+}
+`
+
+type templateCWAgentConf struct {
+	RegionName  string
+	ClusterName string
+}
+
+func (ts *tester) createCWAgentConfigMapConfig() (err error) {
+	ts.cfg.Logger.Info("creating cw agent ConfigMap config")
+
+	buf := bytes.NewBuffer(nil)
+	cwConf := templateCWAgentConf{
+		RegionName:  ts.cfg.EKSConfig.Region,
+		ClusterName: ts.cfg.EKSConfig.Name,
+	}
+	cwConfTmpl := template.Must(template.New("TemplateCWAgentConf").Parse(TemplateCWAgentConf))
+	if err := cwConfTmpl.Execute(buf, cwConf); err != nil {
+		return err
+	}
+	cwConfBody := buf.String()
+	buf.Reset()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err = ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ConfigMaps(ts.cfg.EKSConfig.AddOnCWAgent.Namespace).
+		Create(
+			ctx,
+			&v1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cwAgentConfigMapNameConfig,
+					Namespace: ts.cfg.EKSConfig.AddOnCWAgent.Namespace,
+					Labels: map[string]string{
+						"name": cwAgentConfigMapNameConfig,
+					},
+				},
+				Data: map[string]string{
+					cwAgentConfigMapFileNameConfig: cwConfBody,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return err
+	}
+
+	ts.cfg.Logger.Info("created cw agent ConfigMap config")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+func (ts *tester) deleteCWAgentConfigMapConfig() error {
+	ts.cfg.Logger.Info("deleting cw agent ConfigMap config")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err := ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ConfigMaps(ts.cfg.EKSConfig.AddOnCWAgent.Namespace).
+		Delete(
+			ctx,
+			cwAgentConfigMapNameConfig,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil {
+		return err
+	}
+	ts.cfg.Logger.Info("deleted cw agent ConfigMap config")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// CWAgentImageName is the image name of CloudWatch agent daemon set.
+// ref. https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html
+// ref. https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html
+// ref. https://hub.docker.com/r/amazon/cloudwatch-agent
+const CWAgentImageName = "amazon/cloudwatch-agent:1.245315.0"
+
+func (ts *tester) createCWAgentDaemonSet() (err error) {
+	podSpec := v1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app.kubernetes.io/name": cwAgentAppName,
+			},
+		},
+		Spec: v1.PodSpec{
+			ServiceAccountName:            cwAgentServiceAccountName,
+			TerminationGracePeriodSeconds: aws.Int64(60),
+			// Unsupported value: "OnFailure": supported values: "Always"
+			RestartPolicy: v1.RestartPolicyAlways,
+
+			// https://www.eksworkshop.com/intermediate/230_logging/deploy/
+			Containers: []v1.Container{
+				{
+					Name:            cwAgentAppName,
+					Image:           CWAgentImageName,
+					ImagePullPolicy: v1.PullAlways,
+
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("200m"),
+							v1.ResourceMemory: resource.MustParse("200Mi"),
+						},
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("200m"),
+							v1.ResourceMemory: resource.MustParse("200Mi"),
+						},
+					},
+
+					Env: []v1.EnvVar{
+						{
+							Name: "HOST_IP",
+							ValueFrom: &v1.EnvVarSource{
+								FieldRef: &v1.ObjectFieldSelector{
+									FieldPath: "status.hostIP",
+								},
+							},
+						},
+						{
+							Name: "HOST_NAME",
+							ValueFrom: &v1.EnvVarSource{
+								FieldRef: &v1.ObjectFieldSelector{
+									FieldPath: "spec.nodeName",
+								},
+							},
+						},
+						{
+							Name: "K8S_NAMESPACE",
+							ValueFrom: &v1.EnvVarSource{
+								FieldRef: &v1.ObjectFieldSelector{
+									FieldPath: "metadata.namespace",
+								},
+							},
+						},
+						{
+							Name:  "CI_VERSION",
+							Value: "k8s/1.1.1",
+						},
+					},
+
+					// ref. https://kubernetes.io/docs/concepts/cluster-administration/logging/
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      cwAgentConfigMapNameConfig,
+							MountPath: "/etc/cwagentconfig",
+						},
+						{
+							Name:      "rootfs",
+							MountPath: "/rootfs",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "dockersock",
+							MountPath: "/var/run/docker.sock",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "varlibdocker",
+							MountPath: "/var/lib/docker",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "sys",
+							MountPath: "/sys",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "devdisk",
+							MountPath: "/dev/disk",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+
+			// ref. https://kubernetes.io/docs/concepts/cluster-administration/logging/
+			Volumes: []v1.Volume{
+				{
+					Name: cwAgentConfigMapNameConfig,
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: cwAgentConfigMapNameConfig,
+							},
+							DefaultMode: aws.Int32(0666),
+						},
+					},
+				},
+				{
+					Name: "rootfs",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/",
+						},
+					},
+				},
+				{
+					Name: "dockersock",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/var/run/docker.sock",
+						},
+					},
+				},
+				{
+					Name: "varlibdocker",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/var/lib/docker",
+						},
+					},
+				},
+				{
+					Name: "sys",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/sys",
+						},
+					},
+				},
+				{
+					Name: "devdisk",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/dev/disk/",
+						},
+					},
+				},
+			},
+
+			NodeSelector: map[string]string{
+				// do not deploy in fake nodes, obviously
+				"NodeType": "regular",
+			},
+		},
+	}
+
+	dsObj := appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "DaemonSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cwAgentDaemonSetName,
+			Namespace: ts.cfg.EKSConfig.AddOnCWAgent.Namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name": cwAgentAppName,
+				},
+			},
+
+			Template: podSpec,
+		},
+	}
+
+	ts.cfg.Logger.Info("creating cw agent DaemonSet", zap.String("name", cwAgentDaemonSetName))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err = ts.cfg.K8SClient.KubernetesClientSet().
+		AppsV1().
+		DaemonSets(ts.cfg.EKSConfig.AddOnCWAgent.Namespace).
+		Create(ctx, &dsObj, metav1.CreateOptions{})
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create cw agent DaemonSet (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created cw agent DaemonSet")
+	return nil
+}
+
+func (ts *tester) deleteCWAgentDaemonSet() (err error) {
+	foreground := metav1.DeletePropagationForeground
+	ts.cfg.Logger.Info("deleting cw agent DaemonSet", zap.String("name", cwAgentDaemonSetName))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err = ts.cfg.
+		K8SClient.KubernetesClientSet().
+		AppsV1().
+		DaemonSets(ts.cfg.EKSConfig.AddOnCWAgent.Namespace).
+		Delete(
+			ctx,
+			cwAgentDaemonSetName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete cw agent DaemonSet", zap.Error(err))
+		return fmt.Errorf("failed to delete cw agent DaemonSet (%v)", err)
+	}
+	return nil
+}
+
+func (ts *tester) checkCWAgentPods() (err error) {
+	waitDur := 10 * time.Minute
+	retryStart := time.Now()
+	for time.Now().Sub(retryStart) < waitDur {
+		select {
+		case <-ts.cfg.Stopc:
+			return errors.New("check aborted")
+		case <-time.After(15 * time.Second):
+		}
+		if err = ts._checkCWAgentPods(); err == nil {
+			break
+		}
+		ts.cfg.Logger.Info("failed to check cw agent pods; retrying", zap.Error(err))
+	}
+	return err
+}
+
+func (ts *tester) _checkCWAgentPods() error {
+	pods, err := ts.cfg.K8SClient.ListPods(ts.cfg.EKSConfig.AddOnCWAgent.Namespace, 150, 5*time.Second)
+	if err != nil {
+		ts.cfg.Logger.Warn("listing pods failed", zap.Error(err))
+		return err
+	}
+	if len(pods) > 0 {
+		ts.cfg.Logger.Info("pods found", zap.Int("pods", len(pods)))
+		fmt.Fprintf(ts.cfg.LogWriter, "\n")
+		for _, pod := range pods {
+			fmt.Fprintf(ts.cfg.LogWriter, "%q Pod using client-go: %q\n", ts.cfg.EKSConfig.AddOnCWAgent.Namespace, pod.Name)
+		}
+		fmt.Fprintf(ts.cfg.LogWriter, "\n")
+	} else {
+		ts.cfg.Logger.Info("no pod found", zap.String("namespace", ts.cfg.EKSConfig.AddOnCWAgent.Namespace))
+		return errors.New("no pod found in " + ts.cfg.EKSConfig.AddOnCWAgent.Namespace)
+	}
+
+	targetNodes := int64(1)
+	if ts.cfg.EKSConfig.TotalNodes > 1 {
+		targetNodes = ts.cfg.EKSConfig.TotalNodes / int64(2)
+	}
+	ts.cfg.Logger.Info("checking cw agent pods",
+		zap.Int64("total-nodes", ts.cfg.EKSConfig.TotalNodes),
+		zap.Int64("target-nodes", targetNodes),
+	)
+	readyNodes := int64(0)
+	for _, pod := range pods {
+		appName, ok := pod.Labels["app.kubernetes.io/name"]
+		if !ok || appName != cwAgentAppName {
+			ts.cfg.Logger.Info("skipping pod, not cw agent", zap.String("labels", fmt.Sprintf("%+v", pod.Labels)))
+			continue
+		}
+
+		descArgsPods := []string{
+			ts.cfg.EKSConfig.KubectlPath,
+			"--kubeconfig=" + ts.cfg.EKSConfig.KubeConfigPath,
+			"--namespace=" + ts.cfg.EKSConfig.AddOnCWAgent.Namespace,
+			"describe",
+			"pods/" + pod.Name,
+		}
+		descCmdPods := strings.Join(descArgsPods, " ")
+
+		logArgs := []string{
+			ts.cfg.EKSConfig.KubectlPath,
+			"--kubeconfig=" + ts.cfg.EKSConfig.KubeConfigPath,
+			"--namespace=" + ts.cfg.EKSConfig.AddOnCWAgent.Namespace,
+			"logs",
+			"pods/" + pod.Name,
+			"--all-containers=true",
+			"--timestamps",
+		}
+		logsCmd := strings.Join(logArgs, " ")
+
+		ts.cfg.Logger.Info("checking Pod",
+			zap.String("pod-name", pod.Name),
+			zap.String("app-name", appName),
+			zap.String("command-describe", descCmdPods),
+			zap.String("command-logs", logsCmd),
+		)
+
+		ready := false
+		for _, cond := range pod.Status.Conditions {
+			if cond.Status != v1.ConditionTrue {
+				continue
+			}
+			ts.cfg.Logger.Info("pod",
+				zap.String("name", pod.GetName()),
+				zap.String("status-type", fmt.Sprintf("%s", cond.Type)),
+				zap.String("status", fmt.Sprintf("%s", cond.Status)),
+			)
+			if cond.Type == v1.PodInitialized || cond.Type == v1.PodReady {
+				ready = true
+				readyNodes++
+			}
+			break
+		}
+		if !ready {
+			ts.cfg.Logger.Warn("pod is not ready yet", zap.String("pod-name", pod.Name))
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		output, err := exec.New().CommandContext(ctx, descArgsPods[0], descArgsPods[1:]...).CombinedOutput()
+		cancel()
+		outDesc := string(output)
+		if err != nil {
+			ts.cfg.Logger.Warn("'kubectl describe' failed", zap.Error(err))
+			continue
+		}
+		ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+		output, err = exec.New().CommandContext(ctx, logArgs[0], logArgs[1:]...).CombinedOutput()
+		cancel()
+		outLogs := string(output)
+		if err != nil {
+			ts.cfg.Logger.Warn("'kubectl logs' failed", zap.Error(err))
+			continue
+		}
+		if readyNodes < 3 { // only logs first 3 nodes
+			fmt.Fprintf(ts.cfg.LogWriter, "\n'%s' output:\n\n%s\n\n", descCmdPods, outDesc)
+			logLines := strings.Split(outLogs, "\n")
+			logLinesN := len(logLines)
+			if logLinesN > 15 {
+				logLines = logLines[logLinesN-15:]
+				outLogs = strings.Join(logLines, "\n")
+			}
+			fmt.Fprintf(ts.cfg.LogWriter, "\n'%s' output:\n\n%s\n\n", logsCmd, outLogs)
+		}
+
+		ts.cfg.Logger.Info("checked pod, ready", zap.String("pod-name", pod.Name))
+	}
+	ts.cfg.Logger.Info("checking cw agent pods",
+		zap.Int64("total-nodes", ts.cfg.EKSConfig.TotalNodes),
+		zap.Int64("target-nodes", targetNodes),
+		zap.Int64("ready-nodes", readyNodes),
+	)
+	if readyNodes < targetNodes {
+		return errors.New("not enough cw agent pods ready")
+	}
+
+	return nil
+}

--- a/eks/cw-agent/cw-agent_test.go
+++ b/eks/cw-agent/cw-agent_test.go
@@ -1,0 +1,29 @@
+package cwagent
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestTemplateCWAgentConf(t *testing.T) {
+	tr := templateCWAgentConf{
+		RegionName:  "us-east-1",
+		ClusterName: "test-cluster",
+	}
+	tpl := template.Must(template.New("TemplateCWAgentConf").Parse(TemplateCWAgentConf))
+	buf := bytes.NewBuffer(nil)
+	if err := tpl.Execute(buf, tr); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `"region": "us-east-1"`) {
+		t.Fatalf("unexpected region %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `"cluster_name": "test-cluster",`) {
+		t.Fatalf("unexpected cluster_name %s", buf.String())
+	}
+
+	fmt.Println(buf.String())
+}

--- a/eks/cw-agent/tester.go
+++ b/eks/cw-agent/tester.go
@@ -1,0 +1,157 @@
+// Package cwagent implements CloudWatch agent plugin.
+// ref. https://github.com/aws-samples/amazon-cloudwatch-container-insights/tree/master/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart
+// ref. https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-metrics.html
+// ref. https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html
+// ref. https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html
+//
+// Publishes worker nodes logs to:
+//  - /aws/containerinsights/[CLUSTER-NAME]/performance
+//
+package cwagent
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"time"
+
+	eks_tester "github.com/aws/aws-k8s-tester/eks/tester"
+	"github.com/aws/aws-k8s-tester/eksconfig"
+	k8s_client "github.com/aws/aws-k8s-tester/pkg/k8s-client"
+	"github.com/aws/aws-k8s-tester/pkg/timeutil"
+	"go.uber.org/zap"
+)
+
+// Config defines fluentd configuration.
+type Config struct {
+	Logger    *zap.Logger
+	LogWriter io.Writer
+	Stopc     chan struct{}
+	EKSConfig *eksconfig.Config
+	K8SClient k8s_client.EKS
+}
+
+var pkgName = reflect.TypeOf(tester{}).PkgPath()
+
+func (ts *tester) Name() string { return pkgName }
+
+func New(cfg Config) eks_tester.Tester {
+	cfg.Logger.Info("creating tester", zap.String("tester", pkgName))
+	return &tester{cfg: cfg, busyboxImg: "busybox"}
+}
+
+type tester struct {
+	cfg Config
+
+	busyboxImg string
+}
+
+func (ts *tester) Create() (err error) {
+	if !ts.cfg.EKSConfig.IsEnabledAddOnCWAgent() {
+		ts.cfg.Logger.Info("skipping tester.Create", zap.String("tester", pkgName))
+		return nil
+	}
+	if ts.cfg.EKSConfig.AddOnCWAgent.Created {
+		ts.cfg.Logger.Info("skipping tester.Create", zap.String("tester", pkgName))
+		return nil
+	}
+
+	ts.cfg.Logger.Info("starting tester.Create", zap.String("tester", pkgName))
+	ts.cfg.EKSConfig.AddOnCWAgent.Created = true
+	ts.cfg.EKSConfig.Sync()
+	createStart := time.Now()
+	defer func() {
+		createEnd := time.Now()
+		ts.cfg.EKSConfig.AddOnCWAgent.TimeFrameCreate = timeutil.NewTimeFrame(createStart, createEnd)
+		ts.cfg.EKSConfig.Sync()
+	}()
+
+	if err = k8s_client.CreateNamespace(
+		ts.cfg.Logger,
+		ts.cfg.K8SClient.KubernetesClientSet(),
+		ts.cfg.EKSConfig.AddOnCWAgent.Namespace,
+	); err != nil {
+		return err
+	}
+
+	// create CloudWatch agent components
+	if err = ts.createCWAgentServiceAccount(); err != nil {
+		return err
+	}
+	if err = ts.createCWAgentRBACClusterRole(); err != nil {
+		return err
+	}
+	if err = ts.createCWAgentRBACClusterRoleBinding(); err != nil {
+		return err
+	}
+	if err = ts.createCWAgentConfigMapConfig(); err != nil {
+		return err
+	}
+	if err = ts.createCWAgentDaemonSet(); err != nil {
+		return err
+	}
+	if err = ts.checkCWAgentPods(); err != nil {
+		return err
+	}
+
+	return ts.cfg.EKSConfig.Sync()
+}
+
+func (ts *tester) Delete() error {
+	if !ts.cfg.EKSConfig.IsEnabledAddOnCWAgent() {
+		ts.cfg.Logger.Info("skipping tester.Delete", zap.String("tester", pkgName))
+		return nil
+	}
+	if !ts.cfg.EKSConfig.AddOnCWAgent.Created {
+		ts.cfg.Logger.Info("skipping tester.Delete", zap.String("tester", pkgName))
+		return nil
+	}
+
+	ts.cfg.Logger.Info("starting tester.Delete", zap.String("tester", pkgName))
+	deleteStart := time.Now()
+	defer func() {
+		deleteEnd := time.Now()
+		ts.cfg.EKSConfig.AddOnCWAgent.TimeFrameDelete = timeutil.NewTimeFrame(deleteStart, deleteEnd)
+		ts.cfg.EKSConfig.Sync()
+	}()
+
+	var errs []string
+
+	if err := ts.deleteCWAgentDaemonSet(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	time.Sleep(time.Minute)
+
+	if err := ts.deleteCWAgentConfigMapConfig(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := ts.deleteCWAgentRBACClusterRoleBinding(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := ts.deleteCWAgentRBACClusterRole(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := ts.deleteCWAgentServiceAccount(); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	if err := k8s_client.DeleteNamespaceAndWait(
+		ts.cfg.Logger,
+		ts.cfg.K8SClient.KubernetesClientSet(),
+		ts.cfg.EKSConfig.AddOnCWAgent.Namespace,
+		k8s_client.DefaultNamespaceDeletionInterval,
+		k8s_client.DefaultNamespaceDeletionTimeout,
+		k8s_client.WithForceDelete(true),
+	); err != nil {
+		errs = append(errs, fmt.Sprintf("failed to delete fluentd namespace (%v)", err))
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ", "))
+	}
+
+	ts.cfg.EKSConfig.AddOnCWAgent.Created = false
+	return ts.cfg.EKSConfig.Sync()
+}

--- a/eks/cw-agent/tester.go
+++ b/eks/cw-agent/tester.go
@@ -39,13 +39,11 @@ func (ts *tester) Name() string { return pkgName }
 
 func New(cfg Config) eks_tester.Tester {
 	cfg.Logger.Info("creating tester", zap.String("tester", pkgName))
-	return &tester{cfg: cfg, busyboxImg: "busybox"}
+	return &tester{cfg: cfg}
 }
 
 type tester struct {
 	cfg Config
-
-	busyboxImg string
 }
 
 func (ts *tester) Create() (err error) {

--- a/eks/eks.go
+++ b/eks/eks.go
@@ -35,7 +35,9 @@ import (
 	csrs_local "github.com/aws/aws-k8s-tester/eks/csrs/local"
 	csrs_remote "github.com/aws/aws-k8s-tester/eks/csrs/remote"
 	cuda_vector_add "github.com/aws/aws-k8s-tester/eks/cuda-vector-add"
+	cw_agent "github.com/aws/aws-k8s-tester/eks/cw-agent"
 	"github.com/aws/aws-k8s-tester/eks/fargate"
+	"github.com/aws/aws-k8s-tester/eks/fluentd"
 	"github.com/aws/aws-k8s-tester/eks/gpu"
 	hollow_nodes_local "github.com/aws/aws-k8s-tester/eks/hollow-nodes/local"
 	hollow_nodes_remote "github.com/aws/aws-k8s-tester/eks/hollow-nodes/remote"
@@ -462,6 +464,20 @@ func (ts *Tester) createTesters() (err error) {
 	})
 
 	ts.testers = []eks_tester.Tester{
+		cw_agent.New(cw_agent.Config{
+			Logger:    ts.lg,
+			LogWriter: ts.logWriter,
+			Stopc:     ts.stopCreationCh,
+			EKSConfig: ts.cfg,
+		}),
+		fluentd.New(fluentd.Config{
+			Logger:    ts.lg,
+			LogWriter: ts.logWriter,
+			Stopc:     ts.stopCreationCh,
+			EKSConfig: ts.cfg,
+			K8SClient: ts.k8sClient,
+			ECRAPI:    ecr.New(ts.awsSession, aws.NewConfig().WithRegion(ts.cfg.GetAddOnFluentdRepositoryBusyboxRegion())),
+		}),
 		metrics_server.New(metrics_server.Config{
 			Logger:    ts.lg,
 			LogWriter: ts.logWriter,

--- a/eks/eks.go
+++ b/eks/eks.go
@@ -53,6 +53,7 @@ import (
 	"github.com/aws/aws-k8s-tester/eks/ng"
 	nlb_guestbook "github.com/aws/aws-k8s-tester/eks/nlb-guestbook"
 	nlb_hello_world "github.com/aws/aws-k8s-tester/eks/nlb-hello-world"
+	php_apache "github.com/aws/aws-k8s-tester/eks/php-apache"
 	prometheus_grafana "github.com/aws/aws-k8s-tester/eks/prometheus-grafana"
 	secrets_local "github.com/aws/aws-k8s-tester/eks/secrets/local"
 	secrets_remote "github.com/aws/aws-k8s-tester/eks/secrets/remote"
@@ -517,6 +518,13 @@ func (ts *Tester) createTesters() (err error) {
 			K8SClient: ts.k8sClient,
 		}),
 		prometheus_grafana.New(prometheus_grafana.Config{
+			Logger:    ts.lg,
+			LogWriter: ts.logWriter,
+			Stopc:     ts.stopCreationCh,
+			EKSConfig: ts.cfg,
+			K8SClient: ts.k8sClient,
+		}),
+		php_apache.New(php_apache.Config{
 			Logger:    ts.lg,
 			LogWriter: ts.logWriter,
 			Stopc:     ts.stopCreationCh,

--- a/eks/fluentd/fluentd.go
+++ b/eks/fluentd/fluentd.go
@@ -1,0 +1,1123 @@
+package fluentd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"html/template"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/exec"
+)
+
+const (
+	fluentdServiceAccountName              = "fluentd-service-account"
+	fluentdRBACRoleName                    = "fluentd-rbac-role"
+	fluentdRBACClusterRoleBindingName      = "fluentd-rbac-role-binding"
+	fluentdConfigMapNameClusterInfo        = "fluentd-configmap-cluster-info"
+	fluentdConfigMapNameConfig             = "fluentd-configmap-config"
+	fluentdConfigMapFileNameFluentConf     = "fluent.conf"
+	fluentdConfigMapFileNameContainersConf = "containers.conf"
+	fluentdConfigMapFileNameSystemdConf    = "systemd.conf"
+	fluentdConfigMapFileNameHostConf       = "host.conf"
+	fluentdAppName                         = "fluentd-cloudwatch"
+	fluentdDaemonSetName                   = "fluentd-cloudwatch"
+)
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) createFluentdServiceAccount() error {
+	ts.cfg.Logger.Info("creating fluentd ServiceAccount")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ServiceAccounts(ts.cfg.EKSConfig.AddOnFluentd.Namespace).
+		Create(
+			ctx,
+			&v1.ServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fluentdServiceAccountName,
+					Namespace: ts.cfg.EKSConfig.AddOnFluentd.Namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": fluentdAppName,
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create fluentd ServiceAccount (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created fluentd ServiceAccount")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) deleteFluentdServiceAccount() error {
+	ts.cfg.Logger.Info("deleting fluentd ServiceAccount")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err := ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ServiceAccounts(ts.cfg.EKSConfig.AddOnFluentd.Namespace).
+		Delete(
+			ctx,
+			fluentdServiceAccountName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete", zap.Error(err))
+		return fmt.Errorf("failed to delete fluentd ServiceAccount (%v)", err)
+	}
+	ts.cfg.Logger.Info("deleted fluentd ServiceAccount", zap.Error(err))
+
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) createFluentdRBACClusterRole() error {
+	ts.cfg.Logger.Info("creating fluentd RBAC ClusterRole")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoles().
+		Create(
+			ctx,
+			&rbacv1.ClusterRole{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "ClusterRole",
+				},
+				// "ClusterRole" is a non-namespaced resource.
+				// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fluentdRBACRoleName,
+					Namespace: "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name": fluentdAppName,
+					},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						// "" indicates the core API group
+						// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole
+						APIGroups: []string{
+							"",
+						},
+						Resources: []string{
+							"namespaces",
+							"pods",
+							"pods/logs",
+						},
+						Verbs: []string{
+							"get",
+							"list",
+							"watch",
+						},
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create fluentd RBAC ClusterRole (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created fluentd RBAC ClusterRole")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) deleteFluentdRBACClusterRole() error {
+	ts.cfg.Logger.Info("deleting fluentd RBAC ClusterRole")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err := ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoles().
+		Delete(
+			ctx,
+			fluentdRBACRoleName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete", zap.Error(err))
+		return fmt.Errorf("failed to delete fluentd RBAC ClusterRole (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("deleted fluentd RBAC ClusterRole", zap.Error(err))
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) createFluentdRBACClusterRoleBinding() error {
+	ts.cfg.Logger.Info("creating fluentd RBAC ClusterRoleBinding")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoleBindings().
+		Create(
+			ctx,
+			&rbacv1.ClusterRoleBinding{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "ClusterRoleBinding",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fluentdRBACClusterRoleBindingName,
+					Namespace: "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name": fluentdAppName,
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     fluentdRBACRoleName,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						APIGroup:  "",
+						Kind:      "ServiceAccount",
+						Name:      fluentdServiceAccountName,
+						Namespace: ts.cfg.EKSConfig.AddOnFluentd.Namespace,
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create fluentd RBAC ClusterRoleBinding (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created fluentd RBAC ClusterRoleBinding")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// ref. https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) deleteFluentdRBACClusterRoleBinding() error {
+	ts.cfg.Logger.Info("deleting fluentd RBAC ClusterRoleBinding")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err := ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoleBindings().
+		Delete(
+			ctx,
+			fluentdRBACClusterRoleBindingName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete", zap.Error(err))
+		return fmt.Errorf("failed to delete fluentd RBAC ClusterRoleBinding (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("deleted fluentd RBAC ClusterRoleBinding", zap.Error(err))
+	return ts.cfg.EKSConfig.Sync()
+}
+
+func (ts *tester) createFluentdConfigMapClusterInfo() (err error) {
+	ts.cfg.Logger.Info("creating fluentd ConfigMap cluster-info")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err = ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ConfigMaps(ts.cfg.EKSConfig.AddOnFluentd.Namespace).
+		Create(
+			ctx,
+			&v1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fluentdConfigMapNameClusterInfo,
+					Namespace: ts.cfg.EKSConfig.AddOnFluentd.Namespace,
+					Labels: map[string]string{
+						"name": fluentdConfigMapNameClusterInfo,
+					},
+				},
+				Data: map[string]string{
+					"cluster.name": ts.cfg.EKSConfig.Name,
+					"logs.region":  ts.cfg.EKSConfig.Region,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return err
+	}
+
+	ts.cfg.Logger.Info("created fluentd ConfigMap cluster-info")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+func (ts *tester) deleteFluentdConfigMapClusterInfo() error {
+	ts.cfg.Logger.Info("deleting fluentd ConfigMap cluster-info")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err := ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ConfigMaps(ts.cfg.EKSConfig.AddOnFluentd.Namespace).
+		Delete(
+			ctx,
+			fluentdConfigMapNameClusterInfo,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil {
+		return err
+	}
+	ts.cfg.Logger.Info("deleted fluentd ConfigMap cluster-info")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+const TemplateFluentdConf = `
+@include containers.conf
+@include systemd.conf
+@include host.conf
+
+<filter kubernetes.var.log.containers.**.log>
+  @type kubernetes_metadata
+  @id filter_kube_metadata_application
+  @log_level "{{.MetadataLogLevel}}"
+  skip_labels {{.MetadataSkipLabels}}
+  skip_container_metadata {{.MetadataSkipContainerMetadata}}
+  skip_master_url {{.MetadataSkipMasterURL}}
+  skip_namespace_metadata {{.MetadataSkipNamespaceMetadata}}
+  cache_size {{.MetadataCacheSize}}
+  watch {{.MetadataWatch}}
+  de_dot false
+</filter>
+
+<match fluent.**>
+  @type null
+  num_threads {{.Threads}}
+</match>
+`
+
+type templateFluentdConf struct {
+	Threads                       int
+	MetadataLogLevel              string
+	MetadataCacheSize             int
+	MetadataWatch                 bool
+	MetadataSkipLabels            bool
+	MetadataSkipMasterURL         bool
+	MetadataSkipContainerMetadata bool
+	MetadataSkipNamespaceMetadata bool
+}
+
+const TemplateContainersConf = `
+<source>
+  @type tail
+  @id in_tail_container_logs
+  @label @containers
+  path /var/log/containers/*.log
+  exclude_path ["/var/log/containers/cloudwatch-agent*", "/var/log/containers/fluentd*"]
+  pos_file /var/log/fluentd-containers.log.pos
+  tag *
+  read_from_head true
+  <parse>
+    @type json
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+  </parse>
+</source>
+
+<source>
+  @type tail
+  @id in_tail_cwagent_logs
+  @label @cwagentlogs
+  path /var/log/containers/cloudwatch-agent*
+  pos_file /var/log/cloudwatch-agent.log.pos
+  tag *
+  read_from_head true
+  <parse>
+    @type json
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+  </parse>
+</source>
+
+<source>
+  @type tail
+  @id in_tail_fluentd_logs
+  @label @fluentdlogs
+  path /var/log/containers/fluentd*
+  pos_file /var/log/fluentd.log.pos
+  tag *
+  read_from_head true
+  <parse>
+    @type json
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+  </parse>
+</source>
+
+<label @fluentdlogs>
+  <filter **>
+    @type kubernetes_metadata
+    @id filter_kube_metadata_fluentd
+  </filter>
+
+  <filter **>
+    @type record_transformer
+    @id filter_fluentd_stream_transformer
+    <record>
+      stream_name ${tag_parts[3]}
+    </record>
+  </filter>
+
+  <match **>
+    @type relabel
+    @label @NORMAL
+  </match>
+</label>
+
+<label @containers>
+  <filter **>
+    @type kubernetes_metadata
+    @id filter_kube_metadata
+  </filter>
+
+  <filter **>
+    @type record_transformer
+    @id filter_containers_stream_transformer
+    <record>
+      stream_name ${tag_parts[3]}
+    </record>
+  </filter>
+
+  <filter **>
+    @type concat
+    key log
+    multiline_start_regexp /^\S/
+    separator ""
+    flush_interval 5
+    timeout_label @NORMAL
+  </filter>
+
+  <match **>
+    @type relabel
+    @label @NORMAL
+  </match>
+</label>
+
+<label @cwagentlogs>
+  <filter **>
+    @type kubernetes_metadata
+    @id filter_kube_metadata_cwagent
+  </filter>
+
+  <filter **>
+    @type record_transformer
+    @id filter_cwagent_stream_transformer
+    <record>
+      stream_name ${tag_parts[3]}
+    </record>
+  </filter>
+
+  <filter **>
+    @type concat
+    key log
+    multiline_start_regexp /^\d{4}[-/]\d{1,2}[-/]\d{1,2}/
+    separator ""
+    flush_interval 5
+    timeout_label @NORMAL
+  </filter>
+
+  <match **>
+    @type relabel
+    @label @NORMAL
+  </match>
+</label>
+
+<label @NORMAL>
+  <match **>
+    @type cloudwatch_logs
+    @id out_cloudwatch_logs_containers
+    region "#{ENV.fetch('REGION')}"
+    log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/application"
+    log_stream_name_key stream_name
+    remove_log_stream_name_key true
+    auto_create_stream true
+    <buffer>
+      flush_interval 5
+      chunk_limit_size 2m
+      queued_chunks_limit_size 32
+      retry_forever true
+    </buffer>
+  </match>
+</label>
+`
+
+const TemplateSystemdConf = `
+<source>
+  @type systemd
+  @id in_systemd_kubelet
+  @label @systemd
+  filters [{ "_SYSTEMD_UNIT": "kubelet.service" }]
+  <entry>
+    field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+    field_map_strict true
+  </entry>
+  path /run/log/journal
+  <storage>
+    @type local
+    persistent true
+    path /var/log/fluentd-journald-kubelet-pos.json
+  </storage>
+  read_from_head true
+  tag kubelet.service
+</source>
+
+<source>
+  @type systemd
+  @id in_systemd_kubeproxy
+  @label @systemd
+  filters [{ "_SYSTEMD_UNIT": "kubeproxy.service" }]
+  <entry>
+    field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+    field_map_strict true
+  </entry>
+  path /run/log/journal
+  <storage>
+    @type local
+    persistent true
+    path /var/log/fluentd-journald-kubeproxy-pos.json
+  </storage>
+  read_from_head true
+  tag kubeproxy.service
+</source>
+
+<source>
+  @type systemd
+  @id in_systemd_docker
+  @label @systemd
+  filters [{ "_SYSTEMD_UNIT": "docker.service" }]
+  <entry>
+    field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+    field_map_strict true
+  </entry>
+  <storage>
+    @type local
+    persistent true
+    path /var/log/fluentd-journald-docker-pos.json
+  </storage>
+  read_from_head true
+  tag docker.service
+</source>
+
+<label @systemd>
+  <filter **>
+    @type kubernetes_metadata
+    @id filter_kube_metadata_systemd
+  </filter>
+
+  <filter **>
+    @type record_transformer
+    @id filter_systemd_stream_transformer
+    <record>
+      stream_name ${tag}-${record["hostname"]}
+    </record>
+  </filter>
+
+  <match **>
+    @type cloudwatch_logs
+    @id out_cloudwatch_logs_systemd
+    region "#{ENV.fetch('REGION')}"
+    log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/dataplane"
+    log_stream_name_key stream_name
+    auto_create_stream true
+    remove_log_stream_name_key true
+    <buffer>
+      flush_interval 5
+      chunk_limit_size 2m
+      queued_chunks_limit_size 32
+      retry_forever true
+    </buffer>
+  </match>
+</label>
+`
+
+const TemplateHostConf = `
+<source>
+  @type tail
+  @id in_tail_dmesg
+  @label @hostlogs
+  path /var/log/dmesg
+  pos_file /var/log/dmesg.log.pos
+  tag host.dmesg
+  read_from_head true
+  <parse>
+    @type syslog
+  </parse>
+</source>
+
+<source>
+  @type tail
+  @id in_tail_secure
+  @label @hostlogs
+  path /var/log/secure
+  pos_file /var/log/secure.log.pos
+  tag host.secure
+  read_from_head true
+  <parse>
+    @type syslog
+  </parse>
+</source>
+
+<source>
+  @type tail
+  @id in_tail_messages
+  @label @hostlogs
+  path /var/log/messages
+  pos_file /var/log/messages.log.pos
+  tag host.messages
+  read_from_head true
+  <parse>
+    @type syslog
+  </parse>
+</source>
+
+<label @hostlogs>
+  <filter **>
+    @type kubernetes_metadata
+    @id filter_kube_metadata_host
+  </filter>
+
+  <filter **>
+    @type record_transformer
+    @id filter_containers_stream_transformer_host
+    <record>
+      stream_name ${tag}-${record["host"]}
+    </record>
+  </filter>
+
+  <match host.**>
+    @type cloudwatch_logs
+    @id out_cloudwatch_logs_host_logs
+    region "#{ENV.fetch('REGION')}"
+    log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/host"
+    log_stream_name_key stream_name
+    remove_log_stream_name_key true
+    auto_create_stream true
+    <buffer>
+      flush_interval 5
+      chunk_limit_size 2m
+      queued_chunks_limit_size 32
+      retry_forever true
+    </buffer>
+  </match>
+</label>
+`
+
+func (ts *tester) createFluentdConfigMapConfig() (err error) {
+	ts.cfg.Logger.Info("creating fluentd ConfigMap config")
+
+	buf := bytes.NewBuffer(nil)
+	fdConf := templateFluentdConf{
+		Threads:                       ts.cfg.EKSConfig.AddOnFluentd.Threads,
+		MetadataLogLevel:              ts.cfg.EKSConfig.AddOnFluentd.MetadataLogLevel,
+		MetadataCacheSize:             ts.cfg.EKSConfig.AddOnFluentd.MetadataCacheSize,
+		MetadataWatch:                 ts.cfg.EKSConfig.AddOnFluentd.MetadataWatch,
+		MetadataSkipLabels:            ts.cfg.EKSConfig.AddOnFluentd.MetadataSkipLabels,
+		MetadataSkipMasterURL:         ts.cfg.EKSConfig.AddOnFluentd.MetadataSkipMasterURL,
+		MetadataSkipContainerMetadata: ts.cfg.EKSConfig.AddOnFluentd.MetadataSkipContainerMetadata,
+		MetadataSkipNamespaceMetadata: ts.cfg.EKSConfig.AddOnFluentd.MetadataSkipNamespaceMetadata,
+	}
+	fdConfTmpl := template.Must(template.New("TemplateFluentdConf").Parse(TemplateFluentdConf))
+	if err := fdConfTmpl.Execute(buf, fdConf); err != nil {
+		return err
+	}
+	fdConfBody := buf.String()
+	buf.Reset()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err = ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ConfigMaps(ts.cfg.EKSConfig.AddOnFluentd.Namespace).
+		Create(
+			ctx,
+			&v1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fluentdConfigMapNameConfig,
+					Namespace: ts.cfg.EKSConfig.AddOnFluentd.Namespace,
+					Labels: map[string]string{
+						"name": fluentdConfigMapNameConfig,
+					},
+				},
+				Data: map[string]string{
+					fluentdConfigMapFileNameFluentConf:     fdConfBody,
+					fluentdConfigMapFileNameContainersConf: TemplateContainersConf,
+					fluentdConfigMapFileNameSystemdConf:    TemplateSystemdConf,
+					fluentdConfigMapFileNameHostConf:       TemplateHostConf,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return err
+	}
+
+	ts.cfg.Logger.Info("created fluentd ConfigMap config")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+func (ts *tester) deleteFluentdConfigMapConfig() error {
+	ts.cfg.Logger.Info("deleting fluentd ConfigMap config")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err := ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ConfigMaps(ts.cfg.EKSConfig.AddOnFluentd.Namespace).
+		Delete(
+			ctx,
+			fluentdConfigMapNameConfig,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil {
+		return err
+	}
+	ts.cfg.Logger.Info("deleted fluentd ConfigMap config")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+// FluentdImageName is the image name of Fluentd daemon set.
+// ref. https://github.com/fluent/fluentd-kubernetes-daemonset
+const FluentdImageName = "fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0"
+
+func (ts *tester) createFluentdDaemonSet() (err error) {
+	dirOrCreate := v1.HostPathDirectoryOrCreate
+	podSpec := v1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app.kubernetes.io/name": fluentdAppName,
+			},
+		},
+		Spec: v1.PodSpec{
+			ServiceAccountName:            fluentdServiceAccountName,
+			TerminationGracePeriodSeconds: aws.Int64(30),
+			// Unsupported value: "OnFailure": supported values: "Always"
+			RestartPolicy: v1.RestartPolicyAlways,
+
+			// image's entrypoint requires to write on /fluentd/etc
+			// but we mount configmap there as read-only
+			// this init container copy workaround is required
+			// https://github.com/fluent/fluentd-kubernetes-daemonset/issues/90
+			InitContainers: []v1.Container{
+				{
+					Name:  "copy-fluentd-config",
+					Image: ts.busyboxImg,
+					Command: []string{
+						"sh",
+						"-c",
+						"cp /config-volume/..data/* /fluentd/etc",
+					},
+					// ref. https://kubernetes.io/docs/concepts/cluster-administration/logging/
+					VolumeMounts: []v1.VolumeMount{
+						{ // to execute
+							Name:      fluentdConfigMapNameConfig,
+							MountPath: "/config-volume",
+						},
+						{
+							Name:      "fluentdconf",
+							MountPath: "/fluentd/etc",
+						},
+					},
+				},
+
+				// TODO: do we need this?
+				// ref. https://github.com/aws-samples/amazon-cloudwatch-container-insights/tree/master/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart
+				// {
+				// 	Name:    "update-log-driver",
+				// 	Image:   ts.busyboxImg,
+				// 	Command: []string{"sh", "-c", "''"},
+				// },
+			},
+
+			// https://www.eksworkshop.com/intermediate/230_logging/deploy/
+			Containers: []v1.Container{
+				{
+					Name:            fluentdAppName,
+					Image:           FluentdImageName,
+					ImagePullPolicy: v1.PullAlways,
+
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("100m"),
+							v1.ResourceMemory: resource.MustParse("200Mi"),
+						},
+					},
+
+					Env: []v1.EnvVar{
+						{
+							Name: "REGION",
+							ValueFrom: &v1.EnvVarSource{
+								ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: fluentdConfigMapNameClusterInfo,
+									},
+									Key: "logs.region",
+								},
+							},
+						},
+						{
+							Name: "CLUSTER_NAME",
+							ValueFrom: &v1.EnvVarSource{
+								ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: fluentdConfigMapNameClusterInfo,
+									},
+									Key: "cluster.name",
+								},
+							},
+						},
+						{
+							Name:  "CI_VERSION",
+							Value: "k8s/1.1.1",
+						},
+					},
+
+					// ref. https://kubernetes.io/docs/concepts/cluster-administration/logging/
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      fluentdConfigMapNameConfig,
+							MountPath: "/config-volume",
+						},
+						{
+							Name:      "fluentdconf",
+							MountPath: "/fluentd/etc",
+						},
+						{
+							Name:      "varlog",
+							MountPath: "/var/log",
+						},
+						{
+							Name:      "varlibdockercontainers",
+							MountPath: "/var/lib/docker/containers",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "runlogjournal",
+							MountPath: "/run/log/journal",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "dmesg",
+							MountPath: "/var/log/dmesg",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+
+			// ref. https://kubernetes.io/docs/concepts/cluster-administration/logging/
+			Volumes: []v1.Volume{
+				{
+					Name: fluentdConfigMapNameConfig,
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: fluentdConfigMapNameConfig,
+							},
+							DefaultMode: aws.Int32(0666),
+						},
+					},
+				},
+				{
+					Name: "fluentdconf",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{},
+					},
+				},
+				{ // to write
+					Name: "varlog",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/var/log",
+							Type: &dirOrCreate,
+						},
+					},
+				},
+				{
+					Name: "varlibdockercontainers",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/var/lib/docker/containers",
+							Type: &dirOrCreate,
+						},
+					},
+				},
+				{
+					Name: "runlogjournal",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/run/log/journal",
+							Type: &dirOrCreate,
+						},
+					},
+				},
+				{
+					Name: "dmesg",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/var/log/dmesg",
+						},
+					},
+				},
+			},
+
+			NodeSelector: map[string]string{
+				// do not deploy in fake nodes, obviously
+				"NodeType": "regular",
+			},
+		},
+	}
+
+	dsObj := appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "DaemonSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fluentdDaemonSetName,
+			Namespace: ts.cfg.EKSConfig.AddOnFluentd.Namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name": fluentdAppName,
+				},
+			},
+
+			Template: podSpec,
+		},
+	}
+
+	ts.cfg.Logger.Info("creating fluentd DaemonSet", zap.String("name", fluentdDaemonSetName))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err = ts.cfg.K8SClient.KubernetesClientSet().
+		AppsV1().
+		DaemonSets(ts.cfg.EKSConfig.AddOnFluentd.Namespace).
+		Create(ctx, &dsObj, metav1.CreateOptions{})
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create fluentd DaemonSet (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created fluentd DaemonSet")
+	return nil
+}
+
+func (ts *tester) deleteFluentdDaemonSet() (err error) {
+	foreground := metav1.DeletePropagationForeground
+	ts.cfg.Logger.Info("deleting fluentd DaemonSet", zap.String("name", fluentdDaemonSetName))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err = ts.cfg.
+		K8SClient.KubernetesClientSet().
+		AppsV1().
+		DaemonSets(ts.cfg.EKSConfig.AddOnFluentd.Namespace).
+		Delete(
+			ctx,
+			fluentdDaemonSetName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete fluentd DaemonSet", zap.Error(err))
+		return fmt.Errorf("failed to delete fluentd DaemonSet (%v)", err)
+	}
+	return nil
+}
+
+func (ts *tester) checkFluentdPods() (err error) {
+	waitDur := 10 * time.Minute
+	retryStart := time.Now()
+	for time.Now().Sub(retryStart) < waitDur {
+		select {
+		case <-ts.cfg.Stopc:
+			return errors.New("check aborted")
+		case <-time.After(15 * time.Second):
+		}
+		if err = ts._checkFluentdPods(); err == nil {
+			break
+		}
+		ts.cfg.Logger.Info("failed to check fluentd pods; retrying", zap.Error(err))
+	}
+	return err
+}
+
+func (ts *tester) _checkFluentdPods() error {
+	pods, err := ts.cfg.K8SClient.ListPods(ts.cfg.EKSConfig.AddOnFluentd.Namespace, 150, 5*time.Second)
+	if err != nil {
+		ts.cfg.Logger.Warn("listing pods failed", zap.Error(err))
+		return err
+	}
+	if len(pods) > 0 {
+		ts.cfg.Logger.Info("pods found", zap.Int("pods", len(pods)))
+		fmt.Fprintf(ts.cfg.LogWriter, "\n")
+		for _, pod := range pods {
+			fmt.Fprintf(ts.cfg.LogWriter, "%q Pod using client-go: %q\n", ts.cfg.EKSConfig.AddOnFluentd.Namespace, pod.Name)
+		}
+		fmt.Fprintf(ts.cfg.LogWriter, "\n")
+	} else {
+		ts.cfg.Logger.Info("no pod found", zap.String("namespace", ts.cfg.EKSConfig.AddOnFluentd.Namespace))
+		return errors.New("no pod found in " + ts.cfg.EKSConfig.AddOnFluentd.Namespace)
+	}
+
+	targetNodes := int64(1)
+	if ts.cfg.EKSConfig.TotalNodes > 1 {
+		targetNodes = ts.cfg.EKSConfig.TotalNodes / int64(2)
+	}
+	ts.cfg.Logger.Info("checking fluentd pods",
+		zap.Int64("total-nodes", ts.cfg.EKSConfig.TotalNodes),
+		zap.Int64("target-nodes", targetNodes),
+	)
+	readyNodes := int64(0)
+	for _, pod := range pods {
+		appName, ok := pod.Labels["app.kubernetes.io/name"]
+		if !ok || appName != fluentdAppName {
+			ts.cfg.Logger.Info("skipping pod, not fluentd", zap.String("labels", fmt.Sprintf("%+v", pod.Labels)))
+			continue
+		}
+
+		descArgsPods := []string{
+			ts.cfg.EKSConfig.KubectlPath,
+			"--kubeconfig=" + ts.cfg.EKSConfig.KubeConfigPath,
+			"--namespace=" + ts.cfg.EKSConfig.AddOnFluentd.Namespace,
+			"describe",
+			"pods/" + pod.Name,
+		}
+		descCmdPods := strings.Join(descArgsPods, " ")
+
+		logArgs := []string{
+			ts.cfg.EKSConfig.KubectlPath,
+			"--kubeconfig=" + ts.cfg.EKSConfig.KubeConfigPath,
+			"--namespace=" + ts.cfg.EKSConfig.AddOnFluentd.Namespace,
+			"logs",
+			"pods/" + pod.Name,
+			"--all-containers=true",
+			"--timestamps",
+		}
+		logsCmd := strings.Join(logArgs, " ")
+
+		ts.cfg.Logger.Info("checking Pod",
+			zap.String("pod-name", pod.Name),
+			zap.String("app-name", appName),
+			zap.String("command-describe", descCmdPods),
+			zap.String("command-logs", logsCmd),
+		)
+
+		ready := false
+		for _, cond := range pod.Status.Conditions {
+			if cond.Status != v1.ConditionTrue {
+				continue
+			}
+			ts.cfg.Logger.Info("pod",
+				zap.String("name", pod.GetName()),
+				zap.String("status-type", fmt.Sprintf("%s", cond.Type)),
+				zap.String("status", fmt.Sprintf("%s", cond.Status)),
+			)
+			if cond.Type == v1.PodInitialized || cond.Type == v1.PodReady {
+				ready = true
+				readyNodes++
+			}
+			break
+		}
+		if !ready {
+			ts.cfg.Logger.Warn("pod is not ready yet", zap.String("pod-name", pod.Name))
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		output, err := exec.New().CommandContext(ctx, descArgsPods[0], descArgsPods[1:]...).CombinedOutput()
+		cancel()
+		outDesc := string(output)
+		if err != nil {
+			ts.cfg.Logger.Warn("'kubectl describe' failed", zap.Error(err))
+			continue
+		}
+		ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+		output, err = exec.New().CommandContext(ctx, logArgs[0], logArgs[1:]...).CombinedOutput()
+		cancel()
+		outLogs := string(output)
+		if err != nil {
+			ts.cfg.Logger.Warn("'kubectl logs' failed", zap.Error(err))
+			continue
+		}
+		if readyNodes < 3 { // only logs first 3 nodes
+			fmt.Fprintf(ts.cfg.LogWriter, "\n'%s' output:\n\n%s\n\n", descCmdPods, outDesc)
+			logLines := strings.Split(outLogs, "\n")
+			logLinesN := len(logLines)
+			if logLinesN > 15 {
+				logLines = logLines[logLinesN-15:]
+				outLogs = strings.Join(logLines, "\n")
+			}
+			fmt.Fprintf(ts.cfg.LogWriter, "\n'%s' output:\n\n%s\n\n", logsCmd, outLogs)
+		}
+
+		ts.cfg.Logger.Info("checked pod, ready", zap.String("pod-name", pod.Name))
+	}
+	ts.cfg.Logger.Info("checking fluentd pods",
+		zap.Int64("total-nodes", ts.cfg.EKSConfig.TotalNodes),
+		zap.Int64("target-nodes", targetNodes),
+		zap.Int64("ready-nodes", readyNodes),
+	)
+	if readyNodes < targetNodes {
+		return errors.New("not enough fluentd pods ready")
+	}
+
+	return nil
+}

--- a/eks/fluentd/fluentd_test.go
+++ b/eks/fluentd/fluentd_test.go
@@ -1,0 +1,35 @@
+package fluentd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestTemplateFluentdConf(t *testing.T) {
+	tr := templateFluentdConf{
+		Threads:                       10,
+		MetadataLogLevel:              "info",
+		MetadataCacheSize:             100,
+		MetadataWatch:                 true,
+		MetadataSkipLabels:            false,
+		MetadataSkipMasterURL:         true,
+		MetadataSkipContainerMetadata: false,
+		MetadataSkipNamespaceMetadata: true,
+	}
+	tpl := template.Must(template.New("TemplateFluentdConf").Parse(TemplateFluentdConf))
+	buf := bytes.NewBuffer(nil)
+	if err := tpl.Execute(buf, tr); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `@log_level "info"`) {
+		t.Fatalf("expected log level 'info', got %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `cache_size 100`) {
+		t.Fatalf("expected cache size '1000', got %s", buf.String())
+	}
+
+	fmt.Println(buf.String())
+}

--- a/eks/fluentd/tester.go
+++ b/eks/fluentd/tester.go
@@ -1,0 +1,184 @@
+// Package fluentd implements Fluentd plugin.
+// ref. https://github.com/aws-samples/amazon-cloudwatch-container-insights/tree/master/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart
+// ref. https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-metrics.html
+// ref. https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html
+// ref. https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html
+//
+// Publishes worker nodes logs to:
+//  - /aws/containerinsights/[CLUSTER-NAME]/application
+//  - /aws/containerinsights/[CLUSTER-NAME]/dataplane
+//  - /aws/containerinsights/[CLUSTER-NAME]/host
+//
+package fluentd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"time"
+
+	eks_tester "github.com/aws/aws-k8s-tester/eks/tester"
+	"github.com/aws/aws-k8s-tester/eksconfig"
+	aws_ecr "github.com/aws/aws-k8s-tester/pkg/aws/ecr"
+	k8s_client "github.com/aws/aws-k8s-tester/pkg/k8s-client"
+	"github.com/aws/aws-k8s-tester/pkg/timeutil"
+	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
+	"go.uber.org/zap"
+)
+
+// Config defines fluentd configuration.
+type Config struct {
+	Logger    *zap.Logger
+	LogWriter io.Writer
+	Stopc     chan struct{}
+	EKSConfig *eksconfig.Config
+	K8SClient k8s_client.EKS
+	ECRAPI    ecriface.ECRAPI
+}
+
+var pkgName = reflect.TypeOf(tester{}).PkgPath()
+
+func (ts *tester) Name() string { return pkgName }
+
+func New(cfg Config) eks_tester.Tester {
+	cfg.Logger.Info("creating tester", zap.String("tester", pkgName))
+	return &tester{cfg: cfg, busyboxImg: "busybox"}
+}
+
+type tester struct {
+	cfg Config
+
+	busyboxImg string
+}
+
+func (ts *tester) Create() (err error) {
+	if !ts.cfg.EKSConfig.IsEnabledAddOnFluentd() {
+		ts.cfg.Logger.Info("skipping tester.Create", zap.String("tester", pkgName))
+		return nil
+	}
+	if ts.cfg.EKSConfig.AddOnFluentd.Created {
+		ts.cfg.Logger.Info("skipping tester.Create", zap.String("tester", pkgName))
+		return nil
+	}
+
+	ts.cfg.Logger.Info("starting tester.Create", zap.String("tester", pkgName))
+	ts.cfg.EKSConfig.AddOnFluentd.Created = true
+	ts.cfg.EKSConfig.Sync()
+	createStart := time.Now()
+	defer func() {
+		createEnd := time.Now()
+		ts.cfg.EKSConfig.AddOnFluentd.TimeFrameCreate = timeutil.NewTimeFrame(createStart, createEnd)
+		ts.cfg.EKSConfig.Sync()
+	}()
+
+	if ts.cfg.EKSConfig.AddOnFluentd.RepositoryBusyboxAccountID != "" &&
+		ts.cfg.EKSConfig.AddOnFluentd.RepositoryBusyboxRegion != "" &&
+		ts.cfg.EKSConfig.AddOnFluentd.RepositoryBusyboxName != "" &&
+		ts.cfg.EKSConfig.AddOnFluentd.RepositoryBusyboxImageTag != "" {
+		if ts.busyboxImg, err = aws_ecr.Check(
+			ts.cfg.Logger,
+			ts.cfg.ECRAPI,
+			ts.cfg.EKSConfig.AddOnFluentd.RepositoryBusyboxAccountID,
+			ts.cfg.EKSConfig.AddOnFluentd.RepositoryBusyboxRegion,
+			ts.cfg.EKSConfig.AddOnFluentd.RepositoryBusyboxName,
+			ts.cfg.EKSConfig.AddOnFluentd.RepositoryBusyboxImageTag,
+		); err != nil {
+			return err
+		}
+	}
+
+	if err = k8s_client.CreateNamespace(
+		ts.cfg.Logger,
+		ts.cfg.K8SClient.KubernetesClientSet(),
+		ts.cfg.EKSConfig.AddOnFluentd.Namespace,
+	); err != nil {
+		return err
+	}
+
+	// create Fluentd components
+	if err = ts.createFluentdServiceAccount(); err != nil {
+		return err
+	}
+	if err = ts.createFluentdRBACClusterRole(); err != nil {
+		return err
+	}
+	if err = ts.createFluentdRBACClusterRoleBinding(); err != nil {
+		return err
+	}
+	if err = ts.createFluentdConfigMapClusterInfo(); err != nil {
+		return err
+	}
+	if err = ts.createFluentdConfigMapConfig(); err != nil {
+		return err
+	}
+	if err = ts.createFluentdDaemonSet(); err != nil {
+		return err
+	}
+	if err = ts.checkFluentdPods(); err != nil {
+		return err
+	}
+
+	return ts.cfg.EKSConfig.Sync()
+}
+
+func (ts *tester) Delete() error {
+	if !ts.cfg.EKSConfig.IsEnabledAddOnFluentd() {
+		ts.cfg.Logger.Info("skipping tester.Delete", zap.String("tester", pkgName))
+		return nil
+	}
+	if !ts.cfg.EKSConfig.AddOnFluentd.Created {
+		ts.cfg.Logger.Info("skipping tester.Delete", zap.String("tester", pkgName))
+		return nil
+	}
+
+	ts.cfg.Logger.Info("starting tester.Delete", zap.String("tester", pkgName))
+	deleteStart := time.Now()
+	defer func() {
+		deleteEnd := time.Now()
+		ts.cfg.EKSConfig.AddOnFluentd.TimeFrameDelete = timeutil.NewTimeFrame(deleteStart, deleteEnd)
+		ts.cfg.EKSConfig.Sync()
+	}()
+
+	var errs []string
+
+	if err := ts.deleteFluentdDaemonSet(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	time.Sleep(time.Minute)
+
+	if err := ts.deleteFluentdConfigMapConfig(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := ts.deleteFluentdConfigMapClusterInfo(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := ts.deleteFluentdRBACClusterRoleBinding(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := ts.deleteFluentdRBACClusterRole(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := ts.deleteFluentdServiceAccount(); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	if err := k8s_client.DeleteNamespaceAndWait(
+		ts.cfg.Logger,
+		ts.cfg.K8SClient.KubernetesClientSet(),
+		ts.cfg.EKSConfig.AddOnFluentd.Namespace,
+		k8s_client.DefaultNamespaceDeletionInterval,
+		k8s_client.DefaultNamespaceDeletionTimeout,
+		k8s_client.WithForceDelete(true),
+	); err != nil {
+		errs = append(errs, fmt.Sprintf("failed to delete fluentd namespace (%v)", err))
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ", "))
+	}
+
+	ts.cfg.EKSConfig.AddOnFluentd.Created = false
+	return ts.cfg.EKSConfig.Sync()
+}

--- a/eks/php-apache/php-apache.go
+++ b/eks/php-apache/php-apache.go
@@ -1,0 +1,301 @@
+// Package phpapache implements PHP Apache
+// with a simple PHP app.
+package phpapache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"time"
+
+	eks_tester "github.com/aws/aws-k8s-tester/eks/tester"
+	"github.com/aws/aws-k8s-tester/eksconfig"
+	k8s_client "github.com/aws/aws-k8s-tester/pkg/k8s-client"
+	"github.com/aws/aws-k8s-tester/pkg/timeutil"
+	"github.com/aws/aws-sdk-go/aws"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/exec"
+)
+
+// Config defines configuration.
+type Config struct {
+	Logger    *zap.Logger
+	LogWriter io.Writer
+	Stopc     chan struct{}
+	EKSConfig *eksconfig.Config
+	K8SClient k8s_client.EKS
+}
+
+var pkgName = reflect.TypeOf(tester{}).PkgPath()
+
+func (ts *tester) Name() string { return pkgName }
+
+// New creates a new Job tester.
+func New(cfg Config) eks_tester.Tester {
+	cfg.Logger.Info("creating tester", zap.String("tester", pkgName))
+	return &tester{cfg: cfg}
+}
+
+type tester struct {
+	cfg Config
+}
+
+const (
+	phpApacheDeploymentName = "php-apache-deployment"
+	phpApacheAppName        = "php-apache"
+	phpApacheAppImageName   = "pjlewis/php-apache"
+)
+
+func (ts *tester) Create() error {
+	if !ts.cfg.EKSConfig.IsEnabledAddOnPHPApache() {
+		ts.cfg.Logger.Info("skipping tester.Create", zap.String("tester", pkgName))
+		return nil
+	}
+	if ts.cfg.EKSConfig.AddOnPHPApache.Created {
+		ts.cfg.Logger.Info("skipping tester.Create", zap.String("tester", pkgName))
+		return nil
+	}
+
+	ts.cfg.Logger.Info("starting tester.Create", zap.String("tester", pkgName))
+	ts.cfg.EKSConfig.AddOnPHPApache.Created = true
+	ts.cfg.EKSConfig.Sync()
+	createStart := time.Now()
+	defer func() {
+		createEnd := time.Now()
+		ts.cfg.EKSConfig.AddOnPHPApache.TimeFrameCreate = timeutil.NewTimeFrame(createStart, createEnd)
+		ts.cfg.EKSConfig.Sync()
+	}()
+
+	if err := k8s_client.CreateNamespace(
+		ts.cfg.Logger,
+		ts.cfg.K8SClient.KubernetesClientSet(),
+		ts.cfg.EKSConfig.AddOnPHPApache.Namespace,
+	); err != nil {
+		return err
+	}
+	if err := ts.createDeployment(); err != nil {
+		return err
+	}
+	if err := ts.waitDeployment(); err != nil {
+		return err
+	}
+	return ts.cfg.EKSConfig.Sync()
+}
+
+func (ts *tester) Delete() error {
+	if !ts.cfg.EKSConfig.IsEnabledAddOnPHPApache() {
+		ts.cfg.Logger.Info("skipping tester.Delete", zap.String("tester", pkgName))
+		return nil
+	}
+	if !ts.cfg.EKSConfig.AddOnPHPApache.Created {
+		ts.cfg.Logger.Info("skipping tester.Delete", zap.String("tester", pkgName))
+		return nil
+	}
+
+	ts.cfg.Logger.Info("starting tester.Delete", zap.String("tester", pkgName))
+	deleteStart := time.Now()
+	defer func() {
+		deleteEnd := time.Now()
+		ts.cfg.EKSConfig.AddOnPHPApache.TimeFrameDelete = timeutil.NewTimeFrame(deleteStart, deleteEnd)
+		ts.cfg.EKSConfig.Sync()
+	}()
+
+	var errs []string
+
+	if err := ts.deleteDeployment(); err != nil {
+		errs = append(errs, fmt.Sprintf("failed to delete php-apache Deployment (%v)", err))
+	}
+	ts.cfg.Logger.Info("wait for a minute after deleting Deployment")
+	time.Sleep(time.Minute)
+
+	if err := k8s_client.DeleteNamespaceAndWait(
+		ts.cfg.Logger,
+		ts.cfg.K8SClient.KubernetesClientSet(),
+		ts.cfg.EKSConfig.AddOnPHPApache.Namespace,
+		k8s_client.DefaultNamespaceDeletionInterval,
+		k8s_client.DefaultNamespaceDeletionTimeout,
+		k8s_client.WithForceDelete(true),
+	); err != nil {
+		errs = append(errs, fmt.Sprintf("failed to delete namespace (%v)", err))
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ", "))
+	}
+
+	ts.cfg.EKSConfig.AddOnPHPApache.Created = false
+	return ts.cfg.EKSConfig.Sync()
+}
+
+func (ts *tester) createDeployment() error {
+	var nodeSelector map[string]string
+	if len(ts.cfg.EKSConfig.AddOnPHPApache.DeploymentNodeSelector) > 0 {
+		nodeSelector = ts.cfg.EKSConfig.AddOnPHPApache.DeploymentNodeSelector
+	} else {
+		nodeSelector = nil
+	}
+	ts.cfg.Logger.Info("creating php-apache Deployment", zap.Any("node-selector", nodeSelector))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err := ts.cfg.K8SClient.KubernetesClientSet().
+		AppsV1().
+		Deployments(ts.cfg.EKSConfig.AddOnPHPApache.Namespace).
+		Create(
+			ctx,
+			&appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      phpApacheDeploymentName,
+					Namespace: ts.cfg.EKSConfig.AddOnPHPApache.Namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": phpApacheAppName,
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: aws.Int32(ts.cfg.EKSConfig.AddOnPHPApache.DeploymentReplicas),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app.kubernetes.io/name": phpApacheAppName,
+						},
+					},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/name": phpApacheAppName,
+							},
+						},
+						Spec: v1.PodSpec{
+							RestartPolicy: v1.RestartPolicyAlways,
+							Containers: []v1.Container{
+								{
+									Name:            phpApacheAppName,
+									Image:           phpApacheAppImageName,
+									ImagePullPolicy: v1.PullAlways,
+								},
+							},
+							NodeSelector: nodeSelector,
+						},
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create php-apache Deployment (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created php-apache Deployment")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+func (ts *tester) deleteDeployment() error {
+	ts.cfg.Logger.Info("deleting php-apache Deployment")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err := ts.cfg.K8SClient.KubernetesClientSet().
+		AppsV1().
+		Deployments(ts.cfg.EKSConfig.AddOnPHPApache.Namespace).
+		Delete(
+			ctx,
+			phpApacheDeploymentName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete", zap.Error(err))
+		return fmt.Errorf("failed to delete php-apache Deployment (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("deleted php-apache Deployment")
+	return ts.cfg.EKSConfig.Sync()
+}
+
+func (ts *tester) waitDeployment() error {
+	ts.cfg.Logger.Info("waiting for php-apache Deployment")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	output, err := exec.New().CommandContext(
+		ctx,
+		ts.cfg.EKSConfig.KubectlPath,
+		"--kubeconfig="+ts.cfg.EKSConfig.KubeConfigPath,
+		"--namespace="+ts.cfg.EKSConfig.AddOnPHPApache.Namespace,
+		"describe",
+		"deployment",
+		phpApacheDeploymentName,
+	).CombinedOutput()
+	cancel()
+	if err != nil {
+		return fmt.Errorf("'kubectl describe deployment' failed %v", err)
+	}
+	out := string(output)
+	fmt.Fprintf(ts.cfg.LogWriter, "\n\n\"kubectl describe deployment\" output:\n%s\n\n", out)
+
+	ready := false
+	waitDur := 7*time.Minute + time.Duration(ts.cfg.EKSConfig.AddOnPHPApache.DeploymentReplicas)*time.Minute
+	retryStart := time.Now()
+	for time.Now().Sub(retryStart) < waitDur {
+		select {
+		case <-ts.cfg.Stopc:
+			return errors.New("check aborted")
+		case <-time.After(15 * time.Second):
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		dresp, err := ts.cfg.K8SClient.KubernetesClientSet().
+			AppsV1().
+			Deployments(ts.cfg.EKSConfig.AddOnPHPApache.Namespace).
+			Get(ctx, phpApacheDeploymentName, metav1.GetOptions{})
+		cancel()
+		if err != nil {
+			return fmt.Errorf("failed to get Deployment (%v)", err)
+		}
+		ts.cfg.Logger.Info("get deployment",
+			zap.Int32("desired-replicas", dresp.Status.Replicas),
+			zap.Int32("available-replicas", dresp.Status.AvailableReplicas),
+			zap.Int32("unavailable-replicas", dresp.Status.UnavailableReplicas),
+			zap.Int32("ready-replicas", dresp.Status.ReadyReplicas),
+		)
+
+		// TODO: remove the pod with "Error: ImagePullBackOff"
+		available := false
+		for _, cond := range dresp.Status.Conditions {
+			ts.cfg.Logger.Info("condition",
+				zap.String("last-updated", cond.LastUpdateTime.String()),
+				zap.String("type", string(cond.Type)),
+				zap.String("status", string(cond.Status)),
+				zap.String("reason", cond.Reason),
+				zap.String("message", cond.Message),
+			)
+			if cond.Status != v1.ConditionTrue {
+				continue
+			}
+			if cond.Type == appsv1.DeploymentAvailable {
+				available = true
+				break
+			}
+		}
+		// TODO: remove this hack and handle "Error: ImagePullBackOff"
+		if available && dresp.Status.AvailableReplicas+1 >= ts.cfg.EKSConfig.AddOnPHPApache.DeploymentReplicas {
+			ready = true
+			break
+		}
+	}
+	if !ready {
+		return errors.New("deployment not ready")
+	}
+
+	ts.cfg.Logger.Info("waited for php-apache Deployment")
+	return ts.cfg.EKSConfig.Sync()
+}

--- a/eksconfig/README.md
+++ b/eksconfig/README.md
@@ -1,6 +1,6 @@
 
 ```
-# total 36 add-ons
+# total 37 add-ons
 # set the following *_ENABLE env vars to enable add-ons, rest are set with default values
 AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ENABLE=true \
@@ -12,6 +12,7 @@ AWS_K8S_TESTER_EKS_ADD_ON_APP_MESH_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_CSI_EBS_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_KUBERNETES_DASHBOARD_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_PROMETHEUS_GRAFANA_ENABLE=true \
+AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_NLB_GUESTBOOK_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_ALB_2048_ENABLE=true \
@@ -305,6 +306,19 @@ AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_VERSION_UPGRADE_ENABLE=true \
 | AWS_K8S_TESTER_EKS_ADD_ON_PROMETHEUS_GRAFANA_GRAFANA_NLB_NAME        | read-only "true"  | *eksconfig.AddOnPrometheusGrafana.GrafanaNLBName       | string             |
 | AWS_K8S_TESTER_EKS_ADD_ON_PROMETHEUS_GRAFANA_GRAFANA_URL             | read-only "true"  | *eksconfig.AddOnPrometheusGrafana.GrafanaURL           | string             |
 *----------------------------------------------------------------------*-------------------*--------------------------------------------------------*--------------------*
+
+
+*---------------------------------------------------------------*-------------------*--------------------------------------------------*--------------------*
+|                    ENVIRONMENTAL VARIABLE                     |     READ ONLY     |                       TYPE                       |      GO TYPE       |
+*---------------------------------------------------------------*-------------------*--------------------------------------------------*--------------------*
+| AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_ENABLE                   | read-only "false" | *eksconfig.AddOnPHPApache.Enable                 | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_CREATED                  | read-only "true"  | *eksconfig.AddOnPHPApache.Created                | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_TIME_FRAME_CREATE        | read-only "true"  | *eksconfig.AddOnPHPApache.TimeFrameCreate        | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_TIME_FRAME_DELETE        | read-only "true"  | *eksconfig.AddOnPHPApache.TimeFrameDelete        | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_NAMESPACE                | read-only "false" | *eksconfig.AddOnPHPApache.Namespace              | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_DEPLOYMENT_REPLICAS      | read-only "false" | *eksconfig.AddOnPHPApache.DeploymentReplicas     | int32              |
+| AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_DEPLOYMENT_NODE_SELECTOR | read-only "false" | *eksconfig.AddOnPHPApache.DeploymentNodeSelector | map[string]string  |
+*---------------------------------------------------------------*-------------------*--------------------------------------------------*--------------------*
 
 
 *--------------------------------------------------------------------*-------------------*------------------------------------------------------*--------------------*

--- a/eksconfig/README.md
+++ b/eksconfig/README.md
@@ -1,9 +1,11 @@
 
 ```
-# total 34 add-ons
+# total 36 add-ons
 # set the following *_ENABLE env vars to enable add-ons, rest are set with default values
 AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ENABLE=true \
+AWS_K8S_TESTER_EKS_ADD_ON_CW_AGENT_ENABLE=true \
+AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_METRICS_SERVER_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_ENABLE=true \
 AWS_K8S_TESTER_EKS_ADD_ON_APP_MESH_ENABLE=true \
@@ -176,6 +178,40 @@ AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_VERSION_UPGRADE_ENABLE=true \
 | AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_LOGS_TAR_GZ_PATH           | read-only "false" | *eksconfig.AddOnManagedNodeGroups.LogsTarGzPath         | string                   |
 | AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_MNGS                       | read-only "false" | *eksconfig.AddOnManagedNodeGroups.MNGs                  | map[string]eksconfig.MNG |
 *--------------------------------------------------------------------------*-------------------*---------------------------------------------------------*--------------------------*
+
+
+*------------------------------------------------------*-------------------*-----------------------------------------*--------------------*
+|                ENVIRONMENTAL VARIABLE                |     READ ONLY     |                  TYPE                   |      GO TYPE       |
+*------------------------------------------------------*-------------------*-----------------------------------------*--------------------*
+| AWS_K8S_TESTER_EKS_ADD_ON_CW_AGENT_ENABLE            | read-only "false" | *eksconfig.AddOnCWAgent.Enable          | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CW_AGENT_CREATED           | read-only "true"  | *eksconfig.AddOnCWAgent.Created         | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CW_AGENT_TIME_FRAME_CREATE | read-only "true"  | *eksconfig.AddOnCWAgent.TimeFrameCreate | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_CW_AGENT_TIME_FRAME_DELETE | read-only "true"  | *eksconfig.AddOnCWAgent.TimeFrameDelete | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_CW_AGENT_NAMESPACE         | read-only "false" | *eksconfig.AddOnCWAgent.Namespace       | string             |
+*------------------------------------------------------*-------------------*-----------------------------------------*--------------------*
+
+
+*--------------------------------------------------------------------*-------------------*-------------------------------------------------------*--------------------*
+|                       ENVIRONMENTAL VARIABLE                       |     READ ONLY     |                         TYPE                          |      GO TYPE       |
+*--------------------------------------------------------------------*-------------------*-------------------------------------------------------*--------------------*
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_ENABLE                           | read-only "false" | *eksconfig.AddOnFluentd.Enable                        | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_CREATED                          | read-only "true"  | *eksconfig.AddOnFluentd.Created                       | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_TIME_FRAME_CREATE                | read-only "true"  | *eksconfig.AddOnFluentd.TimeFrameCreate               | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_TIME_FRAME_DELETE                | read-only "true"  | *eksconfig.AddOnFluentd.TimeFrameDelete               | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_NAMESPACE                        | read-only "false" | *eksconfig.AddOnFluentd.Namespace                     | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_ACCOUNT_ID    | read-only "false" | *eksconfig.AddOnFluentd.RepositoryBusyboxAccountID    | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_REGION        | read-only "false" | *eksconfig.AddOnFluentd.RepositoryBusyboxRegion       | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_NAME          | read-only "false" | *eksconfig.AddOnFluentd.RepositoryBusyboxName         | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_IMAGE_TAG     | read-only "false" | *eksconfig.AddOnFluentd.RepositoryBusyboxImageTag     | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_THREADS                          | read-only "false" | *eksconfig.AddOnFluentd.Threads                       | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_METADATA_LOG_LEVEL               | read-only "false" | *eksconfig.AddOnFluentd.MetadataLogLevel              | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_METADATA_CACHE_SIZE              | read-only "false" | *eksconfig.AddOnFluentd.MetadataCacheSize             | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_METADATA_WATCH                   | read-only "false" | *eksconfig.AddOnFluentd.MetadataWatch                 | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_METADATA_SKIP_LABELS             | read-only "false" | *eksconfig.AddOnFluentd.MetadataSkipLabels            | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_METADATA_SKIP_MASTER_URL         | read-only "false" | *eksconfig.AddOnFluentd.MetadataSkipMasterURL         | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_METADATA_SKIP_CONTAINER_METADATA | read-only "false" | *eksconfig.AddOnFluentd.MetadataSkipContainerMetadata | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_METADATA_SKIP_NAMESPACE_METADATA | read-only "false" | *eksconfig.AddOnFluentd.MetadataSkipNamespaceMetadata | bool               |
+*--------------------------------------------------------------------*-------------------*-------------------------------------------------------*--------------------*
 
 
 *------------------------------------------------------------*-------------------*-----------------------------------------------*--------------------*

--- a/eksconfig/add-on-cw-agent.go
+++ b/eksconfig/add-on-cw-agent.go
@@ -1,0 +1,59 @@
+package eksconfig
+
+import (
+	"errors"
+
+	"github.com/aws/aws-k8s-tester/pkg/timeutil"
+)
+
+// AddOnCWAgent defines parameters for EKS cluster
+// add-on CloudWatch agent.
+// Publishes worker nodes logs to:
+//  - /aws/containerinsights/[CLUSTER-NAME]/performance
+type AddOnCWAgent struct {
+	// Enable is 'true' to create this add-on.
+	Enable bool `json:"enable"`
+	// Created is true when the resource has been created.
+	// Used for delete operations.
+	Created         bool               `json:"created" read-only:"true"`
+	TimeFrameCreate timeutil.TimeFrame `json:"time-frame-create" read-only:"true"`
+	TimeFrameDelete timeutil.TimeFrame `json:"time-frame-delete" read-only:"true"`
+
+	// Namespace is the namespace to create objects in.
+	Namespace string `json:"namespace"`
+}
+
+// EnvironmentVariablePrefixAddOnCWAgent is the environment variable prefix used for "eksconfig".
+const EnvironmentVariablePrefixAddOnCWAgent = AWS_K8S_TESTER_EKS_PREFIX + "ADD_ON_CW_AGENT_"
+
+// IsEnabledAddOnCWAgent returns true if "AddOnCWAgent" is enabled.
+// Otherwise, nil the field for "omitempty".
+func (cfg *Config) IsEnabledAddOnCWAgent() bool {
+	if cfg.AddOnCWAgent == nil {
+		return false
+	}
+	if cfg.AddOnCWAgent.Enable {
+		return true
+	}
+	cfg.AddOnCWAgent = nil
+	return false
+}
+
+func getDefaultAddOnCWAgent() *AddOnCWAgent {
+	return &AddOnCWAgent{
+		Enable: false,
+	}
+}
+
+func (cfg *Config) validateAddOnCWAgent() error {
+	if !cfg.IsEnabledAddOnCWAgent() {
+		return nil
+	}
+	if !cfg.IsEnabledAddOnNodeGroups() && !cfg.IsEnabledAddOnManagedNodeGroups() {
+		return errors.New("AddOnCWAgent.Enable true but no node group is enabled")
+	}
+	if cfg.AddOnCWAgent.Namespace == "" {
+		cfg.AddOnCWAgent.Namespace = cfg.Name + "-cw-agent"
+	}
+	return nil
+}

--- a/eksconfig/add-on-fluentd.go
+++ b/eksconfig/add-on-fluentd.go
@@ -1,0 +1,125 @@
+package eksconfig
+
+import (
+	"errors"
+
+	"github.com/aws/aws-k8s-tester/pkg/timeutil"
+)
+
+// AddOnFluentd defines parameters for EKS cluster
+// add-on Fluentd.
+// Publishes worker nodes logs to:
+//  - /aws/containerinsights/[CLUSTER-NAME]/application
+//  - /aws/containerinsights/[CLUSTER-NAME]/dataplane
+//  - /aws/containerinsights/[CLUSTER-NAME]/host
+type AddOnFluentd struct {
+	// Enable is 'true' to create this add-on.
+	Enable bool `json:"enable"`
+	// Created is true when the resource has been created.
+	// Used for delete operations.
+	Created         bool               `json:"created" read-only:"true"`
+	TimeFrameCreate timeutil.TimeFrame `json:"time-frame-create" read-only:"true"`
+	TimeFrameDelete timeutil.TimeFrame `json:"time-frame-delete" read-only:"true"`
+
+	// Namespace is the namespace to create objects in.
+	Namespace string `json:"namespace"`
+
+	// RepositoryBusyboxAccountID is the account ID for tester ECR image.
+	// e.g. "busybox" for "[ACCOUNT_ID].dkr.ecr.[REGION].amazonaws.com/busybox"
+	RepositoryBusyboxAccountID string `json:"repository-busybox-account-id,omitempty"`
+	// RepositoryBusyboxRegion is the ECR repository region to pull from.
+	RepositoryBusyboxRegion string `json:"repository-busybox-region,omitempty"`
+	// RepositoryBusyboxName is the repositoryName for tester ECR image.
+	// e.g. "busybox" for "[ACCOUNT_ID].dkr.ecr.[REGION].amazonaws.com/busybox"
+	RepositoryBusyboxName string `json:"repository-busybox-name,omitempty"`
+	// RepositoryBusyboxImageTag is the image tag for tester ECR image.
+	// e.g. "latest" for image URI "[ACCOUNT_ID].dkr.ecr.[REGION].amazonaws.com/busybox:latest"
+	RepositoryBusyboxImageTag string `json:"repository-busybox-image-tag,omitempty"`
+
+	// Threads is the number of threads for fluentd.
+	// ref. https://docs.fluentd.org/v/0.12/output#num_threads
+	Threads int `json:"threads"`
+	// MetadataLogLevel is the log level for "@type kubernetes_metadata".
+	// ref. https://docs.fluentd.org/deployment/system-config
+	// ref. https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter
+	MetadataLogLevel string `json:"metadata-log-level"`
+	// MetadataCacheSize is the size of the cache of Kubernetes metadata
+	// to reduce the requests to the kube-apiserver.
+	// ref. "@type kubernetes_metadata"
+	// ref. https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter
+	MetadataCacheSize int `json:"metadata-cache-size"`
+	// MetadataWatch is true to enable watch on pods on the kube-apiserver
+	// for updates to the metadata.
+	// ref. "@type kubernetes_metadata"
+	// ref. https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter
+	MetadataWatch bool `json:"metadata-watch"`
+	// MetadataSkipLabels is true to skip all label fields from the metadata.
+	// ref. "@type kubernetes_metadata"
+	// ref. https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter
+	MetadataSkipLabels bool `json:"metadata-skip-labels"`
+	// MetadataSkipMasterURL is true to skip "master_url" field from the metadata.
+	// ref. "@type kubernetes_metadata"
+	// ref. https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter
+	MetadataSkipMasterURL bool `json:"metadata-skip-master-url"`
+	// MetadataSkipContainerMetadata is true to skip some container data of the metadata.
+	// For example, if true, it skips container image and image ID fields.
+	// ref. "@type kubernetes_metadata"
+	// ref. https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter
+	MetadataSkipContainerMetadata bool `json:"metadata-skip-container-metadata"`
+	// MetadataSkipNamespaceMetadata is true to skip "namespace_id" field from the metadata.
+	// If true, the plugin will be faster with less CPU consumption.
+	// ref. "@type kubernetes_metadata"
+	// ref. https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter
+	MetadataSkipNamespaceMetadata bool `json:"metadata-skip-namespace-metadata"`
+}
+
+// EnvironmentVariablePrefixAddOnFluentd is the environment variable prefix used for "eksconfig".
+const EnvironmentVariablePrefixAddOnFluentd = AWS_K8S_TESTER_EKS_PREFIX + "ADD_ON_FLUENTD_"
+
+// IsEnabledAddOnFluentd returns true if "AddOnFluentd" is enabled.
+// Otherwise, nil the field for "omitempty".
+func (cfg *Config) IsEnabledAddOnFluentd() bool {
+	if cfg.AddOnFluentd == nil {
+		return false
+	}
+	if cfg.AddOnFluentd.Enable {
+		return true
+	}
+	cfg.AddOnFluentd = nil
+	return false
+}
+
+func getDefaultAddOnFluentd() *AddOnFluentd {
+	return &AddOnFluentd{
+		Enable: false,
+
+		Threads:                       8,
+		MetadataLogLevel:              "warn",
+		MetadataCacheSize:             20000,
+		MetadataWatch:                 false,
+		MetadataSkipLabels:            true,
+		MetadataSkipMasterURL:         true,
+		MetadataSkipContainerMetadata: true,
+		MetadataSkipNamespaceMetadata: true,
+	}
+}
+
+func (cfg *Config) GetAddOnFluentdRepositoryBusyboxRegion() string {
+	if !cfg.IsEnabledAddOnFluentd() {
+		return cfg.Region
+	}
+	return cfg.AddOnFluentd.RepositoryBusyboxRegion
+}
+
+func (cfg *Config) validateAddOnFluentd() error {
+	if !cfg.IsEnabledAddOnFluentd() {
+		return nil
+	}
+	if !cfg.IsEnabledAddOnNodeGroups() && !cfg.IsEnabledAddOnManagedNodeGroups() {
+		return errors.New("AddOnFluentd.Enable true but no node group is enabled")
+	}
+	if cfg.AddOnFluentd.Namespace == "" {
+		cfg.AddOnFluentd.Namespace = cfg.Name + "-fluentd"
+	}
+	return nil
+}

--- a/eksconfig/add-on-php-apache.go
+++ b/eksconfig/add-on-php-apache.go
@@ -1,0 +1,65 @@
+package eksconfig
+
+import (
+	"errors"
+
+	"github.com/aws/aws-k8s-tester/pkg/timeutil"
+)
+
+// AddOnPHPApache defines parameters for EKS cluster
+// add-on PHP Apache.
+type AddOnPHPApache struct {
+	// Enable is 'true' to create this add-on.
+	Enable bool `json:"enable"`
+	// Created is true when the resource has been created.
+	// Used for delete operations.
+	Created         bool               `json:"created" read-only:"true"`
+	TimeFrameCreate timeutil.TimeFrame `json:"time-frame-create" read-only:"true"`
+	TimeFrameDelete timeutil.TimeFrame `json:"time-frame-delete" read-only:"true"`
+
+	// Namespace is the namespace to create objects in.
+	Namespace string `json:"namespace"`
+
+	// DeploymentReplicas is the number of replicas to deploy using "Deployment" object.
+	DeploymentReplicas int32 `json:"deployment-replicas"`
+	// DeploymentNodeSelector is configured to overwrite existing node selector
+	// for PHP Apache deployment. If left empty, tester sets default selector.
+	DeploymentNodeSelector map[string]string `json:"deployment-node-selector"`
+}
+
+// EnvironmentVariablePrefixAddOnPHPApache is the environment variable prefix used for "eksconfig".
+const EnvironmentVariablePrefixAddOnPHPApache = AWS_K8S_TESTER_EKS_PREFIX + "ADD_ON_PHP_APACHE_"
+
+// IsEnabledAddOnPHPApache returns true if "AddOnPHPApache" is enabled.
+// Otherwise, nil the field for "omitempty".
+func (cfg *Config) IsEnabledAddOnPHPApache() bool {
+	if cfg.AddOnPHPApache == nil {
+		return false
+	}
+	if cfg.AddOnPHPApache.Enable {
+		return true
+	}
+	cfg.AddOnPHPApache = nil
+	return false
+}
+
+func getDefaultAddOnPHPApache() *AddOnPHPApache {
+	return &AddOnPHPApache{
+		Enable:                 false,
+		DeploymentReplicas:     3,
+		DeploymentNodeSelector: make(map[string]string),
+	}
+}
+
+func (cfg *Config) validateAddOnPHPApache() error {
+	if !cfg.IsEnabledAddOnPHPApache() {
+		return nil
+	}
+	if !cfg.IsEnabledAddOnNodeGroups() && !cfg.IsEnabledAddOnManagedNodeGroups() {
+		return errors.New("AddOnPHPApache.Enable true but no node group is enabled")
+	}
+	if cfg.AddOnPHPApache.Namespace == "" {
+		cfg.AddOnPHPApache.Namespace = cfg.Name + "-php-apache"
+	}
+	return nil
+}

--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -220,6 +220,9 @@ type Config struct {
 	// add-on Prometheus/Grafana.
 	AddOnPrometheusGrafana *AddOnPrometheusGrafana `json:"add-on-prometheus-grafana,omitempty"`
 
+	// AddOnPHPApache defines parameters for EKS cluster
+	// add-on PHP Apache.
+	AddOnPHPApache *AddOnPHPApache `json:"add-on-php-apache,omitempty"`
 	// AddOnNLBHelloWorld defines parameters for EKS cluster
 	// add-on NLB hello-world service.
 	AddOnNLBHelloWorld *AddOnNLBHelloWorld `json:"add-on-nlb-hello-world,omitempty"`
@@ -791,6 +794,7 @@ func NewDefault() *Config {
 		AddOnCSIEBS:                getDefaultAddOnCSIEBS(),
 		AddOnKubernetesDashboard:   getDefaultAddOnKubernetesDashboard(),
 		AddOnPrometheusGrafana:     getDefaultAddOnPrometheusGrafana(),
+		AddOnPHPApache:             getDefaultAddOnPHPApache(),
 		AddOnNLBHelloWorld:         getDefaultAddOnNLBHelloWorld(),
 		AddOnNLBGuestbook:          getDefaultAddOnNLBGuestbook(),
 		AddOnALB2048:               getDefaultAddOnALB2048(),
@@ -915,6 +919,9 @@ func (cfg *Config) ValidateAndSetDefaults() error {
 	}
 	if err := cfg.validateAddOnPrometheusGrafana(); err != nil {
 		return fmt.Errorf("validateAddOnPrometheusGrafana failed [%v]", err)
+	}
+	if err := cfg.validateAddOnPHPApache(); err != nil {
+		return fmt.Errorf("validateAddOnPHPApache failed [%v]", err)
 	}
 	if err := cfg.validateAddOnNLBHelloWorld(); err != nil {
 		return fmt.Errorf("validateAddOnNLBHelloWorld failed [%v]", err)

--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -193,6 +193,12 @@ type Config struct {
 	TotalNodes       int64 `json:"total-nodes" read-only:"true"`
 	TotalHollowNodes int64 `json:"total-hollow-nodes" read-only:"true"`
 
+	// AddOnCWAgent defines parameters for EKS cluster
+	// add-on Fluentd.
+	AddOnCWAgent *AddOnCWAgent `json:"add-on-cw-agent,omitempty"`
+	// AddOnFluentd defines parameters for EKS cluster
+	// add-on Fluentd.
+	AddOnFluentd *AddOnFluentd `json:"add-on-fluentd,omitempty"`
 	// AddOnMetricsServer defines parameters for EKS cluster
 	// add-on metrics server.
 	AddOnMetricsServer *AddOnMetricsServer `json:"add-on-metrics-server,omitempty"`
@@ -775,6 +781,8 @@ func NewDefault() *Config {
 		AddOnNodeGroups:        getDefaultAddOnNodeGroups(name),
 		AddOnManagedNodeGroups: getDefaultAddOnManagedNodeGroups(name),
 
+		AddOnCWAgent:       getDefaultAddOnCWAgent(),
+		AddOnFluentd:       getDefaultAddOnFluentd(),
 		AddOnMetricsServer: getDefaultAddOnMetricsServer(),
 
 		AddOnConformance: getDefaultAddOnConformance(),
@@ -881,6 +889,12 @@ func (cfg *Config) ValidateAndSetDefaults() error {
 	}
 	cfg.TotalHollowNodes = totalHollowNodes
 
+	if err := cfg.validateAddOnCWAgent(); err != nil {
+		return fmt.Errorf("validateAddOnCWAgent failed [%v]", err)
+	}
+	if err := cfg.validateAddOnFluentd(); err != nil {
+		return fmt.Errorf("validateAddOnFluentd failed [%v]", err)
+	}
 	if err := cfg.validateAddOnMetricsServer(); err != nil {
 		return fmt.Errorf("validateAddOnMetricsServer failed [%v]", err)
 	}

--- a/eksconfig/default.yaml
+++ b/eksconfig/default.yaml
@@ -24,7 +24,7 @@ log-level: info
 log-outputs:
 - stderr
 - /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.log
-name: eks-2020070610-galaxylhcmn1
+name: eks-2020070622-sunsetvo3kc7
 on-failure-delete: true
 on-failure-delete-wait-seconds: 120
 parameters:
@@ -40,10 +40,10 @@ parameters:
   role-arn: ""
   role-cfn-stack-id: ""
   role-cfn-stack-yaml-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.role.cfn.yaml
-  role-cfn-stack-yaml-s3-key: eks-2020070610-galaxylhcmn1/default.role.cfn.yaml
+  role-cfn-stack-yaml-s3-key: eks-2020070622-sunsetvo3kc7/default.role.cfn.yaml
   role-create: true
   role-managed-policy-arns: null
-  role-name: eks-2020070610-galaxylhcmn1-role
+  role-name: eks-2020070622-sunsetvo3kc7-role
   role-service-principals: null
   signing-name: eks
   tags: null
@@ -51,19 +51,19 @@ parameters:
   version-value: 1.16
   vpc-cfn-stack-id: ""
   vpc-cfn-stack-yaml-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.vpc.cfn.yaml
-  vpc-cfn-stack-yaml-s3-key: eks-2020070610-galaxylhcmn1/default.vpc.cfn.yaml
+  vpc-cfn-stack-yaml-s3-key: eks-2020070622-sunsetvo3kc7/default.vpc.cfn.yaml
   vpc-create: true
   vpc-id: ""
 partition: aws
 region: us-west-2
 remote-access-commands-output-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.ssh.sh
 remote-access-key-create: true
-remote-access-key-name: eks-2020070610-galaxylhcmn1-remote-access-key
-remote-access-private-key-path: /tmp/delight99zappln.insecure.key
+remote-access-key-name: eks-2020070622-sunsetvo3kc7-remote-access-key
+remote-access-private-key-path: /tmp/spheres7eggv9hv.insecure.key
 s3-bucket-create: true
 s3-bucket-create-keep: true
 s3-bucket-lifecycle-expiration-days: 0
-s3-bucket-name: eks-2020070610-galaxylhcmn1-s3-bucket
+s3-bucket-name: eks-2020070622-sunsetvo3kc7-s3-bucket
 status:
   aws-account-id: ""
   aws-credential-path: ""
@@ -75,7 +75,7 @@ status:
   cluster-ca-decoded: ""
   cluster-cfn-stack-id: ""
   cluster-cfn-stack-yaml-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.cluster.cfn.yaml
-  cluster-cfn-stack-yaml-s3-key: eks-2020070610-galaxylhcmn1/default.cluster.cfn.yaml
+  cluster-cfn-stack-yaml-s3-key: eks-2020070622-sunsetvo3kc7/default.cluster.cfn.yaml
   cluster-control-plane-security-group-id: ""
   cluster-oidc-issuer-arn: ""
   cluster-oidc-issuer-ca-thumbprint: ""

--- a/eksconfig/default.yaml
+++ b/eksconfig/default.yaml
@@ -24,7 +24,7 @@ log-level: info
 log-outputs:
 - stderr
 - /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.log
-name: eks-2020070622-sunsetvo3kc7
+name: eks-2020070622-spotlightga1
 on-failure-delete: true
 on-failure-delete-wait-seconds: 120
 parameters:
@@ -40,10 +40,10 @@ parameters:
   role-arn: ""
   role-cfn-stack-id: ""
   role-cfn-stack-yaml-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.role.cfn.yaml
-  role-cfn-stack-yaml-s3-key: eks-2020070622-sunsetvo3kc7/default.role.cfn.yaml
+  role-cfn-stack-yaml-s3-key: eks-2020070622-spotlightga1/default.role.cfn.yaml
   role-create: true
   role-managed-policy-arns: null
-  role-name: eks-2020070622-sunsetvo3kc7-role
+  role-name: eks-2020070622-spotlightga1-role
   role-service-principals: null
   signing-name: eks
   tags: null
@@ -51,19 +51,19 @@ parameters:
   version-value: 1.16
   vpc-cfn-stack-id: ""
   vpc-cfn-stack-yaml-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.vpc.cfn.yaml
-  vpc-cfn-stack-yaml-s3-key: eks-2020070622-sunsetvo3kc7/default.vpc.cfn.yaml
+  vpc-cfn-stack-yaml-s3-key: eks-2020070622-spotlightga1/default.vpc.cfn.yaml
   vpc-create: true
   vpc-id: ""
 partition: aws
 region: us-west-2
 remote-access-commands-output-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.ssh.sh
 remote-access-key-create: true
-remote-access-key-name: eks-2020070622-sunsetvo3kc7-remote-access-key
-remote-access-private-key-path: /tmp/spheres7eggv9hv.insecure.key
+remote-access-key-name: eks-2020070622-spotlightga1-remote-access-key
+remote-access-private-key-path: /tmp/waves5ywx5ha26r.insecure.key
 s3-bucket-create: true
 s3-bucket-create-keep: true
 s3-bucket-lifecycle-expiration-days: 0
-s3-bucket-name: eks-2020070622-sunsetvo3kc7-s3-bucket
+s3-bucket-name: eks-2020070622-spotlightga1-s3-bucket
 status:
   aws-account-id: ""
   aws-credential-path: ""
@@ -75,7 +75,7 @@ status:
   cluster-ca-decoded: ""
   cluster-cfn-stack-id: ""
   cluster-cfn-stack-yaml-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.cluster.cfn.yaml
-  cluster-cfn-stack-yaml-s3-key: eks-2020070622-sunsetvo3kc7/default.cluster.cfn.yaml
+  cluster-cfn-stack-yaml-s3-key: eks-2020070622-spotlightga1/default.cluster.cfn.yaml
   cluster-control-plane-security-group-id: ""
   cluster-oidc-issuer-arn: ""
   cluster-oidc-issuer-ca-thumbprint: ""

--- a/eksconfig/env.go
+++ b/eksconfig/env.go
@@ -79,6 +79,32 @@ func (cfg *Config) UpdateFromEnvs() (err error) {
 		return fmt.Errorf("expected *AddOnManagedNodeGroups, got %T", vv)
 	}
 
+	if cfg.AddOnCWAgent == nil {
+		cfg.AddOnCWAgent = &AddOnCWAgent{}
+	}
+	vv, err = parseEnvs(EnvironmentVariablePrefixAddOnCWAgent, cfg.AddOnCWAgent)
+	if err != nil {
+		return err
+	}
+	if av, ok := vv.(*AddOnCWAgent); ok {
+		cfg.AddOnCWAgent = av
+	} else {
+		return fmt.Errorf("expected *AddOnCWAgent, got %T", vv)
+	}
+
+	if cfg.AddOnFluentd == nil {
+		cfg.AddOnFluentd = &AddOnFluentd{}
+	}
+	vv, err = parseEnvs(EnvironmentVariablePrefixAddOnFluentd, cfg.AddOnFluentd)
+	if err != nil {
+		return err
+	}
+	if av, ok := vv.(*AddOnFluentd); ok {
+		cfg.AddOnFluentd = av
+	} else {
+		return fmt.Errorf("expected *AddOnFluentd, got %T", vv)
+	}
+
 	if cfg.AddOnMetricsServer == nil {
 		cfg.AddOnMetricsServer = &AddOnMetricsServer{}
 	}

--- a/eksconfig/env.go
+++ b/eksconfig/env.go
@@ -157,6 +157,45 @@ func (cfg *Config) UpdateFromEnvs() (err error) {
 		return fmt.Errorf("expected *AddOnCSIEBS, got %T", vv)
 	}
 
+	if cfg.AddOnKubernetesDashboard == nil {
+		cfg.AddOnKubernetesDashboard = &AddOnKubernetesDashboard{}
+	}
+	vv, err = parseEnvs(EnvironmentVariablePrefixAddOnKubernetesDashboard, cfg.AddOnKubernetesDashboard)
+	if err != nil {
+		return err
+	}
+	if av, ok := vv.(*AddOnKubernetesDashboard); ok {
+		cfg.AddOnKubernetesDashboard = av
+	} else {
+		return fmt.Errorf("expected *AddOnKubernetesDashboard, got %T", vv)
+	}
+
+	if cfg.AddOnPrometheusGrafana == nil {
+		cfg.AddOnPrometheusGrafana = &AddOnPrometheusGrafana{}
+	}
+	vv, err = parseEnvs(EnvironmentVariablePrefixAddOnPrometheusGrafana, cfg.AddOnPrometheusGrafana)
+	if err != nil {
+		return err
+	}
+	if av, ok := vv.(*AddOnPrometheusGrafana); ok {
+		cfg.AddOnPrometheusGrafana = av
+	} else {
+		return fmt.Errorf("expected *AddOnPrometheusGrafana, got %T", vv)
+	}
+
+	if cfg.AddOnPHPApache == nil {
+		cfg.AddOnPHPApache = &AddOnPHPApache{}
+	}
+	vv, err = parseEnvs(EnvironmentVariablePrefixAddOnPHPApache, cfg.AddOnPHPApache)
+	if err != nil {
+		return err
+	}
+	if av, ok := vv.(*AddOnPHPApache); ok {
+		cfg.AddOnPHPApache = av
+	} else {
+		return fmt.Errorf("expected *AddOnPHPApache, got %T", vv)
+	}
+
 	if cfg.AddOnNLBHelloWorld == nil {
 		cfg.AddOnNLBHelloWorld = &AddOnNLBHelloWorld{}
 	}
@@ -363,32 +402,6 @@ func (cfg *Config) UpdateFromEnvs() (err error) {
 		cfg.AddOnWordpress = av
 	} else {
 		return fmt.Errorf("expected *AddOnWordpress, got %T", vv)
-	}
-
-	if cfg.AddOnKubernetesDashboard == nil {
-		cfg.AddOnKubernetesDashboard = &AddOnKubernetesDashboard{}
-	}
-	vv, err = parseEnvs(EnvironmentVariablePrefixAddOnKubernetesDashboard, cfg.AddOnKubernetesDashboard)
-	if err != nil {
-		return err
-	}
-	if av, ok := vv.(*AddOnKubernetesDashboard); ok {
-		cfg.AddOnKubernetesDashboard = av
-	} else {
-		return fmt.Errorf("expected *AddOnKubernetesDashboard, got %T", vv)
-	}
-
-	if cfg.AddOnPrometheusGrafana == nil {
-		cfg.AddOnPrometheusGrafana = &AddOnPrometheusGrafana{}
-	}
-	vv, err = parseEnvs(EnvironmentVariablePrefixAddOnPrometheusGrafana, cfg.AddOnPrometheusGrafana)
-	if err != nil {
-		return err
-	}
-	if av, ok := vv.(*AddOnPrometheusGrafana); ok {
-		cfg.AddOnPrometheusGrafana = av
-	} else {
-		return fmt.Errorf("expected *AddOnPrometheusGrafana, got %T", vv)
 	}
 
 	if cfg.AddOnJupyterHub == nil {

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -174,6 +174,22 @@ func TestEnv(t *testing.T) {
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_LOGS_DIR", "a")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_LOGS_DIR")
 
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CW_AGENT_ENABLE", "true")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CW_AGENT_ENABLE")
+
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_ENABLE", "true")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_ENABLE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_ACCOUNT_ID", "uri")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_ACCOUNT_ID")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_REGION", "eu-north-1")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_REGION")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_NAME", "busybox")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_NAME")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_IMAGE_TAG", "latest2")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_IMAGE_TAG")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_METADATA_WATCH", "false")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_METADATA_WATCH")
+
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_ENABLE", "true")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_ENABLE")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_DEPLOYMENT_REPLICAS", "333")
@@ -876,6 +892,29 @@ func TestEnv(t *testing.T) {
 	}
 	if cfg.AddOnManagedNodeGroups.LogsDir != "a" {
 		t.Fatalf("unexpected cfg.AddOnManagedNodeGroups.LogsDir %q", cfg.AddOnManagedNodeGroups.LogsDir)
+	}
+
+	if !cfg.AddOnCWAgent.Enable {
+		t.Fatalf("unexpected cfg.AddOnCWAgent.Enable %v", cfg.AddOnCWAgent.Enable)
+	}
+
+	if !cfg.AddOnFluentd.Enable {
+		t.Fatalf("unexpected cfg.AddOnFluentd.Enable %v", cfg.AddOnFluentd.Enable)
+	}
+	if cfg.AddOnFluentd.RepositoryBusyboxAccountID != "uri" {
+		t.Fatalf("unexpected cfg.AddOnFluentd.RepositoryBusyboxAccountID %v", cfg.AddOnFluentd.RepositoryBusyboxAccountID)
+	}
+	if cfg.AddOnFluentd.RepositoryBusyboxRegion != "eu-north-1" {
+		t.Fatalf("unexpected cfg.AddOnFluentd.RepositoryBusyboxRegion %v", cfg.AddOnFluentd.RepositoryBusyboxRegion)
+	}
+	if cfg.AddOnFluentd.RepositoryBusyboxName != "busybox" {
+		t.Fatalf("unexpected cfg.AddOnFluentd.RepositoryBusyboxName %v", cfg.AddOnFluentd.RepositoryBusyboxName)
+	}
+	if cfg.AddOnFluentd.RepositoryBusyboxImageTag != "latest2" {
+		t.Fatalf("unexpected cfg.AddOnFluentd.RepositoryBusyboxImageTag %v", cfg.AddOnFluentd.RepositoryBusyboxImageTag)
+	}
+	if cfg.AddOnFluentd.MetadataWatch {
+		t.Fatalf("unexpected cfg.AddOnFluentd.MetadataWatch %v", cfg.AddOnFluentd.MetadataWatch)
 	}
 
 	if !cfg.AddOnNLBHelloWorld.Enable {

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -190,6 +190,15 @@ func TestEnv(t *testing.T) {
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_METADATA_WATCH", "false")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_METADATA_WATCH")
 
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_ENABLE", "true")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_ENABLE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_DEPLOYMENT_REPLICAS", "333")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_DEPLOYMENT_REPLICAS")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_NAMESPACE", "test-namespace")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_NAMESPACE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_DEPLOYMENT_NODE_SELECTOR", `{"a":"b","c":"d"}`)
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_PHP_APACHE_DEPLOYMENT_NODE_SELECTOR")
+
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_ENABLE", "true")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_ENABLE")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_DEPLOYMENT_REPLICAS", "333")
@@ -915,6 +924,20 @@ func TestEnv(t *testing.T) {
 	}
 	if cfg.AddOnFluentd.MetadataWatch {
 		t.Fatalf("unexpected cfg.AddOnFluentd.MetadataWatch %v", cfg.AddOnFluentd.MetadataWatch)
+	}
+
+	if !cfg.AddOnPHPApache.Enable {
+		t.Fatalf("unexpected cfg.AddOnPHPApache.Enable %v", cfg.AddOnPHPApache.Enable)
+	}
+	if cfg.AddOnPHPApache.DeploymentReplicas != 333 {
+		t.Fatalf("unexpected cfg.AddOnPHPApache.DeploymentReplicas %d", cfg.AddOnPHPApache.DeploymentReplicas)
+	}
+	if cfg.AddOnPHPApache.Namespace != "test-namespace" {
+		t.Fatalf("unexpected cfg.AddOnPHPApache.Namespace %q", cfg.AddOnPHPApache.Namespace)
+	}
+	expectedNodeSelectorPHPApache := map[string]string{"a": "b", "c": "d"}
+	if !reflect.DeepEqual(cfg.AddOnPHPApache.DeploymentNodeSelector, expectedNodeSelectorPHPApache) {
+		t.Fatalf("unexpected cfg.AddOnPHPApache.DeploymentNodeSelector %v", cfg.AddOnPHPApache.DeploymentNodeSelector)
 	}
 
 	if !cfg.AddOnNLBHelloWorld.Enable {

--- a/eksconfig/gen/main.go
+++ b/eksconfig/gen/main.go
@@ -42,6 +42,14 @@ func createDoc() string {
 
 	b.WriteByte('\n')
 	b.WriteByte('\n')
+	b.WriteString(es.writeDoc(eksconfig.EnvironmentVariablePrefixAddOnCWAgent, &eksconfig.AddOnCWAgent{}))
+
+	b.WriteByte('\n')
+	b.WriteByte('\n')
+	b.WriteString(es.writeDoc(eksconfig.EnvironmentVariablePrefixAddOnFluentd, &eksconfig.AddOnFluentd{}))
+
+	b.WriteByte('\n')
+	b.WriteByte('\n')
 	b.WriteString(es.writeDoc(eksconfig.EnvironmentVariablePrefixAddOnMetricsServer, &eksconfig.AddOnMetricsServer{}))
 
 	b.WriteByte('\n')

--- a/eksconfig/gen/main.go
+++ b/eksconfig/gen/main.go
@@ -74,6 +74,10 @@ func createDoc() string {
 
 	b.WriteByte('\n')
 	b.WriteByte('\n')
+	b.WriteString(es.writeDoc(eksconfig.EnvironmentVariablePrefixAddOnPHPApache, &eksconfig.AddOnPHPApache{}))
+
+	b.WriteByte('\n')
+	b.WriteByte('\n')
 	b.WriteString(es.writeDoc(eksconfig.EnvironmentVariablePrefixAddOnNLBHelloWorld, &eksconfig.AddOnNLBHelloWorld{}))
 
 	b.WriteByte('\n')


### PR DESCRIPTION
Automate
- https://github.com/aws-samples/amazon-cloudwatch-container-insights/tree/master/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart
- https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html
- https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html

### Test

```
AWS_K8S_TESTER_EKS_ON_FAILURE_DELETE=true \
AWS_K8S_TESTER_EKS_REGION=us-west-2 \
AWS_K8S_TESTER_EKS_LOG_COLOR=true \
AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE=true \
AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_CREATE=true \
AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_CREATE=true \
AWS_K8S_TESTER_EKS_PARAMETERS_VERSION=1.16 \
AWS_K8S_TESTER_EKS_PARAMETERS_VPC_CREATE=true \
AWS_K8S_TESTER_EKS_CLIENTS=5 \
AWS_K8S_TESTER_EKS_CLIENT_QPS=30 \
AWS_K8S_TESTER_EKS_CLIENT_BURST=20 \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE=true \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_CREATE=true \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_FETCH_LOGS=true \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS='{"GetRef.Name-ng-al2-cpu":{"name":"GetRef.Name-ng-al2-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id":"","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.16/amazon-linux-2/recommended/image_id","instance-types":["c5.xlarge"],"volume-size":40,"asg-min-size":2,"asg-max-size":2,"asg-desired-capacity":2,"kubelet-extra-args":"","cluster-autoscaler":{"enable":false}}}' \
AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_ENABLE=true \
AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_ACCOUNT_ID=607362164682 \
AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_REGION=us-west-2 \
AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_NAME=busybox \
AWS_K8S_TESTER_EKS_ADD_ON_FLUENTD_REPOSITORY_BUSYBOX_IMAGE_TAG=latest \
AWS_K8S_TESTER_EKS_ADD_ON_NLB_GUESTBOOK_ENABLE=true \
aws-k8s-tester eks create cluster --enable-prompt=true --auto-path
```

![Screenshot from 2020-07-06 16-58-15](https://user-images.githubusercontent.com/6799218/86670838-eb859580-bfa9-11ea-96d7-bbf29466b751.png)

![Screenshot from 2020-07-06 16-55-33](https://user-images.githubusercontent.com/6799218/86670754-d6a90200-bfa9-11ea-98fa-a32e2b7b9bb7.png)
![Screenshot from 2020-07-06 17-57-03](https://user-images.githubusercontent.com/6799218/86679125-2095e600-bfb2-11ea-9e7d-146a08249166.png)
