### PR TITLE
CL2 TestOverrides capabilities added

### DIFF
--- a/eksconfig/cluster-loader.go
+++ b/eksconfig/cluster-loader.go
@@ -6,6 +6,7 @@ type ClusterLoaderSpec struct {
 	TestConfigUris []string `json:"testConfigUris,omitempty"`
 	TestParams     []string `json:"testParams,omitempty"`
 	S3Uri          string   `json:"s3Uri,omitempty"`
+	TestOverrides  []string `json:"testOverrides,omitempty"`
 }
 
 // MetricsServerStatus defines the status for the Addon


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In clusterloader2, there are some basic flags that drive the shared functionality between different test configurations, such as --nodes or --report-dir, but to further configure your test, you'd need to change your variables in the yaml, such as having a pods_per_node, num_of_namespaces, or enable_chaosmonkey variables. This allows total automation of tests, and by adding override fields, you can configure the test just as well as if it was in the CLI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
