### PR TITLE
Improvements to Makefile and build scripts. Hollow nodes now supports >1 pod per node and taints those nodes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN go version
 ADD ./ /go/src/github.com/aws/aws-k8s-tester
 WORKDIR /go/src/github.com/aws/aws-k8s-tester
 ARG RELEASE_VERSION=latest
-ARG BUILD_TARGETS=linux
+ARG OS_TARGETS=linux
 RUN ./scripts/build.sh
 
 FROM amazonlinux:latest

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,18 @@ AKT_S3_PREFIX ?= $(AKT_S3_BUCKET)/bin/aws-k8s-tester
 AKT_S3_PATH ?= $(AKT_S3_PREFIX)/aws-k8s-tester-$(AKT_TAG)-$(AKT_DISTRIBUTION)
 AKT_ECR_HOST ?= amazonaws.com
 
+WHAT ?= aws-k8s-tester
+TARGETS ?= $(shell uname | awk '{print tolower($0)}')
+
+build:
+	WHAT=$(WHAT) TARGETS=$(TARGETS) RELEASE_VERSION=$(AKT_TAG) ./scripts/build.sh
+
 clean:
 	rm -rf ./bin ./_tmp
 	find **/*.generated.yaml -print0 | xargs -0 rm -f || true
 	find **/*.coverprofile -print0 | xargs -0 rm -f || true
+
+docker-release: docker-build docker-push
 
 docker-build:
 	@if [ ! -f "./_tmp/clusterloader2" ]; then echo "downloading clusterloader2"; aws s3 cp --region us-west-2 s3://aws-k8s-tester-public/clusterloader2-linux-amd64 ./_tmp/clusterloader2; else echo "skipping downloading clusterloader2"; fi;
@@ -23,9 +31,6 @@ docker-build:
 	docker build --network host -t $(AKT_IMG_NAME):$(AKT_TAG) --build-arg RELEASE_VERSION=$(AKT_TAG) .
 	docker tag $(AKT_IMG_NAME):$(AKT_TAG) $(AKT_AWS_ACCOUNT_ID).dkr.ecr.$(AKT_AWS_REGION).$(AKT_ECR_HOST)/$(AKT_IMG_NAME):$(AKT_TAG)
 	docker run --rm -it $(AKT_IMG_NAME):$(AKT_TAG) aws --version
-
-build:
-	RELEASE_VERSION=$(AKT_TAG) ./scripts/build.sh
 
 # release latest aws-k8s-tester to ECR
 docker-push:

