### PR TITLE
ec2: fix "ASGDesiredCapacity" template

### DIFF
--- a/ec2/asgs.go
+++ b/ec2/asgs.go
@@ -128,7 +128,7 @@ Parameters:
   ASGDesiredCapacity:
     Type: Number
     Description: Desired size auto scaling group
-    Default: 0
+    Default: {{.ASGDesiredCapacity}}
     MinValue: 1
     MaxValue: 1000
 


### PR DESCRIPTION
```
  ASGDesiredCapacity:
    Type: Number
    Description: Desired size auto scaling group
    Default: 1
    MinValue: 1
    MaxValue: 1000
```

Fix 

> "Parameter 'ASGDesiredCapacity' must be a number not less than 1\n\tstatus code: 400"