### PR TITLE
pkg/aws/ec2: set minimum wait time for ec2 polling

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -70,8 +70,9 @@ func WaitUntilRunning(
 			}
 		}
 
-		// 25-minute for 500 nodes
-		waitDur := 3 * time.Second * time.Duration(len(instanceIDs))
+		// minimum waits for small number of node + extra waits for large number of nodes
+		// e.g. 5-minute + 25-minute for 500 nodes
+		waitDur := 5*time.Minute + 3*time.Second*time.Duration(len(instanceIDs))
 		ctx2, cancel := context.WithTimeout(ctx, waitDur)
 		ec2Instances, err = pollUntilRunning(ctx2, stopc, ec2API, instanceIDs...)
 		cancel()


### PR DESCRIPTION
Fix the case creating 2-node ASG fails due to timeouts:

```
{"level":"info","msg":"checking ASG","asg-name":"eks-2020081315-everesttishn-ng-al2-cpu"}
{"level":"info","msg":"polling ASG until all EC2 instances are running","asg-name":"eks-2020081315-everesttishn-ng-al2-cpu","ctx-time-left":"10m19.999996088s"}
{"level":"info","msg":"polling instance status","target-total":2,"ctx-time-left":"5.999992891s"}
{"level":"warn","msg":"failed to poll instance status; retrying","error":"context deadline exceeded"}
{"level":"info","msg":"polling instance status","target-total":2,"ctx-time-left":"5.999993504s"}
{"level":"warn","msg":"failed to poll instance status; retrying","error":"context deadline exceeded"}
{"level":"info","msg":"polling instance status","target-total":2,"ctx-time-left":"5.999991503s"}
{"level":"warn","msg":"failed to poll instance status; retrying","error":"context deadline exceeded"}
{"level":"info","msg":"polling instance status","target-total":2,"ctx-time-left":"5.999992861s"}
{"level":"warn","msg":"failed to poll instance status; retrying","error":"context deadline exceeded"}
{"level":"info","msg":"polling instance status","target-total":2,"ctx-time-left":"5.999994489s"}
{"level":"warn","msg":"failed to poll instance status; retrying","error":"context deadline exceeded"}
{"level":"info","msg":"polling instance status","target-total":2,"ctx-time-left":"5.999994177s"}
{"level":"warn","msg":"failed to poll instance status; retrying","error":"context deadline exceeded"}
```

Signed-off-by: Gyuho Lee <leegyuho@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
