### PR TITLE
Increase clusterloader test timeout from 20 min to 120 min

### DIFF
--- a/eks/cluster-loader/cluster-loader.go
+++ b/eks/cluster-loader/cluster-loader.go
@@ -537,7 +537,7 @@ ENABLE_SYSTEM_POD_METRICS: {{ .EnableSystemPodMetrics }}
 // takes about 2-minute
 func (ld *loader) run(idx int, args []string) (err error) {
 	ld.cfg.Logger.Info("running cluster loader", zap.Int("index", idx), zap.String("command", strings.Join(args, " ")))
-	ctx, cancel := context.WithTimeout(ld.rootCtx, 20*time.Minute)
+	ctx, cancel := context.WithTimeout(ld.rootCtx, 120*time.Minute)
 	cmd := exec.New().CommandContext(ctx, args[0], args[1:]...)
 	cmd.SetStderr(ld.testLogsFile)
 	cmd.SetStdout(ld.testLogsFile)


### PR DESCRIPTION
Increase clusterloader test timeout from 20 min to 120 min. This will be configurable in the future.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
