### PR TITLE
eks/cluster: fix OIDC CA thumbprint fetch 

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -3,6 +3,26 @@
 <hr>
 
 
+## [v1.5.3](https://github.com/aws/aws-k8s-tester/releases/tag/v1.5.3) (2020-09)
+
+See [code changes](https://github.com/aws/aws-k8s-tester/compare/v1.5.2...v1.5.3).
+
+### `eks`
+
+- Fix [`eks/cluster` status update panic issue](https://github.com/aws/aws-k8s-tester/pull/TODO).
+
+### Dependency
+
+- Upgrade [`github.com/aws/aws-sdk-go`](https://github.com/aws/aws-sdk-go/releases) from [`v1.34.22`](https://github.com/aws/aws-sdk-go/releases/tag/v1.34.22) to [`v1.34.32`](https://github.com/aws/aws-sdk-go/releases/tag/v1.34.32).
+
+### Go
+
+- Compile with [*Go 1.15.2*](https://golang.org/doc/devel/release.html#go1.15).
+
+
+<hr>
+
+
 ## [v1.5.2](https://github.com/aws/aws-k8s-tester/releases/tag/v1.5.2) (2020-09-12)
 
 See [code changes](https://github.com/aws/aws-k8s-tester/compare/v1.5.1...v1.5.2).

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ replace (
 )
 
 require (
-	github.com/aws/aws-sdk-go v1.34.22
+	github.com/aws/aws-sdk-go v1.34.32
 	github.com/briandowns/spinner v1.11.1
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7/go.mod h1:
 github.com/aws/aws-sdk-go v1.6.10/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.28.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.34.22 h1:7V2sKilVVgHqdjbW+O/xaVWYfnmuLwZdF/+6JuUh6Cw=
-github.com/aws/aws-sdk-go v1.34.22/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.34.32 h1:EHjowHEGXyLHWhcO7M7AVA+oA2c8aLE9WfRvqHwxd3A=
+github.com/aws/aws-sdk-go v1.34.32/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/bazelbuild/bazel-gazelle v0.18.2/go.mod h1:D0ehMSbS+vesFsLGiD6JXu3mVEzOlfUl8wNnq+x/9p0=
 github.com/bazelbuild/bazel-gazelle v0.19.1-0.20191105222053-70208cbdc798/go.mod h1:rPwzNHUqEzngx1iVBfO/2X2npKaT3tqPqqHW6rVsn/A=
 github.com/bazelbuild/buildtools v0.0.0-20190731111112-f720930ceb60/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
@@ -560,8 +560,10 @@ github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mo
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
-github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
-github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -349,6 +349,7 @@ var awsPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
+				"af-south-1":     endpoint{},
 				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
@@ -358,6 +359,7 @@ var awsPartition = partition{
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-north-1":     endpoint{},
+				"eu-south-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -1203,6 +1205,7 @@ var awsPartition = partition{
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-north-1":     endpoint{},
+				"eu-south-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -1250,6 +1253,7 @@ var awsPartition = partition{
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-north-1":     endpoint{},
+				"eu-south-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -2196,6 +2200,7 @@ var awsPartition = partition{
 				"sa-east-1":  endpoint{},
 				"us-east-1":  endpoint{},
 				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
 				"us-west-2":  endpoint{},
 			},
 		},
@@ -2705,6 +2710,7 @@ var awsPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
+				"af-south-1":     endpoint{},
 				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
@@ -2714,6 +2720,7 @@ var awsPartition = partition{
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-north-1":     endpoint{},
+				"eu-south-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -3013,6 +3020,7 @@ var awsPartition = partition{
 		"groundstation": service{
 
 			Endpoints: endpoints{
+				"af-south-1":     endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
@@ -3429,6 +3437,7 @@ var awsPartition = partition{
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-north-1":     endpoint{},
+				"eu-south-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -4190,6 +4199,24 @@ var awsPartition = partition{
 		"oidc": service{
 
 			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{
+					Hostname: "oidc.ap-northeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+				},
+				"ap-northeast-2": endpoint{
+					Hostname: "oidc.ap-northeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-2",
+					},
+				},
+				"ap-south-1": endpoint{
+					Hostname: "oidc.ap-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-south-1",
+					},
+				},
 				"ap-southeast-1": endpoint{
 					Hostname: "oidc.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -4678,9 +4705,16 @@ var awsPartition = partition{
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"rekognition-fips.ca-central-1": endpoint{
+					Hostname: "rekognition-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
 				"rekognition-fips.us-east-1": endpoint{
 					Hostname: "rekognition-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -5532,6 +5566,12 @@ var awsPartition = partition{
 					Hostname: "snowball-fips.ap-northeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-2",
+					},
+				},
+				"fips-ap-northeast-3": endpoint{
+					Hostname: "snowball-fips.ap-northeast-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-3",
 					},
 				},
 				"fips-ap-south-1": endpoint{
@@ -7864,6 +7904,13 @@ var awsusgovPartition = partition{
 				},
 			},
 		},
+		"ebs": service{
+
+			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
+				"us-gov-west-1": endpoint{},
+			},
+		},
 		"ec2": service{
 
 			Endpoints: endpoints{
@@ -8141,7 +8188,12 @@ var awsusgovPartition = partition{
 		"health": service{
 
 			Endpoints: endpoints{
-				"us-gov-west-1": endpoint{},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "health-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 			},
 		},
 		"iam": service{
@@ -8524,7 +8576,7 @@ var awsusgovPartition = partition{
 			},
 			Endpoints: endpoints{
 				"fips-us-gov-west-1": endpoint{
-					Hostname: "s3-fips-us-gov-west-1.amazonaws.com",
+					Hostname: "s3-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.34.22"
+const SDKVersion = "1.34.32"

--- a/vendor/github.com/aws/aws-sdk-go/service/eks/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/eks/api.go
@@ -2630,6 +2630,9 @@ type Cluster struct {
 	// The identity provider information for the cluster.
 	Identity *Identity `locationName:"identity" type:"structure"`
 
+	// Network configuration settings for your cluster.
+	KubernetesNetworkConfig *KubernetesNetworkConfigResponse `locationName:"kubernetesNetworkConfig" type:"structure"`
+
 	// The logging configuration for your cluster.
 	Logging *Logging `locationName:"logging" type:"structure"`
 
@@ -2718,6 +2721,12 @@ func (s *Cluster) SetIdentity(v *Identity) *Cluster {
 	return s
 }
 
+// SetKubernetesNetworkConfig sets the KubernetesNetworkConfig field's value.
+func (s *Cluster) SetKubernetesNetworkConfig(v *KubernetesNetworkConfigResponse) *Cluster {
+	s.KubernetesNetworkConfig = v
+	return s
+}
+
 // SetLogging sets the Logging field's value.
 func (s *Cluster) SetLogging(v *Logging) *Cluster {
 	s.Logging = v
@@ -2775,6 +2784,9 @@ type CreateClusterInput struct {
 
 	// The encryption configuration for the cluster.
 	EncryptionConfig []*EncryptionConfig `locationName:"encryptionConfig" type:"list"`
+
+	// The Kubernetes network configuration for the cluster.
+	KubernetesNetworkConfig *KubernetesNetworkConfigRequest `locationName:"kubernetesNetworkConfig" type:"structure"`
 
 	// Enable or disable exporting the Kubernetes control plane logs for your cluster
 	// to CloudWatch Logs. By default, cluster control plane logs aren't exported
@@ -2864,6 +2876,12 @@ func (s *CreateClusterInput) SetClientRequestToken(v string) *CreateClusterInput
 // SetEncryptionConfig sets the EncryptionConfig field's value.
 func (s *CreateClusterInput) SetEncryptionConfig(v []*EncryptionConfig) *CreateClusterInput {
 	s.EncryptionConfig = v
+	return s
+}
+
+// SetKubernetesNetworkConfig sets the KubernetesNetworkConfig field's value.
+func (s *CreateClusterInput) SetKubernetesNetworkConfig(v *KubernetesNetworkConfigRequest) *CreateClusterInput {
+	s.KubernetesNetworkConfig = v
 	return s
 }
 
@@ -3075,9 +3093,9 @@ type CreateNodegroupInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AMI type for your node group. GPU instance types should use the AL2_x86_64_GPU
-	// AMI type, which uses the Amazon EKS-optimized Linux AMI with GPU support.
-	// Non-GPU instances should use the AL2_x86_64 AMI type, which uses the Amazon
-	// EKS-optimized Linux AMI. If you specify launchTemplate, and your launch template
+	// AMI type. Non-GPU instances should use the AL2_x86_64 AMI type. Arm instances
+	// should use the AL2_ARM_64 AMI type. All types use the Amazon EKS-optimized
+	// Amazon Linux 2 AMI. If you specify launchTemplate, and your launch template
 	// uses a custom AMI, then don't specify amiType, or the node group deployment
 	// will fail. For more information about using launch templates with Amazon
 	// EKS, see Launch template support (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
@@ -3115,8 +3133,8 @@ type CreateNodegroupInput struct {
 	Labels map[string]*string `locationName:"labels" type:"map"`
 
 	// An object representing a node group's launch template specification. If specified,
-	// then do not specify instanceTypes, diskSize, or remoteAccess. If specified,
-	// make sure that the launch template meets the requirements in launchTemplateSpecification.
+	// then do not specify instanceTypes, diskSize, or remoteAccess and make sure
+	// that the launch template meets the requirements in launchTemplateSpecification.
 	LaunchTemplate *LaunchTemplateSpecification `locationName:"launchTemplate" type:"structure"`
 
 	// The Amazon Resource Name (ARN) of the IAM role to associate with your node
@@ -4377,6 +4395,72 @@ func (s *Issue) SetResourceIds(v []*string) *Issue {
 	return s
 }
 
+// The Kubernetes network configuration for the cluster.
+type KubernetesNetworkConfigRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The CIDR block to assign Kubernetes service IP addresses from. If you don't
+	// specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16
+	// or 172.20.0.0/16 CIDR blocks. We recommend that you specify a block that
+	// does not overlap with resources in other networks that are peered or connected
+	// to your VPC. The block must meet the following requirements:
+	//
+	//    * Within one of the following private IP address blocks: 10.0.0.0/8, 172.16.0.0.0/12,
+	//    or 192.168.0.0/16.
+	//
+	//    * Doesn't overlap with any CIDR block assigned to the VPC that you selected
+	//    for VPC.
+	//
+	//    * Between /24 and /12.
+	//
+	// You can only specify a custom CIDR block when you create a cluster and can't
+	// change this value once the cluster is created.
+	ServiceIpv4Cidr *string `locationName:"serviceIpv4Cidr" type:"string"`
+}
+
+// String returns the string representation
+func (s KubernetesNetworkConfigRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s KubernetesNetworkConfigRequest) GoString() string {
+	return s.String()
+}
+
+// SetServiceIpv4Cidr sets the ServiceIpv4Cidr field's value.
+func (s *KubernetesNetworkConfigRequest) SetServiceIpv4Cidr(v string) *KubernetesNetworkConfigRequest {
+	s.ServiceIpv4Cidr = &v
+	return s
+}
+
+// The Kubernetes network configuration for the cluster.
+type KubernetesNetworkConfigResponse struct {
+	_ struct{} `type:"structure"`
+
+	// The CIDR block that Kubernetes service IP addresses are assigned from. If
+	// you didn't specify a CIDR block, then Kubernetes assigns addresses from either
+	// the 10.100.0.0/16 or 172.20.0.0/16 CIDR blocks. If this was specified, then
+	// it was specified when the cluster was created and it cannot be changed.
+	ServiceIpv4Cidr *string `locationName:"serviceIpv4Cidr" type:"string"`
+}
+
+// String returns the string representation
+func (s KubernetesNetworkConfigResponse) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s KubernetesNetworkConfigResponse) GoString() string {
+	return s.String()
+}
+
+// SetServiceIpv4Cidr sets the ServiceIpv4Cidr field's value.
+func (s *KubernetesNetworkConfigResponse) SetServiceIpv4Cidr(v string) *KubernetesNetworkConfigResponse {
+	s.ServiceIpv4Cidr = &v
+	return s
+}
+
 // An object representing a node group launch template specification. The launch
 // template cannot include SubnetId (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkInterface.html),
 // IamInstanceProfile (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IamInstanceProfile.html),
@@ -4997,7 +5081,7 @@ type Nodegroup struct {
 
 	// If the node group wasn't deployed with a launch template, then this is the
 	// disk size in the node group configuration. If the node group was deployed
-	// with a launch template, then diskSize is null.
+	// with a launch template, then this is null.
 	DiskSize *int64 `locationName:"diskSize" type:"integer"`
 
 	// The health status of the node group. If there are issues with your node group's
@@ -5006,7 +5090,7 @@ type Nodegroup struct {
 
 	// If the node group wasn't deployed with a launch template, then this is the
 	// instance type that is associated with the node group. If the node group was
-	// deployed with a launch template, then instanceTypes is null.
+	// deployed with a launch template, then this is null.
 	InstanceTypes []*string `locationName:"instanceTypes" type:"list"`
 
 	// The Kubernetes labels applied to the nodes in the node group.
@@ -5043,7 +5127,7 @@ type Nodegroup struct {
 
 	// If the node group wasn't deployed with a launch template, then this is the
 	// remote access configuration that is associated with the node group. If the
-	// node group was deployed with a launch template, then remoteAccess is null.
+	// node group was deployed with a launch template, then this is null.
 	RemoteAccess *RemoteAccessConfig `locationName:"remoteAccess" type:"structure"`
 
 	// The resources associated with the node group, such as Auto Scaling groups

--- a/vendor/github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/doc.go
@@ -100,6 +100,8 @@
 //
 //    * AWS CodeCommit (https://docs.aws.amazon.com/codecommit)
 //
+//    * AWS CodeGuru Profiler (https://docs.aws.amazon.com/codeguru/latest/profiler-ug/)
+//
 //    * AWS CodePipeline (https://docs.aws.amazon.com/codepipeline)
 //
 //    * AWS CodeStar (https://docs.aws.amazon.com/codestar)
@@ -150,6 +152,8 @@
 //
 //    * Elastic Load Balancing (https://docs.aws.amazon.com/elasticloadbalancing)
 //
+//    * Amazon Elastic Inference (https://docs.aws.amazon.com/elastic-inference)
+//
 //    * Amazon ElastiCache (https://docs.aws.amazon.com/elasticache)
 //
 //    * Amazon Elasticsearch Service (https://docs.aws.amazon.com/elasticsearch-service)
@@ -168,6 +172,10 @@
 //
 //    * AWS Firewall Manager (https://docs.aws.amazon.com/firewall-manager)
 //
+//    * Amazon Forecast (https://docs.aws.amazon.com/forecast)
+//
+//    * Amazon Fraud Detector (https://docs.aws.amazon.com/frauddetector)
+//
 //    * Amazon FSx (https://docs.aws.amazon.com/fsx)
 //
 //    * Amazon S3 Glacier (https://docs.aws.amazon.com/s3/?id=docs_gateway#amazon-s3-glacier)
@@ -181,6 +189,8 @@
 //    * Amazon GuardDuty (https://docs.aws.amazon.com/guardduty)
 //
 //    * Amazon Inspector (https://docs.aws.amazon.com/inspector)
+//
+//    * Amazon Interactive Video Service (https://docs.aws.amazon.com/ivs)
 //
 //    * AWS IoT Analytics (https://docs.aws.amazon.com/iotanalytics)
 //
@@ -216,6 +226,8 @@
 //
 //    * AWS License Manager (https://docs.aws.amazon.com/license-manager)
 //
+//    * Amazon Lightsail (https://docs.aws.amazon.com/lightsail)
+//
 //    * Amazon Macie (https://docs.aws.amazon.com/macie)
 //
 //    * Amazon Machine Learning (https://docs.aws.amazon.com/machine-learning)
@@ -224,7 +236,11 @@
 //
 //    * Amazon MSK (https://docs.aws.amazon.com/msk)
 //
+//    * Amazon MSK (https://docs.aws.amazon.com/msk)
+//
 //    * Amazon Neptune (https://docs.aws.amazon.com/neptune)
+//
+//    * AWS Network Manager (https://docs.aws.amazon.com/vpc/latest/tgw/what-is-network-manager.html)
 //
 //    * AWS OpsWorks (https://docs.aws.amazon.com/opsworks)
 //
@@ -280,7 +296,7 @@
 //
 //    * Amazon VPC (https://docs.aws.amazon.com/vpc)
 //
-//    * AWS WAFv2 (https://docs.aws.amazon.com/waf)
+//    * AWS WAF (https://docs.aws.amazon.com/waf)
 //
 //    * AWS WAF Regional (https://docs.aws.amazon.com/waf)
 //

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/pool.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/pool.go
@@ -60,6 +60,14 @@ func (p *maxSlicePool) Get(ctx aws.Context) (*[]byte, error) {
 				return nil, errZeroCapacity
 			}
 			return bs, nil
+		case <-ctx.Done():
+			p.mtx.RUnlock()
+			return nil, ctx.Err()
+		default:
+			// pass
+		}
+
+		select {
 		case _, ok := <-p.allocations:
 			p.mtx.RUnlock()
 			if !ok {

--- a/vendor/github.com/aws/aws-sdk-go/service/ssm/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ssm/api.go
@@ -15852,10 +15852,10 @@ type AttachmentsSource struct {
 	// to a document. The format for Value depends on the type of key you specify.
 	//
 	//    * For the key SourceUrl, the value is an S3 bucket location. For example:
-	//    "Values": [ "s3://my-bucket/my-folder" ]
+	//    "Values": [ "s3://doc-example-bucket/my-folder" ]
 	//
 	//    * For the key S3FileUrl, the value is a file in an S3 bucket. For example:
-	//    "Values": [ "s3://my-bucket/my-folder/my-file.py" ]
+	//    "Values": [ "s3://doc-example-bucket/my-folder/my-file.py" ]
 	//
 	//    * For the key AttachmentReference, the value is constructed from the name
 	//    of another SSM document in your account, a version number of that document,
@@ -17497,13 +17497,13 @@ type CommandPlugin struct {
 	// This was requested when issuing the command. For example, in the following
 	// response:
 	//
-	// test_folder/ab19cb99-a030-46dd-9dfc-8eSAMPLEPre-Fix/i-1234567876543/awsrunShellScript
+	// doc-example-bucket/ab19cb99-a030-46dd-9dfc-8eSAMPLEPre-Fix/i-02573cafcfEXAMPLE/awsrunShellScript
 	//
-	// test_folder is the name of the S3 bucket;
+	// doc-example-bucket is the name of the S3 bucket;
 	//
 	// ab19cb99-a030-46dd-9dfc-8eSAMPLEPre-Fix is the name of the S3 prefix;
 	//
-	// i-1234567876543 is the instance ID;
+	// i-02573cafcfEXAMPLE is the instance ID;
 	//
 	// awsrunShellScript is the name of the plugin.
 	OutputS3BucketName *string `min:"3" type:"string"`
@@ -17512,13 +17512,13 @@ type CommandPlugin struct {
 	// executions should be stored. This was requested when issuing the command.
 	// For example, in the following response:
 	//
-	// test_folder/ab19cb99-a030-46dd-9dfc-8eSAMPLEPre-Fix/i-1234567876543/awsrunShellScript
+	// doc-example-bucket/ab19cb99-a030-46dd-9dfc-8eSAMPLEPre-Fix/i-02573cafcfEXAMPLE/awsrunShellScript
 	//
-	// test_folder is the name of the S3 bucket;
+	// doc-example-bucket is the name of the S3 bucket;
 	//
 	// ab19cb99-a030-46dd-9dfc-8eSAMPLEPre-Fix is the name of the S3 prefix;
 	//
-	// i-1234567876543 is the instance ID;
+	// i-02573cafcfEXAMPLE is the instance ID;
 	//
 	// awsrunShellScript is the name of the plugin.
 	OutputS3KeyPrefix *string `type:"string"`
@@ -17859,7 +17859,8 @@ type ComplianceItemEntry struct {
 	// Severity is a required field
 	Severity *string `type:"string" required:"true" enum:"ComplianceSeverity"`
 
-	// The status of the compliance item. An item is either COMPLIANT or NON_COMPLIANT.
+	// The status of the compliance item. An item is either COMPLIANT, NON_COMPLIANT,
+	// or an empty string (for Windows patches that aren't applicable).
 	//
 	// Status is a required field
 	Status *string `type:"string" required:"true" enum:"ComplianceStatus"`
@@ -35089,7 +35090,7 @@ type ListResourceDataSyncInput struct {
 	NextToken *string `type:"string"`
 
 	// View a list of resource data syncs according to the sync type. Specify SyncToDestination
-	// to view resource data syncs that synchronize data to an Amazon S3 buckets.
+	// to view resource data syncs that synchronize data to an Amazon S3 bucket.
 	// Specify SyncFromSource to view resource data syncs from AWS Organizations
 	// or from multiple AWS Regions.
 	SyncType *string `min:"1" type:"string"`

--- a/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
@@ -207,6 +207,10 @@ func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, o
 //   and Deactivating AWS STS in an AWS Region (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
 //   in the IAM User Guide.
 //
+//   * ErrCodeExpiredTokenException "ExpiredTokenException"
+//   The web identity token that was passed is expired or is not valid. Get a
+//   new identity token from the identity provider and then retry the request.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/sts-2011-06-15/AssumeRole
 func (c *STS) AssumeRole(input *AssumeRoleInput) (*AssumeRoleOutput, error) {
 	req, out := c.AssumeRoleRequest(input)
@@ -626,7 +630,7 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 //    * Using Web Identity Federation API Operations for Mobile Apps (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc_manual.html)
 //    and Federation Through a Web-based Identity Provider (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity).
 //
-//    * Web Identity Federation Playground (https://web-identity-federation-playground.s3.amazonaws.com/index.html).
+//    * Web Identity Federation Playground (https://aws.amazon.com/blogs/aws/the-aws-web-identity-federation-playground/).
 //    Walk through the process of authenticating through Login with Amazon,
 //    Facebook, or Google, getting temporary security credentials, and then
 //    using those credentials to make a request to AWS.
@@ -1788,7 +1792,7 @@ type AssumeRoleWithSAMLInput struct {
 	// in the IAM User Guide.
 	//
 	// SAMLAssertion is a required field
-	SAMLAssertion *string `min:"4" type:"string" required:"true" sensitive:"true"`
+	SAMLAssertion *string `min:"4" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2100,7 +2104,7 @@ type AssumeRoleWithWebIdentityInput struct {
 	// the application makes an AssumeRoleWithWebIdentity call.
 	//
 	// WebIdentityToken is a required field
-	WebIdentityToken *string `min:"4" type:"string" required:"true" sensitive:"true"`
+	WebIdentityToken *string `min:"4" type:"string" required:"true"`
 }
 
 // String returns the string representation

--- a/vendor/github.com/aws/aws-sdk-go/service/sts/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sts/doc.go
@@ -3,87 +3,11 @@
 // Package sts provides the client and types for making API
 // requests to AWS Security Token Service.
 //
-// The AWS Security Token Service (STS) is a web service that enables you to
-// request temporary, limited-privilege credentials for AWS Identity and Access
-// Management (IAM) users or for users that you authenticate (federated users).
-// This guide provides descriptions of the STS API. For more detailed information
-// about using this service, go to Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html).
-//
-// For information about setting up signatures and authorization through the
-// API, go to Signing AWS API Requests (https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html)
-// in the AWS General Reference. For general information about the Query API,
-// go to Making Query Requests (https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html)
-// in Using IAM. For information about using security tokens with other AWS
-// products, go to AWS Services That Work with IAM (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html)
-// in the IAM User Guide.
-//
-// If you're new to AWS and need additional technical information about a specific
-// AWS product, you can find the product's technical documentation at http://aws.amazon.com/documentation/
-// (http://aws.amazon.com/documentation/).
-//
-// Endpoints
-//
-// By default, AWS Security Token Service (STS) is available as a global service,
-// and all AWS STS requests go to a single endpoint at https://sts.amazonaws.com.
-// Global requests map to the US East (N. Virginia) region. AWS recommends using
-// Regional AWS STS endpoints instead of the global endpoint to reduce latency,
-// build in redundancy, and increase session token validity. For more information,
-// see Managing AWS STS in an AWS Region (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
-// in the IAM User Guide.
-//
-// Most AWS Regions are enabled for operations in all AWS services by default.
-// Those Regions are automatically activated for use with AWS STS. Some Regions,
-// such as Asia Pacific (Hong Kong), must be manually enabled. To learn more
-// about enabling and disabling AWS Regions, see Managing AWS Regions (https://docs.aws.amazon.com/general/latest/gr/rande-manage.html)
-// in the AWS General Reference. When you enable these AWS Regions, they are
-// automatically activated for use with AWS STS. You cannot activate the STS
-// endpoint for a Region that is disabled. Tokens that are valid in all AWS
-// Regions are longer than tokens that are valid in Regions that are enabled
-// by default. Changing this setting might affect existing systems where you
-// temporarily store tokens. For more information, see Managing Global Endpoint
-// Session Tokens (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html#sts-regions-manage-tokens)
-// in the IAM User Guide.
-//
-// After you activate a Region for use with AWS STS, you can direct AWS STS
-// API calls to that Region. AWS STS recommends that you provide both the Region
-// and endpoint when you make calls to a Regional endpoint. You can provide
-// the Region alone for manually enabled Regions, such as Asia Pacific (Hong
-// Kong). In this case, the calls are directed to the STS Regional endpoint.
-// However, if you provide the Region alone for Regions enabled by default,
-// the calls are directed to the global endpoint of https://sts.amazonaws.com.
-//
-// To view the list of AWS STS endpoints and whether they are active by default,
-// see Writing Code to Use AWS STS Regions (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html#id_credentials_temp_enable-regions_writing_code)
-// in the IAM User Guide.
-//
-// Recording API requests
-//
-// STS supports AWS CloudTrail, which is a service that records AWS calls for
-// your AWS account and delivers log files to an Amazon S3 bucket. By using
-// information collected by CloudTrail, you can determine what requests were
-// successfully made to STS, who made the request, when it was made, and so
-// on.
-//
-// If you activate AWS STS endpoints in Regions other than the default global
-// endpoint, then you must also turn on CloudTrail logging in those Regions.
-// This is necessary to record any AWS STS API calls that are made in those
-// Regions. For more information, see Turning On CloudTrail in Additional Regions
-// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/aggregating_logs_regions_turn_on_ct.html)
-// in the AWS CloudTrail User Guide.
-//
-// AWS Security Token Service (STS) is a global service with a single endpoint
-// at https://sts.amazonaws.com. Calls to this endpoint are logged as calls
-// to a global service. However, because this endpoint is physically located
-// in the US East (N. Virginia) Region, your logs list us-east-1 as the event
-// Region. CloudTrail does not write these logs to the US East (Ohio) Region
-// unless you choose to include global service logs in that Region. CloudTrail
-// writes calls to all Regional endpoints to their respective Regions. For example,
-// calls to sts.us-east-2.amazonaws.com are published to the US East (Ohio)
-// Region and calls to sts.eu-central-1.amazonaws.com are published to the EU
-// (Frankfurt) Region.
-//
-// To learn more about CloudTrail, including how to turn it on and find your
-// log files, see the AWS CloudTrail User Guide (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/what_is_cloud_trail_top_level.html).
+// AWS Security Token Service (STS) enables you to request temporary, limited-privilege
+// credentials for AWS Identity and Access Management (IAM) users or for users
+// that you authenticate (federated users). This guide provides descriptions
+// of the STS API. For more information about using this service, see Temporary
+// Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html).
 //
 // See https://docs.aws.amazon.com/goto/WebAPI/sts-2011-06-15 for more information on this service.
 //

--- a/vendor/github.com/jmespath/go-jmespath/.travis.yml
+++ b/vendor/github.com/jmespath/go-jmespath/.travis.yml
@@ -12,6 +12,17 @@ go:
   - 1.11.x
   - 1.12.x
   - 1.13.x
+  - 1.14.x
+  - 1.15.x
+  - tip
 
-install: go get -v -t ./...
-script: make test
+allow_failures:
+  - go: tip
+
+script: make build
+
+matrix:
+  include:
+    - language: go
+      go: 1.15.x
+      script: make test

--- a/vendor/github.com/jmespath/go-jmespath/Makefile
+++ b/vendor/github.com/jmespath/go-jmespath/Makefile
@@ -1,6 +1,8 @@
 
 CMD = jpgo
 
+SRC_PKGS=./ ./cmd/... ./fuzz/...
+
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  test                    to run all the tests"
@@ -9,21 +11,22 @@ help:
 
 
 generate:
-	go generate ./...
+	go generate ${SRC_PKGS}
 
 build:
 	rm -f $(CMD)
-	go build ./...
+	go build ${SRC_PKGS}
 	rm -f cmd/$(CMD)/$(CMD) && cd cmd/$(CMD)/ && go build ./...
 	mv cmd/$(CMD)/$(CMD) .
 
-test:
-	go test -v ./...
+test: test-internal-testify
+	echo "making tests ${SRC_PKGS}"
+	go test -v ${SRC_PKGS}
 
 check:
-	go vet ./...
-	@echo "golint ./..."
-	@lint=`golint ./...`; \
+	go vet ${SRC_PKGS}
+	@echo "golint ${SRC_PKGS}"
+	@lint=`golint ${SRC_PKGS}`; \
 	lint=`echo "$$lint" | grep -v "astnodetype_string.go" | grep -v "toktype_string.go"`; \
 	echo "$$lint"; \
 	if [ "$$lint" != "" ]; then exit 1; fi
@@ -42,3 +45,7 @@ bench:
 
 pprof-cpu:
 	go tool pprof ./go-jmespath.test ./cpu.out
+
+test-internal-testify:
+	cd internal/testify && go test ./...
+

--- a/vendor/github.com/jmespath/go-jmespath/go.mod
+++ b/vendor/github.com/jmespath/go-jmespath/go.mod
@@ -2,4 +2,4 @@ module github.com/jmespath/go-jmespath
 
 go 1.14
 
-require github.com/stretchr/testify v1.5.1
+require github.com/jmespath/go-jmespath/internal/testify v1.5.1

--- a/vendor/github.com/jmespath/go-jmespath/go.sum
+++ b/vendor/github.com/jmespath/go-jmespath/go.sum
@@ -1,11 +1,11 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/andybalholm/brotli
 github.com/armon/circbuf
 # github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
 github.com/asaskevich/govalidator
-# github.com/aws/aws-sdk-go v1.34.22
+# github.com/aws/aws-sdk-go v1.34.32
 ## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
@@ -510,7 +510,7 @@ github.com/huandu/xstrings
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/jmespath/go-jmespath v0.3.0
+# github.com/jmespath/go-jmespath v0.4.0
 github.com/jmespath/go-jmespath
 # github.com/jmoiron/sqlx v1.2.0
 github.com/jmoiron/sqlx


### PR DESCRIPTION
HTTP GET failure due to bad packet or packet loss should be retried.

Fix the following panic:

```
{"level":"info","ts":"2020-09-25T23:43:56.457-0700","caller":"cluster/cluster.go:700","msg":"updating host with port :443","host":"..."}
{"level":"info","ts":"2020-09-25T23:43:56.457-0700","caller":"cluster/cluster.go:711","msg":"fetching OIDC CA thumbprint","url":"https://...:443/test/id/78FD753967D735CEFC309F15590F617F"}
{"level":"warn","ts":"2020-09-25T23:44:38.734-0700","caller":"cluster/cluster.go:720","msg":"failed to fetch OIDC CA thumbprint","url":"https://...:443/test/id/78FD753967D735CEFC309F15590F617F","error":"Get \"https://...:443/test/id/78FD753967D735CEFC309F15590F617F\": local error: tls: bad record MAC"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x221029b]

goroutine 221 [running]:
github.com/aws/aws-k8s-tester/eks/cluster.(*tester).updateClusterStatus(0xc00074d4a0, 0xc00100abd0, 0x0, 0x0, 0x507acd1, 0x6)
        aws-k8s-tester/eks/cluster/cluster.go:725 +0xd5b
github.com/aws/aws-k8s-tester/eks/cluster.(*tester).createEKS(0xc00074d4a0, 0x0, 0x0)
        aws-k8s-tester/eks/cluster/cluster.go:509 +0x1688
github.com/aws/aws-k8s-tester/eks/cluster.(*tester).Create(0xc00074d4a0, 0x527b490, 0xc000623a00)
        aws-k8s-tester/eks/cluster/cluster.go:105 +0x1de
github.com/aws/aws-k8s-tester/eks.catchInterrupt.func1(0xc000661c80, 0xc001003e80)
        aws-k8s-tester/eks/eks.go:1682 +0x27
created by github.com/aws/aws-k8s-tester/eks.catchInterrupt
        aws-k8s-tester/eks/eks.go:1681 +0x7a
```
