### PR TITLE
Redesigned hollow nodes to be compatible with Cluster Autoscaler's Kubemark integration

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -25,6 +25,12 @@ See [code changes](https://github.com/aws/aws-k8s-tester/compare/v1.4.7...v1.4.8
 - Add [`eks/cni-vpc`](https://github.com/aws/aws-k8s-tester/commit/104f581eac40168cc3c73d04b338e995b83e0923).
   - `eks/cni-vpc` is [installed before worker nodes and not deleted](https://github.com/aws/aws-k8s-tester/commit/cb63393b3131a5266deaae2dcfcf417897bc5848).
   - Requires [at least `AddOnCNIVPC.Version` `v1.7`](https://github.com/aws/aws-k8s-tester/commit/52f89b7bc78e84f6a87a081dbea277c07f54b0e5).
+- Fix [`eks/hollow-nodes/remote`]
+  - Deploys to kubemark namespace
+  - Uses a replication controller instead of deployment
+  - Kubemark pods now equal corresponding hollow node names
+  - Adds labels to hollow nodes for CA discovery
+  - Idempotently Create/Update kubemark resources.
 
 ### `pkg`
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean:
 	find **/*.generated.yaml -print0 | xargs -0 rm -f || true
 	find **/*.coverprofile -print0 | xargs -0 rm -f || true
 
-docker:
+docker-build:
 	@if [ ! -f "./_tmp/clusterloader2" ]; then echo "downloading clusterloader2"; aws s3 cp --region us-west-2 s3://aws-k8s-tester-public/clusterloader2-linux-amd64 ./_tmp/clusterloader2; else echo "skipping downloading clusterloader2"; fi;
 	@if [ ! -d "${HOME}/go/src/k8s.io/perf-tests" ]; then echo "cloning perf-tests"; mkdir -p ${HOME}/go/src/k8s.io; pushd ${HOME}/go/src/k8s.io; git clone https://github.com/kubernetes/perf-tests.git; popd; else echo "skipping cloning perf-tests"; fi
 	@if [ ! -d "./_tmp/clusterloader2-testing-load" ]; then echo "copying clusterloader2/testing/load"; cp -rf ${HOME}/go/src/k8s.io/perf-tests/clusterloader2/testing/load ./_tmp/clusterloader2-testing-load; else echo "skipping copying clusterloader2/testing/load"; fi

--- a/cmd/aws-k8s-tester/eks/create-hollow-nodes.go
+++ b/cmd/aws-k8s-tester/eks/create-hollow-nodes.go
@@ -74,26 +74,19 @@ func createHollowNodesFunc(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	// to randomize node names and labels
-	// when multiple pods are created via deployment
-	// we do not want each pod to assign same node name prefix or labels
-	// we want to avoid conflicts and run checks for each pod
-	// node checking is done via prefix check, so this should be good
-	// enough for make them unique per worker
-	sfx := randutil.String(5)
-
 	stopc := make(chan struct{})
 	ng := hollow_nodes.CreateNodeGroup(hollow_nodes.NodeGroupConfig{
 		Logger:         lg,
 		Client:         cli,
 		Stopc:          stopc,
 		Nodes:          hollowNodesNodes,
-		NodeNamePrefix: hollowNodeNamePrefix + sfx,
+		NodeNamePrefix: hollowNodeNamePrefix,
 		NodeLabels: map[string]string{
-			"NodeType": "hollow-nodes",
-			"AMIType":  hollowNodeLabelPrefix + "-ami-type-" + sfx,
-			"NGType":   hollowNodeLabelPrefix + "-ng-type-" + sfx,
-			"NGName":   hollowNodeLabelPrefix + "-ng-name-" + sfx,
+			"autoscaling.k8s.io/nodegroup": hollowNodeNamePrefix,
+			"NodeType":                     "hollow-nodes",
+			"AMIType":                      hollowNodeLabelPrefix + "-ami-type",
+			"NGType":                       hollowNodeLabelPrefix + "-ng-type",
+			"NGName":                       hollowNodeLabelPrefix + "-ng-name",
 		},
 		Remote: hollowNodesRemote,
 	})

--- a/eksconfig/add-on-hollow-nodes-remote.go
+++ b/eksconfig/add-on-hollow-nodes-remote.go
@@ -12,7 +12,7 @@ import (
 // add-on hollow nodes remote.
 // It generates loads from the remote workers (Pod) in the cluster.
 // Each worker writes serially with no concurrency.
-// Configure "ReplicationControllerReplicas" accordingly to increase the concurrency.
+// Configure "NodeGroups" accordingly to increase the concurrency.
 type AddOnHollowNodesRemote struct {
 	// Enable is 'true' to create this add-on.
 	Enable bool `json:"enable"`
@@ -37,15 +37,13 @@ type AddOnHollowNodesRemote struct {
 	// e.g. "latest" for image URI "[ACCOUNT_ID].dkr.ecr.[REGION].amazonaws.com/aws/aws-k8s-tester:latest"
 	RepositoryImageTag string `json:"repository-image-tag,omitempty"`
 
-	// ReplicationControllerReplicas is the number of replicas to create for workers.
-	// The total number of objects to be created is "ReplicationControllerReplicas" * "Nodes".
-	ReplicationControllerReplicas int32 `json:"replication-controller-replicas,omitempty"`
+	// NodeGroups is the number of replicas to create for workers.
+	// The total number of objects to be created is "NodeGroups" * "Nodes".
+	NodeGroups int `json:"node-groups,omitempty"`
 	// Nodes is the number of hollow nodes to create.
-	// The total number of objects to be created is "ReplicationControllerReplicas" * "Nodes".
+	// The total number of objects to be created is "NodeGroups" * "Nodes".
 	Nodes int `json:"nodes"`
 
-	// NodeNamePrefix is the node name prefix for node names.
-	NodeNamePrefix string `json:"node-name-prefix"`
 	// NodeLabelPrefix is the node prefix.
 	NodeLabelPrefix string `json:"node-label-prefix"`
 
@@ -75,12 +73,11 @@ func (cfg *Config) IsEnabledAddOnHollowNodesRemote() bool {
 
 func getDefaultAddOnHollowNodesRemote() *AddOnHollowNodesRemote {
 	return &AddOnHollowNodesRemote{
-		Enable:                        false,
-		ReplicationControllerReplicas: 5,
-		Nodes:                         2,
-		NodeNamePrefix:                "hollow" + randutil.String(5),
-		NodeLabelPrefix:               "hollow" + randutil.String(5),
-		MaxOpenFiles:                  1000000,
+		Enable:          false,
+		NodeGroups:      5,
+		Nodes:           2,
+		NodeLabelPrefix: "hollow" + randutil.String(5),
+		MaxOpenFiles:    1000000,
 	}
 }
 
@@ -97,7 +94,7 @@ func (cfg *Config) validateAddOnHollowNodesRemote() error {
 	}
 
 	if cfg.AddOnHollowNodesRemote.Namespace == "" {
-		cfg.AddOnHollowNodesRemote.Namespace = cfg.Name + "-hollow-nodes-remote"
+		cfg.AddOnHollowNodesRemote.Namespace = "kubemark"
 	}
 
 	if cfg.AddOnHollowNodesRemote.RepositoryAccountID == "" {
@@ -113,14 +110,11 @@ func (cfg *Config) validateAddOnHollowNodesRemote() error {
 		return errors.New("AddOnHollowNodesRemote.RepositoryImageTag empty")
 	}
 
-	if cfg.AddOnHollowNodesRemote.ReplicationControllerReplicas == 0 {
-		cfg.AddOnHollowNodesRemote.ReplicationControllerReplicas = 5
+	if cfg.AddOnHollowNodesRemote.NodeGroups == 0 {
+		cfg.AddOnHollowNodesRemote.NodeGroups = 5
 	}
 	if cfg.AddOnHollowNodesRemote.Nodes == 0 {
-		cfg.AddOnHollowNodesRemote.Nodes = 2
-	}
-	if cfg.AddOnHollowNodesRemote.NodeNamePrefix == "" {
-		cfg.AddOnHollowNodesRemote.NodeNamePrefix = "hollow" + randutil.String(5)
+		cfg.AddOnHollowNodesRemote.Nodes = 1
 	}
 
 	// e.g. Unable to register node "fake-node-000004-evere" with API server: Node "fake-node-000004-evere" is invalid: [metadata.labels: Invalid value: "...-hollow-nodes-remote-fake-ami-type-duneg": must be no more than 63 characters, metadata.labels: Invalid value: "...-hollow-nodes-remote-fake-ng-name-duneg": must be no more than 63 characters, metadata.labels: Invalid value: "...-hollow-nodes-remote-fake-ng-type-duneg": must be no more than 63 characters]

--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -904,7 +904,7 @@ func (cfg *Config) ValidateAndSetDefaults() error {
 		totalHollowNodes += int64(cfg.AddOnHollowNodesLocal.Nodes)
 	}
 	if cfg.IsEnabledAddOnHollowNodesRemote() {
-		totalHollowNodes += int64(cfg.AddOnHollowNodesRemote.Nodes) * int64(cfg.AddOnHollowNodesRemote.ReplicationControllerReplicas)
+		totalHollowNodes += int64(cfg.AddOnHollowNodesRemote.Nodes) * int64(cfg.AddOnHollowNodesRemote.NodeGroups)
 	}
 	cfg.TotalHollowNodes = totalHollowNodes
 


### PR DESCRIPTION
- Deploys to kubemark namespace
- Uses a replication controller instead of deployment
- Correctly names Kubemark pods to equal node names
- Adds correct node labels for CA discovery.
- Idempotently Create/Update kubemark resources.