### PR TITLE
Changed hollow_nodes.go to use a replicationcontroller to enable comp…

### DIFF
--- a/eksconfig/README.md
+++ b/eksconfig/README.md
@@ -904,25 +904,25 @@ AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_VERSION_UPGRADE_ENABLE=true \
 *-----------------------------------------------------------------*-------------------*---------------------------------------------------*--------------------*
 
 
-*---------------------------------------------------------------------*-------------------*-------------------------------------------------------*--------------------*
-|                       ENVIRONMENTAL VARIABLE                        |     READ ONLY     |                         TYPE                          |      GO TYPE       |
-*---------------------------------------------------------------------*-------------------*-------------------------------------------------------*--------------------*
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_ENABLE                | read-only "false" | *eksconfig.AddOnHollowNodesRemote.Enable              | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_CREATED               | read-only "true"  | *eksconfig.AddOnHollowNodesRemote.Created             | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_TIME_FRAME_CREATE     | read-only "true"  | *eksconfig.AddOnHollowNodesRemote.TimeFrameCreate     | timeutil.TimeFrame |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_TIME_FRAME_DELETE     | read-only "true"  | *eksconfig.AddOnHollowNodesRemote.TimeFrameDelete     | timeutil.TimeFrame |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_NAMESPACE             | read-only "false" | *eksconfig.AddOnHollowNodesRemote.Namespace           | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPOSITORY_ACCOUNT_ID | read-only "false" | *eksconfig.AddOnHollowNodesRemote.RepositoryAccountID | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPOSITORY_REGION     | read-only "false" | *eksconfig.AddOnHollowNodesRemote.RepositoryRegion    | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPOSITORY_NAME       | read-only "false" | *eksconfig.AddOnHollowNodesRemote.RepositoryName      | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPOSITORY_IMAGE_TAG  | read-only "false" | *eksconfig.AddOnHollowNodesRemote.RepositoryImageTag  | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_DEPLOYMENT_REPLICAS   | read-only "false" | *eksconfig.AddOnHollowNodesRemote.DeploymentReplicas  | int32              |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_NODES                 | read-only "false" | *eksconfig.AddOnHollowNodesRemote.Nodes               | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_NODE_NAME_PREFIX      | read-only "false" | *eksconfig.AddOnHollowNodesRemote.NodeNamePrefix      | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_NODE_LABEL_PREFIX     | read-only "false" | *eksconfig.AddOnHollowNodesRemote.NodeLabelPrefix     | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_MAX_OPEN_FILES        | read-only "false" | *eksconfig.AddOnHollowNodesRemote.MaxOpenFiles        | int64              |
-| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_CREATED_NODE_NAMES    | read-only "true"  | *eksconfig.AddOnHollowNodesRemote.CreatedNodeNames    | []string           |
-*---------------------------------------------------------------------*-------------------*-------------------------------------------------------*--------------------*
+*-------------------------------------------------------------------------------*-------------------*-----------------------------------------------------------------*--------------------*
+|                            ENVIRONMENTAL VARIABLE                             |     READ ONLY     |                              TYPE                               |      GO TYPE       |
+*-------------------------------------------------------------------------------*-------------------*-----------------------------------------------------------------*--------------------*
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_ENABLE                          | read-only "false" | *eksconfig.AddOnHollowNodesRemote.Enable                        | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_CREATED                         | read-only "true"  | *eksconfig.AddOnHollowNodesRemote.Created                       | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_TIME_FRAME_CREATE               | read-only "true"  | *eksconfig.AddOnHollowNodesRemote.TimeFrameCreate               | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_TIME_FRAME_DELETE               | read-only "true"  | *eksconfig.AddOnHollowNodesRemote.TimeFrameDelete               | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_NAMESPACE                       | read-only "false" | *eksconfig.AddOnHollowNodesRemote.Namespace                     | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPOSITORY_ACCOUNT_ID           | read-only "false" | *eksconfig.AddOnHollowNodesRemote.RepositoryAccountID           | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPOSITORY_REGION               | read-only "false" | *eksconfig.AddOnHollowNodesRemote.RepositoryRegion              | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPOSITORY_NAME                 | read-only "false" | *eksconfig.AddOnHollowNodesRemote.RepositoryName                | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPOSITORY_IMAGE_TAG            | read-only "false" | *eksconfig.AddOnHollowNodesRemote.RepositoryImageTag            | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPLICATION_CONTROLLER_REPLICAS | read-only "false" | *eksconfig.AddOnHollowNodesRemote.ReplicationControllerReplicas | int32              |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_NODES                           | read-only "false" | *eksconfig.AddOnHollowNodesRemote.Nodes                         | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_NODE_NAME_PREFIX                | read-only "false" | *eksconfig.AddOnHollowNodesRemote.NodeNamePrefix                | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_NODE_LABEL_PREFIX               | read-only "false" | *eksconfig.AddOnHollowNodesRemote.NodeLabelPrefix               | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_MAX_OPEN_FILES                  | read-only "false" | *eksconfig.AddOnHollowNodesRemote.MaxOpenFiles                  | int64              |
+| AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_CREATED_NODE_NAMES              | read-only "true"  | *eksconfig.AddOnHollowNodesRemote.CreatedNodeNames              | []string           |
+*-------------------------------------------------------------------------------*-------------------*-----------------------------------------------------------------*--------------------*
 
 
 *----------------------------------------------------------------------------------------*-------------------*----------------------------------------------------------------------*-------------------------*

