### PR TITLE
Changed VPC defaults to be multiple blocks to account for larger testing clusters

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -1,3 +1,19 @@
+## [v1.5.4]
+
+See [code changes]
+
+### `VPC`
+
+- Expanded VPC default CIDR range in order to support more pods for larger scale tests
+  - Previous VPC defaults had one /19 CIDR Block, allowing for 8k pods. Added multiple blocks of max VPC Block size (/16).
+  - Changed VPCs from 192 space to 10 space.
+- Subnets are by default same CIDR range as VPC Blocks, but can be changed with environment variables
+  - Public Subnets are /16 blocks by default
+  - Private Subnets are /17 blocks by default
+  
+### `Clusterloader2`
+
+- Allowed to specify which type of node to place the clusterloader2 pod (as to not have the pod be removed in scale down)
 
 
 <hr>

--- a/eks/cluster-loader/clusterloader2/cluster-loader.gotmpl
+++ b/eks/cluster-loader/clusterloader2/cluster-loader.gotmpl
@@ -44,10 +44,10 @@ metadata:
   name: clusterloader2
   namespace: clusterloader2
 spec:
-  backoffLimit: 0
+  backoffLimit: 1
   template:
     spec:
-      initContainers:
+      containers:
         - name: clusterloader2
           image: {{ .Image }}
           command: ["/clusterloader"]
@@ -55,25 +55,19 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/config
-            - name: reports
-              mountPath: /var/reports
-              readOnly: false
-      containers:
-        - name: uploadresults
-          image: amazon/aws-cli:latest
-          command: 
-            - /bin/sh
-            - -c
-          args:
-            - aws s3 cp /var/reports/cluster-loader {{ .S3Uri }} --recursive        
-          volumeMounts: 
-            - name: reports
-              mountPath: /var/reports
       restartPolicy: Never
       serviceAccountName: clusterloader2
       volumes:
         - name: config
           configMap:
             name: clusterloader2-config
-        - name: reports
-          emptyDir: {}
+    {{ if gt (len .InstanceTypes) 0 }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/instance-type
+                operator: In
+                values: {{ .InstanceTypes }}
+    {{ end }}

--- a/eks/cluster-loader/configs/cluster-autoscaler/config.yaml
+++ b/eks/cluster-loader/configs/cluster-autoscaler/config.yaml
@@ -96,7 +96,7 @@ steps:
       Params:
         labelSelector: group = {{ $POD_GROUP_LABEL }}
         desiredPodCount: {{ $TOTAL_PODS }}
-        timeout: 1h
+        timeout: 4h
 
 - name: stop-timing-for-scale-up
 - measurements:
@@ -136,7 +136,7 @@ steps:
       Params:
         labelSelector: group = {{ $POD_GROUP_LABEL }}
         desiredPodCount: 0
-        timeout: 1h
+        timeout: 4h
 
 - name: stop-measurements
 - measurements:

--- a/eks/ng/nodes.go
+++ b/eks/ng/nodes.go
@@ -429,7 +429,7 @@ func (ts *tester) createASGs() error {
 		case ec2config.AMITypeAL2X8664,
 			ec2config.AMITypeAL2X8664GPU:
 			// https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh
-			clusterVPCIP := ts.cfg.EKSConfig.Parameters.VPCCIDR
+			clusterVPCIP := ts.cfg.EKSConfig.Parameters.VPCBlock1
 			dnsClusterIP := "10.100.0.10"
 			if clusterVPCIP[:strings.IndexByte(clusterVPCIP, '.')] == "10" {
 				dnsClusterIP = "172.20.0.10"

--- a/eksconfig/cluster-loader.go
+++ b/eksconfig/cluster-loader.go
@@ -9,8 +9,10 @@ type ClusterLoaderSpec struct {
 	Image          string   `json:"image,omitempty"`
 	Nodes          int32    `json:"nodes,omitempty"`
 	TestConfigUris []string `json:"testConfigUris,omitempty"`
-	S3Uri          string   `json:"s3Uri,omitempty"`
 	TestOverrides  []string `json:"testOverrides,omitempty"`
+	// Specifies which instance type the clusterloader2 pod will be able to be scheduled on
+	// Leaving this empty will allow it to be scheduled on any instance type
+	InstanceTypes []string `json:"instanceTypes,omitempty"`
 }
 
 // ClusterLoaderStatus defines the status for the Addon
@@ -26,7 +28,6 @@ func (spec *ClusterLoaderSpec) Validate(cfg *Config) error {
 	if len(spec.TestConfigUris) == 0 {
 		return fmt.Errorf("ClusterLoaderSpec.TestConfigUris array must have length greater than 0")
 	}
-
 	return nil
 }
 
@@ -34,5 +35,8 @@ func (spec *ClusterLoaderSpec) Validate(cfg *Config) error {
 func (spec *ClusterLoaderSpec) Default(cfg *Config) {
 	if spec.Image == "" {
 		spec.Image = "197575167141.dkr.ecr.us-west-2.amazonaws.com/clusterloader2:latest"
+	}
+	if spec.InstanceTypes == nil {
+		spec.InstanceTypes = []string{}
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Expanded VPC default CIDR range in order to support more pods for larger scale tests
  - Previous VPC defaults had one /19 CIDR Block, allowing for 8k pods. Added multiple blocks of max VPC Block size (/16).
  - Changed VPCs from 192 space to 10 space.
- Subnets are by default same CIDR range as VPC Blocks, but can be changed with environment variables
  - Public Subnets are /16 blocks by default
  - Private Subnets are /17 blocks by default

*Testing*
- Tested by bringing up a cluster to a larger size than before to see if VPC was able to handle more IPs than before the change. VPC was brought up successfully, and more IPs were successfully utilized.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
