### PR TITLE
Refactor metrics-server to implement Addon interface

### DIFF
--- a/eks/eks.go
+++ b/eks/eks.go
@@ -500,6 +500,10 @@ func (ts *Tester) createTesters() (err error) {
 			Config:    ts.cfg,
 			K8sClient: ts.k8sClient,
 		},
+		&metrics_server.MetricsServer{
+			Config:    ts.cfg,
+			K8sClient: ts.k8sClient,
+		},
 	}}
 
 	ts.testers = []eks_tester.Tester{
@@ -1361,6 +1365,7 @@ func (ts *Tester) Up() (err error) {
 		}); err != nil {
 			return fmt.Errorf("while applying addons, %w", err)
 		}
+		ts.cfg.Sync()
 	}
 
 	return ts.cfg.Sync()

--- a/eks/metrics-server/addon.go
+++ b/eks/metrics-server/addon.go
@@ -1,0 +1,58 @@
+// Package metricsserver implements Kubernetes metrics server.
+// ref. https://github.com/kubernetes-sigs/metrics-server/releases
+package metricsserver
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-k8s-tester/eksconfig"
+	k8sclient "github.com/aws/aws-k8s-tester/pkg/k8s-client"
+	gotemplate "github.com/aws/aws-k8s-tester/pkg/util"
+)
+
+// MetricsServer is an addon that installs Metrics Server
+type MetricsServer struct {
+	K8sClient k8sclient.EKS
+	Config    *eksconfig.Config
+}
+
+// IsEnabled returns true if enabled
+func (c *MetricsServer) IsEnabled() bool {
+	return c.Config.Spec.MetricsServer != nil
+}
+
+// Apply installs the addon
+func (c *MetricsServer) Apply() (err error) {
+	template, err := gotemplate.FromLocalDirectory(c.Config.Spec.MetricsServer)
+	if err != nil {
+		return fmt.Errorf("while building templates, %v", err)
+	}
+	if err := c.K8sClient.Apply(template.String()); err != nil {
+		return fmt.Errorf("while applying resources, %v", err)
+	}
+	c.Config.Status.MetricsServer = &eksconfig.MetricsServerStatus{
+		AddonStatus: eksconfig.AddonStatus{
+			Installed: true,
+			Ready:     true,
+		},
+	}
+	return nil
+}
+
+// Delete removes the addon
+func (c *MetricsServer) Delete() (err error) {
+	template, err := gotemplate.FromLocalDirectory(c.Config.Spec.MetricsServer)
+	if err != nil {
+		return fmt.Errorf("while building templates, %v", err)
+	}
+	if err := c.K8sClient.Delete(template.String()); err != nil {
+		return fmt.Errorf("while deleting resources, %v", err)
+	}
+	c.Config.Status.MetricsServer = &eksconfig.MetricsServerStatus{
+		AddonStatus: eksconfig.AddonStatus{
+			Installed: false,
+			Ready:     false,
+		},
+	}
+	return nil
+}

--- a/eks/metrics-server/metrics-server.gotmpl
+++ b/eks/metrics-server/metrics-server.gotmpl
@@ -1,0 +1,164 @@
+# ref. https://docs.aws.amazon.com/eks/latest/userguide/dashboard-tutorial.html
+# ref. https://github.com/kubernetes-sigs/metrics-server/releases
+# ref. https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregated-metrics-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+spec:
+  service:
+    name: metrics-server
+    namespace: kube-system
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  template:
+    metadata:
+      name: metrics-server
+      labels:
+        k8s-app: metrics-server
+    spec:
+      serviceAccountName: metrics-server
+      volumes:
+      # mount in tmp so we can safely use from-scratch images and/or read-only containers
+      - name: tmp-dir
+        emptyDir: {}
+      containers:
+      - name: metrics-server
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        imagePullPolicy: IfNotPresent
+        args:
+        - --cert-dir=/tmp
+        - --secure-port=4443
+        - --kubelet-insecure-tls
+        - --kubelet-preferred-address-types=InternalIP
+        ports:
+        - name: main-port
+          containerPort: 4443
+          protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts:
+        - name: tmp-dir
+          mountPath: /tmp
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: "amd64"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/name: "Metrics-server"
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    k8s-app: metrics-server
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: main-port
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  - namespaces
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/eksconfig/metrics-server.go
+++ b/eksconfig/metrics-server.go
@@ -1,0 +1,18 @@
+package eksconfig
+
+// MetricsServerSpec defines the spec for the Addon
+type MetricsServerSpec struct {
+}
+
+// MetricsServerStatus defines the status for the Addon
+type MetricsServerStatus struct {
+	AddonStatus `json:",inline"`
+}
+
+// Validate installs the addon
+func (spec *MetricsServerSpec) Validate(cfg *Config) error {
+	return nil
+}
+
+// Default installs the addon
+func (spec *MetricsServerSpec) Default(cfg *Config) {}

--- a/eksconfig/spec.go
+++ b/eksconfig/spec.go
@@ -6,4 +6,6 @@ type Spec struct {
 	ClusterAutoscaler *ClusterAutoscalerSpec `json:"clusterAutoscaler,omitempty"`
 	// Overprovisioning defines the addon's spec
 	Overprovisioning *OverprovisioningSpec `json:"overprovisioning,omitempty"`
+	// MetricsServer defines the addon's spec
+	MetricsServer *MetricsServerSpec `json:"metricsServer,omitempty"`
 }

--- a/eksconfig/status.go
+++ b/eksconfig/status.go
@@ -69,6 +69,8 @@ type Status struct {
 	ClusterAutoscaler *ClusterAutoscalerStatus `json:"clusterAutoscaler,omitempty"`
 	// Overprovisioning defines the addon's status
 	Overprovisioning *OverprovisioningStatus `json:"overprovisioning,omitempty"`
+	// MetricsServer defines the addon's status
+	MetricsServer *MetricsServerStatus `json:"metricsServer,omitempty"`
 
 	// PrivateDNSToNodeInfo maps each worker node's private IP to its public IP,
 	// public DNS, and SSH access user name.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I refactored metrics-server to implement the Addon interface using overprovisioning and clusterautoscaler as references. Now, we can include `metrics-server` in the spec for `AWS_K8S_TESTER_EKS_CONFIG`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
