### PR TITLE
Changed CL2 test add-on to not retry on failure, and fixed CA add-on max nodes error

### DIFF
--- a/eks/cluster-loader/clusterloader2/cluster-loader.gotmpl
+++ b/eks/cluster-loader/clusterloader2/cluster-loader.gotmpl
@@ -44,6 +44,7 @@ metadata:
   name: clusterloader2
   namespace: clusterloader2
 spec:
+  backoffLimit: 0
   template:
     spec:
       initContainers:

--- a/eks/cluster-loader/configs/cluster-autoscaler/hollowdeployment.yaml
+++ b/eks/cluster-loader/configs/cluster-autoscaler/hollowdeployment.yaml
@@ -23,6 +23,15 @@ spec:
             requests:
               cpu: {{.CpuRequest}}
               memory: {{.MemoryRequest}}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: NodeType
+                    operator: In
+                    values:
+                      - hollow-nodes
       # Add not-ready/unreachable tolerations for 15 minutes so that node
       # failure doesn't trigger pod deletion.
       tolerations:
@@ -34,3 +43,7 @@ spec:
           operator: "Exists"
           effect: "NoExecute"
           tolerationSeconds: 900
+        - key: "provider"
+          value: "kubemark"
+          operator: "Equal"
+          effect: "NoSchedule"

--- a/eks/clusterautoscaler/clusterautoscaler.go
+++ b/eks/clusterautoscaler/clusterautoscaler.go
@@ -105,12 +105,12 @@ func (c *ClusterAutoscaler) buildNodeGroupArguments() (args []string) {
 	if spec.CloudProvider == eksconfig.CloudProviderAWS {
 		if c.Config.AddOnNodeGroups != nil {
 			for _, asg := range c.Config.AddOnNodeGroups.ASGs {
-				args = append(args, fmt.Sprintf(NodeGroupArgumentFormatter, spec.MinNodes, spec.MinNodes, asg.Name))
+				args = append(args, fmt.Sprintf(NodeGroupArgumentFormatter, spec.MinNodes, spec.MaxNodes, asg.Name))
 			}
 		}
 		if c.Config.AddOnManagedNodeGroups != nil {
 			for _, mng := range c.Config.AddOnManagedNodeGroups.MNGs {
-				args = append(args, fmt.Sprintf(NodeGroupArgumentFormatter, spec.MinNodes, spec.MinNodes, mng.Name))
+				args = append(args, fmt.Sprintf(NodeGroupArgumentFormatter, spec.MinNodes, spec.MaxNodes, mng.Name))
 			}
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added backoffLimit so that CL2 addon test doesn't retry
- Changed default deployment.yaml to be real nodes (not hollow-nodes)
- Added hollowdeployment.yaml for option for hollow-nodes
- Fixed a CA add-on error where maxNodes was mis-coded as minNodes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
