### PR TITLE
Added EKS folder to Dockerfile for prow job filesystem fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY --from=aws-k8s-tester-builder /go/src/github.com/aws/aws-k8s-tester/bin/sts
 COPY --from=aws-k8s-tester-builder /go/src/github.com/aws/aws-k8s-tester/_tmp/clusterloader2-testing-load/ /
 COPY --from=aws-k8s-tester-builder /go/src/github.com/aws/aws-k8s-tester/_tmp/clusterloader2-testing-load/config.yaml /clusterloader2-test-config.yaml
 COPY --from=aws-k8s-tester-builder /go/src/github.com/aws/aws-k8s-tester/_tmp/clusterloader2 /clusterloader2
+COPY --from=aws-k8s-tester-builder /go/src/github.com/aws/aws-k8s-tester/eks /eks
 RUN rm -rf /go/src/github.com/aws/aws-k8s-tester
 RUN chmod +x /aws-k8s-tester /cw-utils /ec2-utils /eks-utils /etcd-utils /s3-utils /sts-utils /clusterloader2
 WORKDIR /


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While running prow jobs, the add-on templates cannot be read as they are not copied into the filesystem. As the EKS folder will be able to host different future add-ons and is not limited to the current 4 implemented, copying the folder provides a general solution that provides the same filesystem logic as if running on a local machine. 

Additionally, the eks folder only adds 5MB to the dockerfile, which is already ~750MB.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
