### PR TITLE
Add support for validate MNG + NG RoleServicePrincipals 

### DIFF
--- a/eksconfig/add-on-managed-node-groups.go
+++ b/eksconfig/add-on-managed-node-groups.go
@@ -301,13 +301,13 @@ func (cfg *Config) validateAddOnManagedNodeGroups() error {
 			*/
 			found := false
 			for _, pv := range cfg.AddOnManagedNodeGroups.RoleServicePrincipals {
-				if pv == "ec2.amazonaws.com" { // TODO: support China regions ec2.amazonaws.com.cn or eks.amazonaws.com.cn
+				if pv == "ec2.amazonaws.com" || pv == "ec2.amazonaws.com.cn" {
 					found = true
 					break
 				}
 			}
 			if !found {
-				return fmt.Errorf("AddOnManagedNodeGroups.RoleServicePrincipals %q must include 'ec2.amazonaws.com'", cfg.AddOnManagedNodeGroups.RoleServicePrincipals)
+				return fmt.Errorf("AddOnManagedNodeGroups.RoleServicePrincipals %q must include 'ec2.amazonaws.com' or 'ec2.amazonaws.com.cn'", cfg.AddOnManagedNodeGroups.RoleServicePrincipals)
 			}
 		}
 

--- a/eksconfig/add-on-node-groups.go
+++ b/eksconfig/add-on-node-groups.go
@@ -209,13 +209,13 @@ func (cfg *Config) validateAddOnNodeGroups() error {
 			*/
 			found := false
 			for _, pv := range cfg.AddOnNodeGroups.RoleServicePrincipals {
-				if pv == "ec2.amazonaws.com" { // TODO: support China regions ec2.amazonaws.com.cn or eks.amazonaws.com.cn
+				if pv == "ec2.amazonaws.com" || pv == "ec2.amazonaws.com.cn" {
 					found = true
 					break
 				}
 			}
 			if !found {
-				return fmt.Errorf("AddOnNodeGroups.RoleServicePrincipals %q must include 'ec2.amazonaws.com'", cfg.AddOnNodeGroups.RoleServicePrincipals)
+				return fmt.Errorf("AddOnNodeGroups.RoleServicePrincipals %q must include 'ec2.amazonaws.com' or 'ec2.amazonaws.com.cn'", cfg.AddOnNodeGroups.RoleServicePrincipals)
 			}
 		}
 


### PR DESCRIPTION
*Issue #, if available:*
```
failed to validate configuration "test.yaml" (validateAddOnNodeGroups failed [AddOnNodeGroups.RoleServicePrincipals ["ec2.amazonaws.com.cn" "eks.amazonaws.com" "eks-fargate-pods.amazonaws.com" "eks-dev.aws.internal" "eks-beta-pdx.aws.internal" "eks-fargate-pods.aws.internal"] must include 'ec2.amazonaws.com'])
```

*Description of changes:*
To support `aws-k8s-tester` test against other regions, add extra validation for NodeGroup and ManagedNodegroup RoleServicePrincipals.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
