### PR TITLE
Update sonobuoy tool version to 1.19 and e2e image repo to k8s.gcr.io

### DIFF
--- a/eksconfig/add-on-conformance.go
+++ b/eksconfig/add-on-conformance.go
@@ -86,8 +86,8 @@ func (cfg *Config) IsEnabledAddOnConformance() bool {
 func getDefaultAddOnConformance() *AddOnConformance {
 	addOn := &AddOnConformance{
 		Enable:                false,
-		SonobuoyPath:          "/tmp/sonobuoy-v0.18.3",
-		SonobuoyDownloadURL:   "https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.18.3/sonobuoy_0.18.3_linux_amd64.tar.gz",
+		SonobuoyPath:          "/tmp/sonobuoy-v0.19.0",
+		SonobuoyDownloadURL:   "https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.19.0/sonobuoy_0.19.0_linux_amd64.tar.gz",
 		SonobuoyImage:         "",
 		SystemdLogsImage:      "",
 		SonobuoyE2eRepoConfig: "",
@@ -171,7 +171,7 @@ func (cfg *Config) validateAddOnConformance() error {
 	}
 
 	if cfg.AddOnConformance.SonobuoyRunKubeConformanceImage == "" {
-		cfg.AddOnConformance.SonobuoyRunKubeConformanceImage = fmt.Sprintf("gcr.io/google-containers/conformance:v%s.0", cfg.Parameters.Version)
+		cfg.AddOnConformance.SonobuoyRunKubeConformanceImage = fmt.Sprintf("k8s.gcr.io/conformance:v%s.0", cfg.Parameters.Version)
 	}
 
 	cfg.AddOnConformance.SonobuoyResultDir = filepath.Join(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update sonobuoy tool version to run 1.19 conformance tests. 

Before sonobuoy version output shows this and logs have this warning
```
'sonobuoy version' output:

Sonobuoy Version: v0.18.3
MinimumKubeVersion: 1.16.0
MaximumKubeVersion: 1.18.99 <- Maximum is < 1.19

...
time="2021-02-17T12:44:53-08:00" level=warning msg="The maximum supported Kubernetes version is 1.18.99, but the server version is v1.19.6-eks-49a6c0. Sonobuoy will continue but unexpected results may occur."
```

After updating the tool version, sonobuoy version supports 1.19 and warning log goes away. 

Pulling conformance test image from gcr.io/google-containers throws errors such as 
```
docker pull gcr.io/google-containers/conformance:v1.19.0
Error response from daemon: manifest for gcr.io/google-containers/conformance:v1.19.0 not found: manifest unknown: Failed to fetch "v1.19.0" from request "/v2/google-containers/conformance/manifests/v1.19.0".

docker pull k8s.gcr.io/conformance:v1.19.0
v1.19.0: Pulling from conformance
Digest: sha256:b351fac91831932da3429511db178ab3ac432f87b7a67eba15c385fb6a42152c
Status: Image is up to date for k8s.gcr.io/conformance:v1.19.0
k8s.gcr.io/conformance:v1.19.0
```

It appears upstream images were moved away from gcr.io/google-containers which seems internal to Google.

After these changes tests succeed
```
AWS_K8S_TESTER_EKS_ON_FAILURE_DELETE=true \
AWS_K8S_TESTER_EKS_REGION=us-west-2 \
AWS_K8S_TESTER_EKS_LOG_COLOR=true \
AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE=true \
AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE_KEEP=false \
AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_CREATE=true \
AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_CREATE=true \
AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_SERVICE_PRINCIPALS="ec2.amazonaws.com,eks.amazonaws.com,eks-fargate-pods.amazonaws.com,eks-dev.aws.internal,eks-beta-pdx.aws.internal,eks-fargate-pods.aws.internal" \
AWS_K8S_TESTER_EKS_PARAMETERS_VERSION=1.19 \
AWS_K8S_TESTER_EKS_PARAMETERS_VPC_CREATE=true \
AWS_K8S_TESTER_EKS_CLIENTS=5 \
AWS_K8S_TESTER_EKS_CLIENT_QPS=30 \
AWS_K8S_TESTER_EKS_CLIENT_BURST=20 \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE=true \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_CREATE=true \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_SERVICE_PRINCIPALS="ec2.amazonaws.com,eks.amazonaws.com,eks-fargate-pods.amazonaws.com,eks-dev.aws.internal,eks-beta-pdx.aws.internal,eks-fargate-pods.aws.internal" \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS='{"GetRef.Name-ng-al2-cpu":{"name":"GetRef.Name-ng-al2-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id":"","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.19/amazon-linux-2/recommended/image_id","asg-min-size":15,"asg-max-size":15,"asg-desired-capacity":15,"instance-types":["c5.xlarge"],"volume-size":40,"kubelet-extra-args":"","cluster-autoscaler":{"enable":false}}}' \
AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_ENABLE=true \
aws-k8s-tester eks create cluster --enable-prompt=true --auto-path

...
...
*********************************
kubectl ("/test.yaml")

###########################
# kubectl commands
export KUBECONFIG=/test.kubeconfig.yaml
export KUBECTL="/bin/kubectl --kubeconfig=/test.kubeconfig.yaml"

/bin/kubectl --kubeconfig=/test.kubeconfig.yaml version
/bin/kubectl --kubeconfig=/test.kubeconfig.yaml cluster-info
/bin/kubectl --kubeconfig=/test.kubeconfig.yaml get cs
/bin/kubectl --kubeconfig=/test.kubeconfig.yaml --namespace=kube-system get pods
/bin/kubectl --kubeconfig=/test.kubeconfig.yaml --namespace=kube-system get ds
/bin/kubectl --kubeconfig=/test.kubeconfig.yaml get pods
/bin/kubectl --kubeconfig=/test.kubeconfig.yaml get csr -o=yaml
/bin/kubectl --kubeconfig=/test.kubeconfig.yaml get nodes --show-labels -o=wide
/bin/kubectl --kubeconfig=/test.kubeconfig.yaml get nodes -o=wide
###########################


{"level":"info","ts":"2021-02-18T06:22:53.537Z","caller":"eks/eks.go:980","msg":"Up succeeded","started":"1 hour ago"}
{"level":"info","ts":"2021-02-18T06:22:53.537Z","caller":"eks/eks.go:984","msg":"Up.defer end (/test.yaml, /bin/kubectl --kubeconfig=/test.kubeconfig.yaml)"}


*********************************


💯 😁 👍 :) UP SUCCESS
```

Note: Updating sonobuoy tool version to 1.19 removes 1.16 out of the supported matrix. Conformance tests for 1.17, 1.18 and 1.19 can be run with sonobuoy v1.19

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
