### PR TITLE
eks/ng/nodes.go: fix indentation for ImageIDSSMParameter

### DIFF
--- a/eks/ng/nodes.go
+++ b/eks/ng/nodes.go
@@ -107,9 +107,9 @@ Parameters:
     Type: String
     Default: ""
     Description: Specify your own custom image ID. This value overrides any AWS Systems Manager Parameter Store value specified above.{{ end }}{{ if ne .ImageIDSSMParameter "" }}  ImageIDSSMParameter:
-  Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-  Default: /aws/service/eks/optimized-ami/1.18/amazon-linux-2/recommended/image_id
-  Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances.{{ end }}
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/eks/optimized-ami/1.18/amazon-linux-2/recommended/image_id
+    Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances.{{ end }}
 
   InstanceTypes:
     Type: CommaDelimitedList


### PR DESCRIPTION
*Issue #, if available:* N/A

```
[/Parameters/ImageIDSSMParameter] 'null' values are not allowed in templates
```

*Description of changes:* fix indentation for ImageIDSSMParameter

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
