### PR TITLE
Adds config-as-yaml as a new environment variable AWS_K8S_TESTER_EKS_CONFIG

### DIFF
--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -468,6 +468,13 @@ func Load(p string) (cfg *Config, err error) {
 		return nil, err
 	}
 
+	// Apply overrides from AWS_K8S_TESTER_EKS_CONFIG
+	if env, ok := os.LookupEnv("AWS_K8S_TESTER_EKS_CONFIG"); ok {
+		if err := yaml.Unmarshal([]byte(env), cfg); err != nil {
+			return nil, err
+		}
+	}
+
 	cfg.mu = new(sync.RWMutex)
 	if cfg.ConfigPath != p {
 		cfg.ConfigPath = p


### PR DESCRIPTION
AWS_K8S_TESTER_EKS_CONFIG="
spec:
  clusterAutoscaler:
    cloudProvider: kubemark
    image: 767520670908.dkr.ecr.us-west-2.amazonaws.com/cluster-autoscaler-kubemark:custom-build-20200727
  overprovisioning:
    kubemarkEnabled: true
" \
AWS_K8S_TESTER_EKS_ON_FAILURE_DELETE=false \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE=true \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_CREATE=true \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS='{"default":{"name":"default","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id":"","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.16/amazon-linux-2/recommended/image_id","instance-types":["c5.xlarge"],"volume-size":40,"asg-min-size":3,"asg-max-size":3,"asg-desired-capacity":3,"kubelet-extra-args":"","cluster-autoscaler":{"enable":true}}}' \
AWS_K8S_TESTER_EKS_ADD_ON_IRSA_ENABLE=true \
AWS_K8S_TESTER_EKS_ADD_ON_IRSA_REPOSITORY_ACCOUNT_ID=607362164682 \
AWS_K8S_TESTER_EKS_ADD_ON_IRSA_REPOSITORY_NAME=aws/aws-k8s-tester \
AWS_K8S_TESTER_EKS_ADD_ON_IRSA_REPOSITORY_IMAGE_TAG=latest \
AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_ENABLE=true \
AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_NODES=1 \
AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_NODE_GROUPS=2 \
AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPOSITORY_ACCOUNT_ID=767520670908 \
AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPOSITORY_NAME=aws/aws-k8s-tester \
AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_REMOTE_REPOSITORY_IMAGE_TAG=latest \
akt eks create cluster --enable-prompt=true --path ./hollownodestest.yaml
