### PR TITLE
conformance: expose sonobuoy e2e-repo-config flag

### DIFF
--- a/eks/conformance/conformance.go
+++ b/eks/conformance/conformance.go
@@ -249,6 +249,9 @@ func (ts *tester) runSonobuoy() (err error) {
 	if ts.cfg.EKSConfig.AddOnConformance.SystemdLogsImage != "" {
 		args = append(args, "--systemd-logs-image="+ts.cfg.EKSConfig.AddOnConformance.SystemdLogsImage)
 	}
+	if ts.cfg.EKSConfig.AddOnConformance.SonobuoyE2eRepoConfig != "" {
+		args = append(args, "--e2e-repo-config" + ts.cfg.EKSConfig.AddOnConformance.SonobuoyE2eRepoConfig)
+	}
 	cmd := strings.Join(args, " ")
 
 	ts.cfg.Logger.Info("running sonobuoy",

--- a/eksconfig/add-on-conformance.go
+++ b/eksconfig/add-on-conformance.go
@@ -38,6 +38,9 @@ type AddOnConformance struct {
 	// SonobuoyDownloadURL is the download URL to download "sonobuoy" binary from.
 	// ref. https://github.com/vmware-tanzu/sonobuoy/releases
 	SonobuoyDownloadURL string `json:"sonobuoy-download-url,omitempty"`
+	// SonobuoyE2eRepoConfig File path to e2e registry config
+	// ref. https://sonobuoy.io/docs/master/airgap/
+	SonobuoyE2eRepoConfig string `json:"sonobuoy-e2e-repo-config"`
 	// SonobuoyImage Container override for the sonobuoy worker image
 	SonobuoyImage string `json:"sonobuoy-image"`
 	// SystemdLogsImage Container override for systemd-logs plugin image

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -1700,6 +1700,8 @@ func TestEnvAddOnConformance(t *testing.T) {
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_IMAGE")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SYSTEMD_LOGS_IMAGE", "sonobuoy/systemd-logs:v0.3")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SYSTEMD_LOGS_IMAGE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_E2E_REPO_CONFIG", "/path/to/config.yml")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_E2E_REPO_CONFIG")
 
 	if err := cfg.UpdateFromEnvs(); err != nil {
 		t.Fatal(err)
@@ -1737,6 +1739,9 @@ func TestEnvAddOnConformance(t *testing.T) {
 	}
 	if cfg.AddOnConformance.SystemdLogsImage != "sonobuoy/systemd-logs:v0.3" {
 		t.Fatalf("unexpected cfg.AddOnConformance.SystemdLogsImage %q", cfg.AddOnConformance.SystemdLogsImage)
+	}
+	if cfg.AddOnConformance.SonobuoyE2eRepoConfig != "/path/to/config.yml" {
+		t.Fatalf("unexpected cfg.AddOnConformance.SonobuoyE2eRepoConfig %q", cfg.AddOnConformance.SonobuoyE2eRepoConfig)
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
na

*Description of changes:*
Special image config is required for airgapped regions

*Testing*

`'aws-k8s-tester eks create config --path "./eksconfig/default.yaml"' success`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