--- a/eks/hollow-nodes/hollow-nodes.go
+++ b/eks/hollow-nodes/hollow-nodes.go
@@ -29,6 +29,7 @@ import (
 	kubelet_app "k8s.io/kubernetes/cmd/kubelet/app"
 	kubelet_options "k8s.io/kubernetes/cmd/kubelet/app/options"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/apis/core"
 	pkg_kubelet "k8s.io/kubernetes/pkg/kubelet"
 	kubelet_config "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	cadvisor_test "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
@@ -344,6 +345,7 @@ func newNode(cfg nodeConfig) (kubelet, kubeProxy, error) {
 
 	kubeletFlags.HostnameOverride = cfg.nodeName
 	kubeletFlags.NodeLabels = cfg.nodeLabels
+	kubeletFlags.RegisterWithTaints = []core.Taint{{Key: "provider", Effect: "NoSchedule", Value: "kubemark"}}
 
 	kubeletFlags.MinimumGCAge = metav1.Duration{Duration: 1 * time.Minute}
 	kubeletFlags.MaxContainerCount = 1
@@ -376,8 +378,7 @@ func newNode(cfg nodeConfig) (kubelet, kubeProxy, error) {
 
 	kubeletConfig.SyncFrequency.Duration = 10 * time.Second
 	kubeletConfig.EvictionPressureTransitionPeriod.Duration = 5 * time.Minute
-	kubeletConfig.MaxPods = 1
-	kubeletConfig.PodsPerCore = 1
+	kubeletConfig.MaxPods = 10
 	kubeletConfig.ClusterDNS = []string{}
 	kubeletConfig.ImageGCHighThresholdPercent = 90
 	kubeletConfig.ImageGCLowThresholdPercent = 80

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,120 +6,43 @@ if ! [[ "$0" =~ scripts/build.sh ]]; then
   exit 255
 fi
 
-if [[ -z "${GIT_COMMIT}" ]]; then
-  GIT_COMMIT=$(git rev-parse --short=12 HEAD || echo "GitNotFound")
-fi
-
-if [[ -z "${RELEASE_VERSION}" ]]; then
-  RELEASE_VERSION=v$(date -u '+%Y%m%d.%H%M%S')
-fi
-
-if [[ -z "${BUILD_TIME}" ]]; then
-  BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S')
-fi
-
+GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse --short=12 HEAD || echo "GitNotFound")}
+RELEASE_VERSION=${RELEASE_VERSION:-v$(date -u '+%Y%m%d.%H%M%S')}
+BUILD_TIME=${BUILD_TIME:-$(date -u '+%Y-%m-%d_%H:%M:%S')}
 echo "GIT_COMMIT:" ${GIT_COMMIT}
 echo "RELEASE_VERSION:" ${RELEASE_VERSION}
 echo "BUILD_TIME:" ${BUILD_TIME}
 
+DEFAULT_WHAT='aws-k8s-tester cw-utils ec2-utils ecr-utils eks-utils etcd-utils s3-utils sts-utils'
+DEFAULT_TARGETS='linux darwin'
+
+PACKAGE_NAME='github.com/aws/aws-k8s-tester'
+WHAT=${WHAT:-$DEFAULT_WHAT}
+TARGETS=${TARGETS:-$DEFAULT_TARGETS}
+
+echo ""
+echo "Usage: \`make TARGET='linux' WHAT='aws-k8s-tester cw-utils'\`"
+echo "DEFAULT_TARGETS=$DEFAULT_TARGETS"
+echo "DEFAULT_WHAT=$DEFAULT_WHAT"
+echo ""
+
+
 mkdir -p ./bin
 
-_BUILD_TARGETS=${BUILD_TARGETS:-'linux darwin'}
-
-for os in ${_BUILD_TARGETS}; do
-  CGO_ENABLED=0 GOOS=${os} GOARCH=$(go env GOARCH) \
-    go build -mod=vendor -v \
-    -ldflags "-s -w \
-    -X github.com/aws/aws-k8s-tester/version.GitCommit=${GIT_COMMIT} \
-    -X github.com/aws/aws-k8s-tester/version.ReleaseVersion=${RELEASE_VERSION} \
-    -X github.com/aws/aws-k8s-tester/version.BuildTime=${BUILD_TIME}" \
-    -o ./bin/aws-k8s-tester-${RELEASE_VERSION}-${os}-$(go env GOARCH) \
-    ./cmd/aws-k8s-tester
-
-  CGO_ENABLED=0 GOOS=${os} GOARCH=$(go env GOARCH) \
-    go build -mod=vendor -v \
-    -ldflags "-s -w \
-    -X github.com/aws/aws-k8s-tester/version.GitCommit=${GIT_COMMIT} \
-    -X github.com/aws/aws-k8s-tester/version.ReleaseVersion=${RELEASE_VERSION} \
-    -X github.com/aws/aws-k8s-tester/version.BuildTime=${BUILD_TIME}" \
-    -o ./bin/cw-utils-${RELEASE_VERSION}-${os}-$(go env GOARCH) \
-    ./cmd/cw-utils
-
-  CGO_ENABLED=0 GOOS=${os} GOARCH=$(go env GOARCH) \
-    go build -mod=vendor -v \
-    -ldflags "-s -w \
-    -X github.com/aws/aws-k8s-tester/version.GitCommit=${GIT_COMMIT} \
-    -X github.com/aws/aws-k8s-tester/version.ReleaseVersion=${RELEASE_VERSION} \
-    -X github.com/aws/aws-k8s-tester/version.BuildTime=${BUILD_TIME}" \
-    -o ./bin/ec2-utils-${RELEASE_VERSION}-${os}-$(go env GOARCH) \
-    ./cmd/ec2-utils
-
-  CGO_ENABLED=0 GOOS=${os} GOARCH=$(go env GOARCH) \
-    go build -mod=vendor -v \
-    -ldflags "-s -w \
-    -X github.com/aws/aws-k8s-tester/version.GitCommit=${GIT_COMMIT} \
-    -X github.com/aws/aws-k8s-tester/version.ReleaseVersion=${RELEASE_VERSION} \
-    -X github.com/aws/aws-k8s-tester/version.BuildTime=${BUILD_TIME}" \
-    -o ./bin/ecr-utils-${RELEASE_VERSION}-${os}-$(go env GOARCH) \
-    ./cmd/ecr-utils
-
-  CGO_ENABLED=0 GOOS=${os} GOARCH=$(go env GOARCH) \
-    go build -mod=vendor -v \
-    -ldflags "-s -w \
-    -X github.com/aws/aws-k8s-tester/version.GitCommit=${GIT_COMMIT} \
-    -X github.com/aws/aws-k8s-tester/version.ReleaseVersion=${RELEASE_VERSION} \
-    -X github.com/aws/aws-k8s-tester/version.BuildTime=${BUILD_TIME}" \
-    -o ./bin/eks-utils-${RELEASE_VERSION}-${os}-$(go env GOARCH) \
-    ./cmd/eks-utils
-
-  CGO_ENABLED=0 GOOS=${os} GOARCH=$(go env GOARCH) \
-    go build -mod=vendor -v \
-    -ldflags "-s -w \
-    -X github.com/aws/aws-k8s-tester/version.GitCommit=${GIT_COMMIT} \
-    -X github.com/aws/aws-k8s-tester/version.ReleaseVersion=${RELEASE_VERSION} \
-    -X github.com/aws/aws-k8s-tester/version.BuildTime=${BUILD_TIME}" \
-    -o ./bin/etcd-utils-${RELEASE_VERSION}-${os}-$(go env GOARCH) \
-    ./cmd/etcd-utils
-
-  CGO_ENABLED=0 GOOS=${os} GOARCH=$(go env GOARCH) \
-    go build -mod=vendor -v \
-    -ldflags "-s -w \
-    -X github.com/aws/aws-k8s-tester/version.GitCommit=${GIT_COMMIT} \
-    -X github.com/aws/aws-k8s-tester/version.ReleaseVersion=${RELEASE_VERSION} \
-    -X github.com/aws/aws-k8s-tester/version.BuildTime=${BUILD_TIME}" \
-    -o ./bin/s3-utils-${RELEASE_VERSION}-${os}-$(go env GOARCH) \
-    ./cmd/s3-utils
-
-  CGO_ENABLED=0 GOOS=${os} GOARCH=$(go env GOARCH) \
-    go build -mod=vendor -v \
-    -ldflags "-s -w \
-    -X github.com/aws/aws-k8s-tester/version.GitCommit=${GIT_COMMIT} \
-    -X github.com/aws/aws-k8s-tester/version.ReleaseVersion=${RELEASE_VERSION} \
-    -X github.com/aws/aws-k8s-tester/version.BuildTime=${BUILD_TIME}" \
-    -o ./bin/sts-utils-${RELEASE_VERSION}-${os}-$(go env GOARCH) \
-    ./cmd/sts-utils
+for os in ${TARGETS}; do
+  for cmd in ${WHAT}; do
+    echo "=== Building target=${cmd}, os=${os} ==="
+    CGO_ENABLED=0 GOOS=${os} GOARCH=$(go env GOARCH) \
+      go build -mod=vendor -v \
+      -ldflags "-s -w \
+      -X ${PACKAGE_NAME}/version.GitCommit=${GIT_COMMIT} \
+      -X ${PACKAGE_NAME}/version.ReleaseVersion=${RELEASE_VERSION} \
+      -X ${PACKAGE_NAME}/version.BuildTime=${BUILD_TIME}" \
+      -o ./bin/${cmd}-${RELEASE_VERSION}-${os}-$(go env GOARCH) \
+      ./cmd/${cmd}
+  done
 done
 
-if [[ "${OSTYPE}" == "linux-gnu" ]]; then
-  ./bin/aws-k8s-tester-${RELEASE_VERSION}-linux-$(go env GOARCH) version
-  ./bin/cw-utils-${RELEASE_VERSION}-linux-$(go env GOARCH) version
-  ./bin/ec2-utils-${RELEASE_VERSION}-linux-$(go env GOARCH) version
-  ./bin/ecr-utils-${RELEASE_VERSION}-linux-$(go env GOARCH) version
-  ./bin/eks-utils-${RELEASE_VERSION}-linux-$(go env GOARCH) version
-  ./bin/etcd-utils-${RELEASE_VERSION}-linux-$(go env GOARCH) version
-  ./bin/s3-utils-${RELEASE_VERSION}-linux-$(go env GOARCH) version
-  ./bin/sts-utils-${RELEASE_VERSION}-linux-$(go env GOARCH) version
-  cp ./bin/aws-k8s-tester-${RELEASE_VERSION}-linux-$(go env GOARCH) ./aws-k8s-tester
-elif [[ "${OSTYPE}" == "darwin"* ]]; then
-  ./bin/aws-k8s-tester-${RELEASE_VERSION}-darwin-$(go env GOARCH) version
-  ./bin/cw-utils-${RELEASE_VERSION}-darwin-$(go env GOARCH) version
-  ./bin/ec2-utils-${RELEASE_VERSION}-darwin-$(go env GOARCH) version
-  ./bin/ecr-utils-${RELEASE_VERSION}-darwin-$(go env GOARCH) version
-  ./bin/eks-utils-${RELEASE_VERSION}-darwin-$(go env GOARCH) version
-  ./bin/etcd-utils-${RELEASE_VERSION}-darwin-$(go env GOARCH) version
-  ./bin/s3-utils-${RELEASE_VERSION}-darwin-$(go env GOARCH) version
-  ./bin/sts-utils-${RELEASE_VERSION}-darwin-$(go env GOARCH) version
-fi
-
-echo "Success!"
-find ./bin
+echo ""
+echo "Success! Your shiny new binaries are ready."
+echo "find ./bin -type f"


### PR DESCRIPTION
```
make
```
```
WHAT=aws-k8s-tester TARGETS=darwin RELEASE_VERSION=latest ./scripts/build.sh
GIT_COMMIT: c7f87803ce5d
RELEASE_VERSION: latest
BUILD_TIME: 2020-07-22_18:49:11

Usage: `make TARGET='linux' WHAT='aws-k8s-tester cw-utils'`
DEFAULT_TARGETS=linux darwin
DEFAULT_WHAT=aws-k8s-tester cw-utils ec2-utils ecr-utils eks-utils etcd-utils s3-utils sts-utils

=== Building target=aws-k8s-tester, os=darwin ===

Success! Your shiny new binaries are ready.
find ./bin -type f
```