### PR TITLE
 Set us-west-1 to 2 AZ region for VPC creation

### DIFF
--- a/eks/cluster/vpc.go
+++ b/eks/cluster/vpc.go
@@ -158,6 +158,9 @@ Conditions:
         - Fn::Equals:
           - Ref: AWS::Region
           - us-isob-east-1
+        - Fn::Equals:
+          - Ref: AWS::Region
+          - us-west-1
 
   HasDHCPOptionsOnlyDomainName:
     Fn::And:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This causes issue with AZ index 2 lookup on VPC creation:
`Fn::Select cannot select nonexistent value at index 2`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
