### PR TITLE
*: expose configuration of sonobuoy worker/systemd-logs container overrides

### DIFF
--- a/eks/conformance/conformance.go
+++ b/eks/conformance/conformance.go
@@ -242,6 +242,12 @@ func (ts *tester) runSonobuoy() (err error) {
 		"--show-default-podspec=true",
 		fmt.Sprintf("--timeout=%d", timeoutSeconds), // default "10800", 3-hour
 	}
+	if ts.cfg.EKSConfig.AddOnConformance.SonobuoyImage != "" {
+		args = append(args, "--sonobuoy-image=" + ts.cfg.EKSConfig.AddOnConformance.SonobuoyImage)
+	}
+	if ts.cfg.EKSConfig.AddOnConformance.SystemdLogsImage != "" {
+		args = append(args, "--systemd-logs-image=" + ts.cfg.EKSConfig.AddOnConformance.SystemdLogsImage)
+	}
 	cmd := strings.Join(args, " ")
 
 	ts.cfg.Logger.Info("running sonobuoy",

--- a/eksconfig/add-on-conformance.go
+++ b/eksconfig/add-on-conformance.go
@@ -38,6 +38,10 @@ type AddOnConformance struct {
 	// SonobuoyDownloadURL is the download URL to download "sonobuoy" binary from.
 	// ref. https://github.com/vmware-tanzu/sonobuoy/releases
 	SonobuoyDownloadURL string `json:"sonobuoy-download-url,omitempty"`
+	// SonobuoyImage Container override for the sonobuoy worker image
+	SonobuoyImage string `json:"sonobuoy-image"`
+	// SystemdLogsImage Container override for systemd-logs plugin image
+	SystemdLogsImage string `json:"systemd-logs-image"`
 
 	SonobuoyDeleteTimeout       time.Duration `json:"sonobuoy-delete-timeout"`
 	SonobuoyDeleteTimeoutString string        `json:"sonobuoy-delete-timeout-string" read-only:"true"`
@@ -81,6 +85,8 @@ func getDefaultAddOnConformance() *AddOnConformance {
 		Enable:              false,
 		SonobuoyPath:        "/tmp/sonobuoy-v0.18.3",
 		SonobuoyDownloadURL: "https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.18.3/sonobuoy_0.18.3_linux_amd64.tar.gz",
+		SonobuoyImage:       "",
+		SystemdLogsImage:    "",
 	}
 	if runtime.GOOS == "darwin" {
 		addOn.SonobuoyDownloadURL = strings.Replace(addOn.SonobuoyDownloadURL, "linux", "darwin", -1)

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -1696,6 +1696,10 @@ func TestEnvAddOnConformance(t *testing.T) {
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_RUN_MODE")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_RUN_KUBE_CONFORMANCE_IMAGE", "hello.com/v1")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_RUN_KUBE_CONFORMANCE_IMAGE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_IMAGE", "sonobuoy/sonobuoy:v0.18.3")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_IMAGE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SYSTEMD_LOGS_IMAGE", "sonobuoy/systemd-logs:v0.3")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SYSTEMD_LOGS_IMAGE")
 
 	if err := cfg.UpdateFromEnvs(); err != nil {
 		t.Fatal(err)
@@ -1727,6 +1731,12 @@ func TestEnvAddOnConformance(t *testing.T) {
 	}
 	if cfg.AddOnConformance.SonobuoyRunKubeConformanceImage != "hello.com/v1" {
 		t.Fatalf("unexpected cfg.AddOnConformance.SonobuoyRunKubeConformanceImage %q", cfg.AddOnConformance.SonobuoyRunKubeConformanceImage)
+	}
+	if cfg.AddOnConformance.SonobuoyImage != "sonobuoy/sonobuoy:v0.18.3" {
+		t.Fatalf("unexpected cfg.AddOnConformance.SonobuoyImage %q", cfg.AddOnConformance.SonobuoyImage)
+	}
+	if cfg.AddOnConformance.SystemdLogsImage != "sonobuoy/systemd-logs:v0.3" {
+		t.Fatalf("unexpected cfg.AddOnConformance.SystemdLogsImage %q", cfg.AddOnConformance.SystemdLogsImage)
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

By default, `sonobuoy/sonobuoy` & `sonobuoy/systemd-logs` are pulled from Dockerhub. This change adds the option to override this behavior and provide a custom images.

```
hack/eksconfig.gen.sh 
...
aws-k8s-tester eks create config --path "./eksconfig/default.yaml"' success`
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
