### PR TITLE
eks/cni-vpc: remove unused docker.sock

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -14,6 +14,7 @@ See [code changes](https://github.com/aws/aws-k8s-tester/compare/v1.4.8...v1.5.0
 ### `eks`
 
 - Add [`ClusterAutoscaler` addon with kubemark compatibility](https://github.com/aws/aws-k8s-tester/pull/137).
+- Remove [unused `docker.sock`](https://github.com/aws/aws-k8s-tester/pull/141).
 
 ### `Makefile`
 

--- a/eks/cni-vpc/cni-vpc.go
+++ b/eks/cni-vpc/cni-vpc.go
@@ -739,10 +739,6 @@ func (ts *tester) updateCNIDaemonSet() (err error) {
 							MountPath: "/var/run/aws-node",
 						},
 						{
-							Name:      "dockersock",
-							MountPath: "/var/run/docker.sock",
-						},
-						{
 							Name:      "dockershim",
 							MountPath: "/var/run/dockershim.sock",
 						},
@@ -765,14 +761,6 @@ func (ts *tester) updateCNIDaemonSet() (err error) {
 					VolumeSource: v1.VolumeSource{
 						HostPath: &v1.HostPathVolumeSource{
 							Path: "/etc/cni/net.d",
-						},
-					},
-				},
-				{
-					Name: "dockersock",
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{
-							Path: "/var/run/docker.sock",
 						},
 					},
 				},


### PR DESCRIPTION
ref. https://github.com/aws/amazon-vpc-cni-k8s/pull/1107