### PR TITLE
Ignore error when region is missing from the given partition

### DIFF
--- a/eks/eks.go
+++ b/eks/eks.go
@@ -353,9 +353,11 @@ func New(cfg *eksconfig.Config) (ts *Tester, err error) {
 	if err != nil {
 		return nil, err
 	}
-	ts.cfg.Status.AWSAccountID = aws.StringValue(stsOutput.Account)
-	ts.cfg.Status.AWSUserID = aws.StringValue(stsOutput.UserId)
-	ts.cfg.Status.AWSIAMRoleARN = aws.StringValue(stsOutput.Arn)
+	if stsOutput != nil {
+		ts.cfg.Status.AWSAccountID = aws.StringValue(stsOutput.Account)
+		ts.cfg.Status.AWSUserID = aws.StringValue(stsOutput.UserId)
+		ts.cfg.Status.AWSIAMRoleARN = aws.StringValue(stsOutput.Arn)
+	}
 	ts.cfg.Sync()
 
 	ts.lg.Info("checking AWS SDK Go v2")

--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -1131,7 +1131,8 @@ func (cfg *Config) validateConfig() error {
 	}
 	regions := partition.Regions()
 	if _, ok := regions[cfg.Region]; !ok {
-		return fmt.Errorf("region %q for partition %q not found in %+v", cfg.Region, cfg.Partition, regions)
+		// we will get this error when the Go AWS SDK is not updated to support a new region
+		fmt.Fprintf(os.Stderr, "[WARN] region %q for partition %q not found in %+v", cfg.Region, cfg.Partition, regions)
 	}
 
 	_, cerr := terminal.IsColor()


### PR DESCRIPTION
*Description of changes:*
The AWS Go SDK has not been updated to include ap-northeast-3. This is a workaround to use aws-k8s-tester against KIX without having to update the SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*Testing:*
Previously we'd fail to run create cluster in KIX:
```
AWS_K8S_TESTER_EKS_ON_FAILURE_DELETE=true \
AWS_K8S_TESTER_EKS_REGION=ap-northeast-3 \
AWS_K8S_TESTER_EKS_LOG_COLOR=true \
AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE=true \
AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE_KEEP=false \
AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_CREATE=true \
AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_CREATE=true \
AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_SERVICE_PRINCIPALS="ec2.amazonaws.com,eks.amazonaws.com,eks-fargate-pods.amazonaws.com,eks-dev.aws.internal,eks-beta-pdx.aws.internal,eks-fargate-pods.aws.internal" \
AWS_K8S_TESTER_EKS_PARAMETERS_VERSION=1.18 \
AWS_K8S_TESTER_EKS_PARAMETERS_VPC_CREATE=true \
AWS_K8S_TESTER_EKS_CLIENTS=5 \
AWS_K8S_TESTER_EKS_CLIENT_QPS=30 \
AWS_K8S_TESTER_EKS_CLIENT_BURST=20 \
aws-k8s-tester eks create cluster --enable-prompt=true --auto-path
cannot find configuration; wrote a new one "/tmp/eks-2021021522-soundsq0ryqx.yaml"

*********************************
overwriting config file from environment variables with {"git-commit":"ddc97e9ae042","release-version":"v20201207.204822","build-time":"2020-12-07_20:48:22"}
failed to validate configuration "/tmp/eks-2021021522-soundsq0ryqx.yaml" (validateConfig failed [region "ap-northeast-3" for partition "aws" not found in map[af-south-1:{id:af-south-1 desc:Africa (Cape Town) p:0xc000cc8270} ap-east-1:{id:ap-east-1 desc:Asia Pacific (Hong Kong) p:0xc000cc8270} ap-northeast-1:{id:ap-northeast-1 desc:Asia Pacific (Tokyo) p:0xc000cc8270} ap-northeast-2:{id:ap-northeast-2 desc:Asia Pacific (Seoul) p:0xc000cc8270} ap-south-1:{id:ap-south-1 desc:Asia Pacific (Mumbai) p:0xc000cc8270} ap-southeast-1:{id:ap-southeast-1 desc:Asia Pacific (Singapore) p:0xc000cc8270} ap-southeast-2:{id:ap-southeast-2 desc:Asia Pacific (Sydney) p:0xc000cc8270} ca-central-1:{id:ca-central-1 desc:Canada (Central) p:0xc000cc8270} eu-central-1:{id:eu-central-1 desc:Europe (Frankfurt) p:0xc000cc8270} eu-north-1:{id:eu-north-1 desc:Europe (Stockholm) p:0xc000cc8270} eu-south-1:{id:eu-south-1 desc:Europe (Milan) p:0xc000cc8270} eu-west-1:{id:eu-west-1 desc:Europe (Ireland) p:0xc000cc8270} eu-west-2:{id:eu-west-2 desc:Europe (London) p:0xc000cc8270} eu-west-3:{id:eu-west-3 desc:Europe (Paris) p:0xc000cc8270} me-south-1:{id:me-south-1 desc:Middle East (Bahrain) p:0xc000cc8270} sa-east-1:{id:sa-east-1 desc:South America (Sao Paulo) p:0xc000cc8270} us-east-1:{id:us-east-1 desc:US East (N. Virginia) p:0xc000cc8270} us-east-2:{id:us-east-2 desc:US East (Ohio) p:0xc000cc8270} us-west-1:{id:us-west-1 desc:US West (N. California) p:0xc000cc8270} us-west-2:{id:us-west-2 desc:US West (Oregon) p:0xc000cc8270}]])
```
Now the test successfully runs in KIX:
```
AWS_K8S_TESTER_EKS_ON_FAILURE_DELETE=true \
AWS_K8S_TESTER_EKS_REGION=ap-northeast-3 \
AWS_K8S_TESTER_EKS_LOG_COLOR=true \
AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE=true \
AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE_KEEP=false \
AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_CREATE=true \
AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_CREATE=true \
AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_SERVICE_PRINCIPALS="ec2.amazonaws.com,eks.amazonaws.com,eks-fargate-pods.amazonaws.com,eks-dev.aws.internal,eks-beta-pdx.aws.internal,eks-fargate-pods.aws.internal" \
AWS_K8S_TESTER_EKS_PARAMETERS_VERSION=1.18 \
AWS_K8S_TESTER_EKS_PARAMETERS_VPC_CREATE=true \
AWS_K8S_TESTER_EKS_CLIENTS=5 \
AWS_K8S_TESTER_EKS_CLIENT_QPS=30 \
AWS_K8S_TESTER_EKS_CLIENT_BURST=20 \
./aws-k8s-tester-v20210215.211723-darwin-amd64 eks create cluster --enable-prompt=true --auto-path
cannot find configuration; wrote a new one "/var/folders/35/z5zvm_gn02x975hd3gmh6j5rcqwqzf/T/eks-2021021514-frostyyzy6mr.yaml"

*********************************
overwriting config file from environment variables with {"git-commit":"e1d0b8ef3e8b","release-version":"v20210215.211723","build-time":"2021-02-15_21:17:23"}
[WARN] region "ap-northeast-3" for partition "aws" not found in map[af-south-1:{id:af-south-1 desc:Africa (Cape Town) p:0xc000d252b0} ap-east-1:{id:ap-east-1 desc:Asia Pacific (Hong Kong) p:0xc000d252b0} ap-northeast-1:{id:ap-northeast-1 desc:Asia Pacific (Tokyo) p:0xc000d252b0} ap-northeast-2:{id:ap-northeast-2 desc:Asia Pacific (Seoul) p:0xc000d252b0} ap-south-1:{id:ap-south-1 desc:Asia Pacific (Mumbai) p:0xc000d252b0} ap-southeast-1:{id:ap-southeast-1 desc:Asia Pacific (Singapore) p:0xc000d252b0} ap-southeast-2:{id:ap-southeast-2 desc:Asia Pacific (Sydney) p:0xc000d252b0} ca-central-1:{id:ca-central-1 desc:Canada (Central) p:0xc000d252b0} eu-central-1:{id:eu-central-1 desc:Europe (Frankfurt) p:0xc000d252b0} eu-north-1:{id:eu-north-1 desc:Europe (Stockholm) p:0xc000d252b0} eu-south-1:{id:eu-south-1 desc:Europe (Milan) p:0xc000d252b0} eu-west-1:{id:eu-west-1 desc:Europe (Ireland) p:0xc000d252b0} eu-west-2:{id:eu-west-2 desc:Europe (London) p:0xc000d252b0} eu-west-3:{id:eu-west-3 desc:Europe (Paris) p:0xc000d252b0} me-south-1:{id:me-south-1 desc:Middle East (Bahrain) p:0xc000d252b0} sa-east-1:{id:sa-east-1 desc:South America (Sao Paulo) p:0xc000d252b0} us-east-1:{id:us-east-1 desc:US East (N. Virginia) p:0xc000d252b0} us-east-2:{id:us-east-2 desc:US East (Ohio) p:0xc000d252b0} us-west-1:{id:us-west-1 desc:US West (N. California) p:0xc000d252b0} us-west-2:{id:us-west-2 desc:US West (Oregon) p:0xc000d252b0}]

"/var/folders/35/z5zvm_gn02x975hd3gmh6j5rcqwqzf/T/eks-2021021514-frostyyzy6mr.yaml":
...
*********************************


💯 😁 👍 :) UP SUCCESS




# to delete cluster
aws-k8s-tester eks delete cluster --path /var/folders/35/z5zvm_gn02x975hd3gmh6j5rcqwqzf/T/eks-2021021514-frostyyzy6mr.yaml




*********************************
aws-k8s-tester eks create cluster SUCCESS
```
Deleting the KIX cluster:
```
$ ./aws-k8s-tester-v20210215.211723-darwin-amd64 eks delete cluster --path /var/folders/35/z5zvm_gn02x975hd3gmh6j5rcqwqzf/T/eks-2021021514-frostyyzy6mr.yaml


"/var/folders/35/z5zvm_gn02x975hd3gmh6j5rcqwqzf/T/eks-2021021514-frostyyzy6mr.yaml":
...
✔ Yes, let's delete!
[WARN] region "ap-northeast-3" for partition "aws" not found in map[af-south-1:{id:af-south-1 desc:Africa (Cape Town) p:0xc0005dea90} ap-east-1:{id:ap-east-1 desc:Asia Pacific (Hong Kong) p:0xc0005dea90} ap-northeast-1:{id:ap-northeast-1 desc:Asia Pacific (Tokyo) p:0xc0005dea90} ap-northeast-2:{id:ap-northeast-2 desc:Asia Pacific (Seoul) p:0xc0005dea90} ap-south-1:{id:ap-south-1 desc:Asia Pacific (Mumbai) p:0xc0005dea90} ap-southeast-1:{id:ap-southeast-1 desc:Asia Pacific (Singapore) p:0xc0005dea90} ap-southeast-2:{id:ap-southeast-2 desc:Asia Pacific (Sydney) p:0xc0005dea90} ca-central-1:{id:ca-central-1 desc:Canada (Central) p:0xc0005dea90} eu-central-1:{id:eu-central-1 desc:Europe (Frankfurt) p:0xc0005dea90} eu-north-1:{id:eu-north-1 desc:Europe (Stockholm) p:0xc0005dea90} eu-south-1:{id:eu-south-1 desc:Europe (Milan) p:0xc0005dea90} eu-west-1:{id:eu-west-1 desc:Europe (Ireland) p:0xc0005dea90} eu-west-2:{id:eu-west-2 desc:Europe (London) p:0xc0005dea90} eu-west-3:{id:eu-west-3 desc:Europe (Paris) p:0xc0005dea90} me-south-1:{id:me-south-1 desc:Middle East (Bahrain) p:0xc0005dea90} sa-east-1:{id:sa-east-1 desc:South America (Sao Paulo) p:0xc0005dea90} us-east-1:{id:us-east-1 desc:US East (N. Virginia) p:0xc0005dea90} us-east-2:{id:us-east-2 desc:US East (Ohio) p:0xc0005dea90} us-west-1:{id:us-west-1 desc:US West (N. California) p:0xc0005dea90} us-west-2:{id:us-west-2 desc:US West (Oregon) p:0xc0005dea90}]{"level":"info","ts":"2021-02-15T14:37:41.910-0800","caller":"eks/eks.go:213","msg":"set up log writer and file","outputs":["stderr","/var/folders/35/z5zvm_gn02x975hd3gmh6j5rcqwqzf/T/eks-2021021514-frostyyzy6mr.log"]}
{"level":"info","ts":"2021-02-15T14:37:42.427-0800","caller":"eks/eks.go:218","msg":"requested output in color","output":"256"}
...
*********************************
DOWN DEFER START ("/var/folders/35/z5zvm_gn02x975hd3gmh6j5rcqwqzf/T/eks-2021021514-frostyyzy6mr.yaml")


💯 😁 👍 :) DOWN SUCCESS


{"level":"info","ts":"2021-02-15T14:46:50.880-0800","caller":"eks/eks.go:1571","msg":"successfully finished Down","started":"9 minutes ago"}



*********************************
aws-k8s-tester eks delete cluster SUCCESS
```