### PR TITLE
pkg/aws/ec2: add "WaitUntilRunning"

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -40,7 +40,7 @@ See [code changes](https://github.com/aws/aws-k8s-tester/compare/v1.4.8...v1.5.0
 
 ### `pkg/aws`
 
-- Add [`pkg/aws/ec2.PollASGUntilRunning`](https://github.com/aws/aws-k8s-tester/pull/153).
+- Add [`pkg/aws/ec2.WaitUntilRunning`](https://github.com/aws/aws-k8s-tester/pull/153).
 
 ### Dependency
 

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -38,6 +38,10 @@ See [code changes](https://github.com/aws/aws-k8s-tester/compare/v1.4.8...v1.5.0
 
 - Rename [`scripts` to `hack` for parity with Kubernetes projects](https://github.com/aws/aws-k8s-tester/pull/136).
 
+### `pkg/aws`
+
+- Add [`pkg/aws/ec2.PollASGUntilRunning`](https://github.com/aws/aws-k8s-tester/pull/153).
+
 ### Dependency
 
 - Upgrade [`github.com/aws/aws-sdk-go`](https://github.com/aws/aws-sdk-go/releases) from [`v1.33.8`](https://github.com/aws/aws-sdk-go/releases/tag/v1.33.8) to [`v1.33.18`](https://github.com/aws/aws-sdk-go/releases/tag/v1.33.18).

--- a/ec2/asgs.go
+++ b/ec2/asgs.go
@@ -587,10 +587,9 @@ func (ts *Tester) createASGs() (err error) {
 
 		waitDur := 10*time.Minute + 10*time.Second*time.Duration(cur.ASGDesiredCapacity)
 		ctx, cancel = context.WithTimeout(context.Background(), waitDur)
-		ec2Instances, err := aws_ec2.PollASGUntilRunning(
+		ec2Instances, err := aws_ec2.WaitUntilRunning(
 			ctx,
 			ts.stopCreationCh,
-			ts.lg,
 			ts.asgAPI,
 			ts.ec2API,
 			asgName,

--- a/eks/clusterautoscaler/clusterautoscaler.go
+++ b/eks/clusterautoscaler/clusterautoscaler.go
@@ -3,6 +3,7 @@ package clusterautoscaler
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/aws/aws-k8s-tester/eksconfig"
 	k8sclient "github.com/aws/aws-k8s-tester/pkg/k8s-client"
 	gotemplate "github.com/aws/aws-k8s-tester/pkg/util"

--- a/eks/eks.go
+++ b/eks/eks.go
@@ -175,6 +175,7 @@ func New(cfg *eksconfig.Config) (ts *Tester, err error) {
 	if err != nil {
 		return nil, err
 	}
+	_ = zap.ReplaceGlobals(lg)
 	lg.Info("set up log writer and file", zap.Strings("outputs", cfg.LogOutputs))
 
 	isColor := cfg.LogColor

--- a/eks/mng/wait/wait.go
+++ b/eks/mng/wait/wait.go
@@ -116,10 +116,9 @@ func (ts *tester) waitForNodes(mngName string, retriesLeft int) error {
 	}
 	waitDur := 10*time.Minute + 10*time.Second*checkN
 	ctx, cancel := context.WithTimeout(context.Background(), waitDur)
-	ec2Instances, err := aws_ec2.PollASGUntilRunning(
+	ec2Instances, err := aws_ec2.WaitUntilRunning(
 		ctx,
 		ts.cfg.Stopc,
-		ts.cfg.Logger,
 		ts.cfg.ASGAPI,
 		ts.cfg.EC2API,
 		cur.ASGName,

--- a/eks/ng/wait/wait.go
+++ b/eks/ng/wait/wait.go
@@ -90,10 +90,9 @@ func (ts *tester) waitForNodes(asgName string, retriesLeft int) error {
 	}
 	waitDur := 10*time.Minute + 10*time.Second*checkN
 	ctx, cancel := context.WithTimeout(context.Background(), waitDur)
-	ec2Instances, err := aws_ec2.PollASGUntilRunning(
+	ec2Instances, err := aws_ec2.WaitUntilRunning(
 		ctx,
 		ts.cfg.Stopc,
-		ts.cfg.Logger,
 		ts.cfg.ASGAPI,
 		ts.cfg.EC2API,
 		cur.Name,


### PR DESCRIPTION
Fix a case when ASG has >500 instances and some instances become stale while polling.

Tests:

```
{"level":"info","ts":"2020-08-05T19:31:50.408-0700","caller":"wait/wait.go:71","msg":"checking ASG","asg-name":"eks-2020080519-charismau3mi-ng-al2-cpu-c518xlarge"}
{"level":"info","ts":"2020-08-05T19:31:50.873-0700","caller":"ec2/ec2.go:29","msg":"polling ASG","asg-name":"eks-2020080519-charismau3mi-ng-al2-cpu-c518xlarge","ctx-time-left":"1h33m19.999997228s"}
{"level":"info","ts":"2020-08-05T19:32:01.535-0700","caller":"ec2/ec2.go:103","msg":"polling instance status","target-total":500,"ctx-time-left":"24m59.999955031s"}
{"level":"info","ts":"2020-08-05T19:32:11.536-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:32:12.807-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":8,"running-instances-so-far":30,"target-total":500}
{"level":"info","ts":"2020-08-05T19:32:22.807-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:32:23.100-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":9,"running-instances-so-far":60,"target-total":500}
{"level":"info","ts":"2020-08-05T19:32:33.101-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:32:33.515-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":8,"running-instances-so-far":90,"target-total":500}
{"level":"info","ts":"2020-08-05T19:32:43.516-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:32:44.964-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":7,"running-instances-so-far":120,"target-total":500}
{"level":"info","ts":"2020-08-05T19:32:54.965-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:32:55.435-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":9,"running-instances-so-far":150,"target-total":500}
{"level":"info","ts":"2020-08-05T19:33:05.435-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:33:05.752-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":8,"running-instances-so-far":180,"target-total":500}
{"level":"info","ts":"2020-08-05T19:33:15.753-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:33:16.318-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":9,"running-instances-so-far":210,"target-total":500}
{"level":"info","ts":"2020-08-05T19:33:26.318-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:33:26.790-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":8,"running-instances-so-far":240,"target-total":500}
{"level":"info","ts":"2020-08-05T19:33:36.790-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:33:37.206-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":7,"running-instances-so-far":270,"target-total":500}
{"level":"info","ts":"2020-08-05T19:33:47.206-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:33:47.521-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":9,"running-instances-so-far":300,"target-total":500}
{"level":"info","ts":"2020-08-05T19:33:57.521-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:33:57.867-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":8,"running-instances-so-far":330,"target-total":500}
{"level":"info","ts":"2020-08-05T19:34:07.867-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:34:08.159-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":9,"running-instances-so-far":360,"target-total":500}
{"level":"info","ts":"2020-08-05T19:34:18.159-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:34:18.476-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":8,"running-instances-so-far":390,"target-total":500}
{"level":"info","ts":"2020-08-05T19:34:28.477-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:34:28.833-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":7,"running-instances-so-far":420,"target-total":500}
{"level":"info","ts":"2020-08-05T19:34:38.834-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:34:39.172-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":8,"running-instances-so-far":450,"target-total":500}
{"level":"info","ts":"2020-08-05T19:34:49.172-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":30}
{"level":"info","ts":"2020-08-05T19:34:49.526-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":8,"running-instances-so-far":480,"target-total":500}
{"level":"info","ts":"2020-08-05T19:34:59.526-0700","caller":"ec2/ec2.go:126","msg":"describing batch","batch-total":20}
{"level":"info","ts":"2020-08-05T19:34:59.961-0700","caller":"ec2/ec2.go:147","msg":"checking ec2 instances","reservations":7,"running-instances-so-far":500,"target-total":500}
{"level":"info","ts":"2020-08-05T19:35:00.130-0700","caller":"wait/wait.go:142","msg":"checking nodes readiness","wait":"1h33m20s"}
{"level":"info","ts":"2020-08-05T19:35:05.131-0700","caller":"k8s-client/eks.go:926","msg":"listing nodes","batch-limit":1000,"batch-interval":"5s"}
{"level":"info","ts":"2020-08-05T19:35:06.197-0700","caller":"k8s-client/eks.go:940","msg":"nodes","remained":0,"items":500}
{"level":"info","ts":"2020-08-05T19:35:06.197-0700","caller":"k8s-client/eks.go:949","msg":"listed nodes","nodes":500}
{"level":"info","ts":"2020-08-05T19:35:06.204-0700","caller":"k8s-client/eks.go:959","msg":"listing csrs","batch-limit":1000,"batch-interval":"5s"}
{"level":"info","ts":"2020-08-05T19:35:06.554-0700","caller":"k8s-client/eks.go:976","msg":"csrs","remained":0,"items":500}
{"level":"info","ts":"2020-08-05T19:35:06.555-0700","caller":"k8s-client/eks.go:985","msg":"listed csrs","csrs":500}
{"level":"info","ts":"2020-08-05T19:35:06.555-0700","caller":"wait/wait.go:257","msg":"polling nodes","command":"/tmp/kubectl-test-v1.17.6 --kubeconfig=/tmp/eks-2020080519-charismau3mi.kubeconfig.yaml get nodes","ng-name":"eks-2020080519-charismau3mi-ng-al2-cpu-c518xlarge","current-ready-nodes":500,"min-ready-nodes":500,"desired-ready-nodes":500,"all-csrs":"map[Approved,Issued:500]"}
```