--- a/eksconfig/add-on-hollow-nodes-remote.go
+++ b/eksconfig/add-on-hollow-nodes-remote.go
@@ -12,7 +12,7 @@ import (
 // add-on hollow nodes remote.
 // It generates loads from the remote workers (Pod) in the cluster.
 // Each worker writes serially with no concurrency.
-// Configure "DeploymentReplicas" accordingly to increase the concurrency.
+// Configure "ReplicationControllerReplicas" accordingly to increase the concurrency.
 type AddOnHollowNodesRemote struct {
 	// Enable is 'true' to create this add-on.
 	Enable bool `json:"enable"`
@@ -37,11 +37,11 @@ type AddOnHollowNodesRemote struct {
 	// e.g. "latest" for image URI "[ACCOUNT_ID].dkr.ecr.[REGION].amazonaws.com/aws/aws-k8s-tester:latest"
 	RepositoryImageTag string `json:"repository-image-tag,omitempty"`
 
-	// DeploymentReplicas is the number of replicas to create for workers.
-	// The total number of objects to be created is "DeploymentReplicas" * "Nodes".
-	DeploymentReplicas int32 `json:"deployment-replicas,omitempty"`
+	// ReplicationControllerReplicas is the number of replicas to create for workers.
+	// The total number of objects to be created is "ReplicationControllerReplicas" * "Nodes".
+	ReplicationControllerReplicas int32 `json:"replication-controller-replicas,omitempty"`
 	// Nodes is the number of hollow nodes to create.
-	// The total number of objects to be created is "DeploymentReplicas" * "Nodes".
+	// The total number of objects to be created is "ReplicationControllerReplicas" * "Nodes".
 	Nodes int `json:"nodes"`
 
 	// NodeNamePrefix is the node name prefix for node names.
@@ -75,12 +75,12 @@ func (cfg *Config) IsEnabledAddOnHollowNodesRemote() bool {
 
 func getDefaultAddOnHollowNodesRemote() *AddOnHollowNodesRemote {
 	return &AddOnHollowNodesRemote{
-		Enable:             false,
-		DeploymentReplicas: 5,
-		Nodes:              2,
-		NodeNamePrefix:     "hollow" + randutil.String(5),
-		NodeLabelPrefix:    "hollow" + randutil.String(5),
-		MaxOpenFiles:       1000000,
+		Enable:                        false,
+		ReplicationControllerReplicas: 5,
+		Nodes:                         2,
+		NodeNamePrefix:                "hollow" + randutil.String(5),
+		NodeLabelPrefix:               "hollow" + randutil.String(5),
+		MaxOpenFiles:                  1000000,
 	}
 }
 
@@ -113,8 +113,8 @@ func (cfg *Config) validateAddOnHollowNodesRemote() error {
 		return errors.New("AddOnHollowNodesRemote.RepositoryImageTag empty")
 	}
 
-	if cfg.AddOnHollowNodesRemote.DeploymentReplicas == 0 {
-		cfg.AddOnHollowNodesRemote.DeploymentReplicas = 5
+	if cfg.AddOnHollowNodesRemote.ReplicationControllerReplicas == 0 {
+		cfg.AddOnHollowNodesRemote.ReplicationControllerReplicas = 5
 	}
 	if cfg.AddOnHollowNodesRemote.Nodes == 0 {
 		cfg.AddOnHollowNodesRemote.Nodes = 2

--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -889,7 +889,7 @@ func (cfg *Config) ValidateAndSetDefaults() error {
 		totalHollowNodes += int64(cfg.AddOnHollowNodesLocal.Nodes)
 	}
 	if cfg.IsEnabledAddOnHollowNodesRemote() {
-		totalHollowNodes += int64(cfg.AddOnHollowNodesRemote.Nodes) * int64(cfg.AddOnHollowNodesRemote.DeploymentReplicas)
+		totalHollowNodes += int64(cfg.AddOnHollowNodesRemote.Nodes) * int64(cfg.AddOnHollowNodesRemote.ReplicationControllerReplicas)
 	}
 	cfg.TotalHollowNodes = totalHollowNodes
 

--- a/eksconfig/default.yaml
+++ b/eksconfig/default.yaml
@@ -1,30 +1,30 @@
-aws-cli-path: /home/ANT.AMAZON.COM/leegyuho/.local/bin/aws
+aws-cli-path: /usr/local/bin/aws
 client-burst: 20
 client-qps: 10
 client-timeout: 15000000000
 client-timeout-string: 15s
 clients: 2
 command-after-create-add-ons: ""
-command-after-create-add-ons-output-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.after-create-add-ons.out.log
+command-after-create-add-ons-output-path: /Users/etarn/workspaces/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.after-create-add-ons.out.log
 command-after-create-add-ons-timeout: 180000000000
 command-after-create-add-ons-timeout-string: 3m0s
 command-after-create-cluster: ""
-command-after-create-cluster-output-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.after-create-cluster.out.log
+command-after-create-cluster-output-path: /Users/etarn/workspaces/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.after-create-cluster.out.log
 command-after-create-cluster-timeout: 180000000000
 command-after-create-cluster-timeout-string: 3m0s
-config-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.yaml
+config-path: /Users/etarn/workspaces/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.yaml
 cw-namespace: aws-k8s-tester-eks
-kubeconfig-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.kubeconfig.yaml
-kubectl-commands-output-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.kubectl.sh
-kubectl-download-url: https://storage.googleapis.com/kubernetes-release/release/v1.17.6/bin/linux/amd64/kubectl
+kubeconfig-path: /Users/etarn/workspaces/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.kubeconfig.yaml
+kubectl-commands-output-path: /Users/etarn/workspaces/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.kubectl.sh
+kubectl-download-url: https://storage.googleapis.com/kubernetes-release/release/v1.17.6/bin/darwin/amd64/kubectl
 kubectl-path: /tmp/kubectl-test-v1.17.6
 log-color: true
 log-color-override: false
 log-level: info
 log-outputs:
 - stderr
-- /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.log
-name: eks-2020071402-breezervitnc
+- /Users/etarn/workspaces/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.log
+name: eks-2020071614-sun1aslya9hd
 on-failure-delete: true
 on-failure-delete-wait-seconds: 120
 parameters:
@@ -39,31 +39,31 @@ parameters:
   resolver-url: ""
   role-arn: ""
   role-cfn-stack-id: ""
-  role-cfn-stack-yaml-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.role.cfn.yaml
-  role-cfn-stack-yaml-s3-key: eks-2020071402-breezervitnc/default.role.cfn.yaml
+  role-cfn-stack-yaml-path: /Users/etarn/workspaces/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.role.cfn.yaml
+  role-cfn-stack-yaml-s3-key: eks-2020071614-sun1aslya9hd/default.role.cfn.yaml
   role-create: true
   role-managed-policy-arns: null
-  role-name: eks-2020071402-breezervitnc-role
+  role-name: eks-2020071614-sun1aslya9hd-role
   role-service-principals: null
   signing-name: eks
   tags: null
   version: "1.17"
   version-value: 1.17
   vpc-cfn-stack-id: ""
-  vpc-cfn-stack-yaml-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.vpc.cfn.yaml
-  vpc-cfn-stack-yaml-s3-key: eks-2020071402-breezervitnc/default.vpc.cfn.yaml
+  vpc-cfn-stack-yaml-path: /Users/etarn/workspaces/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.vpc.cfn.yaml
+  vpc-cfn-stack-yaml-s3-key: eks-2020071614-sun1aslya9hd/default.vpc.cfn.yaml
   vpc-create: true
   vpc-id: ""
 partition: aws
 region: us-west-2
-remote-access-commands-output-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.ssh.sh
+remote-access-commands-output-path: /Users/etarn/workspaces/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.ssh.sh
 remote-access-key-create: true
-remote-access-key-name: eks-2020071402-breezervitnc-remote-access-key
-remote-access-private-key-path: /tmp/grandfedbd485wh.insecure.key
+remote-access-key-name: eks-2020071614-sun1aslya9hd-remote-access-key
+remote-access-private-key-path: /var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/river9yx5kos41d.insecure.key
 s3-bucket-create: true
 s3-bucket-create-keep: true
 s3-bucket-lifecycle-expiration-days: 0
-s3-bucket-name: eks-2020071402-breezervitnc-s3-bucket
+s3-bucket-name: eks-2020071614-sun1aslya9hd-s3-bucket
 status:
   aws-account-id: ""
   aws-credential-path: ""
@@ -74,8 +74,8 @@ status:
   cluster-ca: ""
   cluster-ca-decoded: ""
   cluster-cfn-stack-id: ""
-  cluster-cfn-stack-yaml-path: /home/ANT.AMAZON.COM/leegyuho/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.cluster.cfn.yaml
-  cluster-cfn-stack-yaml-s3-key: eks-2020071402-breezervitnc/default.cluster.cfn.yaml
+  cluster-cfn-stack-yaml-path: /Users/etarn/workspaces/go/src/github.com/aws/aws-k8s-tester/eksconfig/default.cluster.cfn.yaml
+  cluster-cfn-stack-yaml-s3-key: eks-2020071614-sun1aslya9hd/default.cluster.cfn.yaml
   cluster-control-plane-security-group-id: ""
   cluster-oidc-issuer-arn: ""
   cluster-oidc-issuer-ca-thumbprint: ""


### PR DESCRIPTION
…atibility with the Kubemark Cloud provider. Added labels to the replicationcontroller to simulate node groups for Cluster Autoscaler integration with Kubemark

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
