### PR TITLE
Stresser v2

### DIFF
--- a/cmd/aws-k8s-tester/eks/create-stresser-v2.go
+++ b/cmd/aws-k8s-tester/eks/create-stresser-v2.go
@@ -1,0 +1,589 @@
+package eks
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-k8s-tester/pkg/randutil"
+	"github.com/dustin/go-humanize"
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
+	"os"
+	"os/signal"
+	"sigs.k8s.io/yaml"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var cfg = stresser2{}
+
+func newCreateStresserV2() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stresser2",
+		Short: "Creates stresser v2",
+		Run:   createStresserFuncV2,
+	}
+	cmd.PersistentFlags().IntVar(&cfg.N, "number", 5, "number of go routines")
+	cmd.PersistentFlags().DurationVar(&cfg.duration, "duration", 10*time.Minute, "duration of the simulation")
+	cmd.PersistentFlags().IntVar(&cfg.objectSize, "object-size", 8, "object size, by default 8 bytes")
+	cmd.PersistentFlags().IntVar(&cfg.secretNum, "secret-num", 10, "secret object in default namespace, no more than 500")
+	return cmd
+}
+
+type stresser2 struct {
+	N int
+	duration time.Duration
+	objectSize int
+	secretNum int
+}
+
+func createStresserFuncV2(cmd *cobra.Command, args []string) {
+	if cfg.secretNum > 500 {
+		fmt.Fprintf(os.Stderr, "fail to start stresser v2, due to secret-num bigger than 500")
+		os.Exit(1)
+	}
+
+	// creates the in cluster cfg
+	config, err := clientcmd.BuildConfigFromFlags("", "")
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// increase qps and burst to avoid throttling on client-side
+	config.QPS = 100000000
+	config.Burst = 200000000
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGINT)
+	terminateC := make(chan struct{}, 1)
+
+	go func(){
+		select {
+		case sig := <- sigs:
+			fmt.Println(fmt.Sprintf("received signal, %s", sig.String()))
+			for i := 0; i < 2 * cfg.N + cfg.secretNum; i++ {
+				terminateC <- struct{}{}
+			}
+
+		case <- time.After(cfg.duration):
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(2 * cfg.N + cfg.secretNum)
+
+	for i := 0; i < cfg.secretNum; i++ {
+		go startWriteSecrets(config, &wg, cfg.duration, cfg.objectSize, terminateC)
+	}
+
+	for i := 0; i < cfg.N; i++ {
+		go startWriteConfigMaps(config, &wg, cfg.duration, cfg.objectSize, terminateC)
+		go startWritePods(config, &wg, cfg.duration, cfg.objectSize, terminateC)
+	}
+
+	wg.Wait()
+	fmt.Println("finish all jobs")
+}
+
+func startWriteSecrets(config *restclient.Config, wg *sync.WaitGroup, duration time.Duration, objectSize int, terminateC <-chan struct{}) {
+	defer wg.Done()
+
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// define the deployment client
+	secretsClient := clientset.CoreV1().Secrets(corev1.NamespaceDefault)
+	id := uuid.Must(uuid.NewRandom()).String()
+	secretName := "demo-secret" + id
+	val := randutil.String(objectSize)
+
+	stopc := make(chan struct{})
+	donecCloseOnce := new(sync.Once)
+
+	go func() {
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <- stopc:
+				fmt.Println("received stop signal")
+				return
+			case <- ticker.C:
+				func() {
+					ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
+					defer cancel()
+					defer func() {
+						time.Sleep(2*time.Second)
+						fmt.Println("Deleting deployment...")
+						err := secretsClient.Delete(context.TODO(), secretName, metav1.DeleteOptions{})
+						if err != nil {
+							fmt.Printf("fail delete secret %s due to %v.\n", secretName, err)
+						} else {
+							fmt.Printf("Deleted secret %s.\n", secretName)
+						}
+					}()
+
+					// define the deployment object
+					secret := &corev1.Secret{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "v1",
+							Kind: "Secret",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							// create random number to distinguish between multiple deployment
+							Name:      secretName,
+							Namespace: corev1.NamespaceDefault,
+							Labels: map[string]string{
+								"name": secretName,
+							},
+						},
+						Data: map[string][]byte{secretName: []byte(val)},
+					}
+					secretRawData, err := yaml.Marshal(secret)
+					if err != nil {
+						panic(fmt.Sprintf("fail marshal secret %v due to (%+v)", secret, err))
+					}
+
+					// Create Secret
+					fmt.Println("Creating secret...")
+					result, _ := secretsClient.Create(context.TODO(), secret, metav1.CreateOptions{})
+					fmt.Printf("Created secret %q with size %s.\n", result.GetObjectMeta().GetName(), humanize.Bytes(uint64(len(secretRawData))))
+
+					// forever loop to update deployment
+					for {
+						select {
+						case <- ctx.Done():
+							fmt.Println(fmt.Sprintf("time out stop updating the secret %s", secretName))
+							cancel()
+							return
+						case <- stopc:
+							fmt.Println("received stop signal")
+							return
+						default:
+						}
+						// Update Deployment
+						fmt.Printf("Updating secret %q.\n", secretName)
+						//    You have two options to Update() this Secret:
+						//
+						//    1. Modify the "deployment" variable and call: Update(secret).
+						//       This works like the "kubectl replace" command and it overwrites/loses changes
+						//       made by other clients between you Create() and Update() the object.
+						//    2. Modify the "result" returned by Get() and retry Update(result) until
+						//       you no longer get a conflict error. This way, you can preserve changes made
+						//       by other clients between Create() and Update(). This is implemented below
+						//			 using the retry utility package included with client-go. (RECOMMENDED)
+						//
+						// More Info:
+						// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+
+						retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+							// Retrieve the latest version of Deployment before attempting update
+							// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+							result, getErr := secretsClient.Get(context.TODO(), secretName, metav1.GetOptions{})
+							if getErr != nil {
+								fmt.Printf("The error message is: %q", getErr.Error())
+							}
+
+							// update annotation
+							if result.Annotations == nil {
+								newAnnotation := make(map[string]string)
+								newAnnotation["KEY"] = "value"
+								result.Annotations = newAnnotation
+								fmt.Println("Add Annotations for secret")
+							} else {
+								result.Annotations = nil
+								fmt.Println("Reset Annotations for secret")
+							}
+
+							_, updateErr := secretsClient.Update(context.TODO(), result, metav1.UpdateOptions{})
+							return updateErr
+						})
+						if retryErr != nil {
+							fmt.Printf("Update failed: %v", retryErr)
+						}
+						fmt.Println("Updated secret...")
+					}
+				}()
+			}
+		}
+	}()
+
+	select {
+	case <- time.After(duration):
+		fmt.Println(fmt.Sprintf("exit after timeout %v", duration))
+		donecCloseOnce.Do(func() {
+			close(stopc)
+		})
+		// enough time to gracefully shutdown and clean up spawned deployments
+		time.Sleep(30 * time.Second)
+		return
+	case <- terminateC:
+		fmt.Println("startWriteSecrets received signal from terminateC, stopping")
+		donecCloseOnce.Do(func() {
+			close(stopc)
+		})
+		// enough time to gracefully shutdown and clean up spawned deployments
+		time.Sleep(30 * time.Second)
+		return
+	}
+}
+
+func startWriteConfigMaps(config *restclient.Config, wg *sync.WaitGroup, duration time.Duration, objectSize int, terminateC <-chan struct{}) {
+	defer wg.Done()
+
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// define the configmap client
+	cmClient := clientset.CoreV1().ConfigMaps(corev1.NamespaceDefault)
+	id := uuid.Must(uuid.NewRandom()).String()
+	cmName := "demo-configmap" + id
+	val := randutil.String(objectSize)
+
+	stopc := make(chan struct{})
+	donecCloseOnce := new(sync.Once)
+
+	go func() {
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <- stopc:
+				fmt.Println("received stop signal")
+				return
+			case <- ticker.C:
+				func() {
+					ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
+					defer cancel()
+					defer func() {
+						time.Sleep(2*time.Second)
+						fmt.Println("Deleting configmap...")
+						err := cmClient.Delete(context.TODO(), cmName, metav1.DeleteOptions{})
+						if err != nil {
+							fmt.Printf("fail delete configmap %s due to %v.\n", cmName, err)
+						} else {
+							fmt.Printf("Deleted configmap %s.\n", cmName)
+						}
+					}()
+
+					// define the deployment object
+					cm := &corev1.ConfigMap{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "v1",
+							Kind: "ConfigMap",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							// create random number to distinguish between multiple deployment
+							Name:      cmName,
+							Namespace: corev1.NamespaceDefault,
+							Labels: map[string]string{
+								"name": cmName,
+							},
+						},
+						Data: map[string]string{cmName: val},
+					}
+					configMapRawData, err := yaml.Marshal(cm)
+					if err != nil {
+						panic(fmt.Sprintf("fail marshal configmap %v due to (%+v)", cm, err))
+					}
+
+					// Create Secret
+					fmt.Println("Creating configmap...")
+					result, _ := cmClient.Create(context.TODO(), cm, metav1.CreateOptions{})
+					fmt.Printf("Created configmap %q with size %s.\n", result.GetObjectMeta().GetName(), humanize.Bytes(uint64(len(configMapRawData))))
+
+					// forever loop to update configmap
+					for {
+						select {
+						case <- ctx.Done():
+							fmt.Println(fmt.Sprintf("time out stop updating the secret %s", cmName))
+							cancel()
+							return
+						case <- stopc:
+							fmt.Println("received stop signal")
+							return
+						default:
+						}
+						// Update Deployment
+						fmt.Printf("Updating configmap %q.\n", cmName)
+						//    You have two options to Update() this Secret:
+						//
+						//    1. Modify the "deployment" variable and call: Update(configmap).
+						//       This works like the "kubectl replace" command and it overwrites/loses changes
+						//       made by other clients between you Create() and Update() the object.
+						//    2. Modify the "result" returned by Get() and retry Update(result) until
+						//       you no longer get a conflict error. This way, you can preserve changes made
+						//       by other clients between Create() and Update(). This is implemented below
+						//			 using the retry utility package included with client-go. (RECOMMENDED)
+						//
+						// More Info:
+						// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+
+						retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+							// Retrieve the latest version of Deployment before attempting update
+							// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+							result, getErr := cmClient.Get(context.TODO(), cmName, metav1.GetOptions{})
+							if getErr != nil {
+								fmt.Printf("The error message is: %q", getErr.Error())
+							}
+
+							// update annotation
+							if result.Annotations == nil {
+								newAnnotation := make(map[string]string)
+								newAnnotation["KEY"] = "value"
+								result.Annotations = newAnnotation
+								fmt.Println("Add Annotations for secret")
+							} else {
+								result.Annotations = nil
+								fmt.Println("Reset Annotations for secret")
+							}
+
+							_, updateErr := cmClient.Update(context.TODO(), result, metav1.UpdateOptions{})
+							return updateErr
+						})
+						if retryErr != nil {
+							fmt.Printf("Update failed: %v", retryErr)
+						}
+						fmt.Println("Updated configmap...")
+					}
+				}()
+			}
+		}
+	}()
+
+	select {
+	case <- time.After(duration):
+		fmt.Println(fmt.Sprintf("exit after timeout %v", duration))
+		donecCloseOnce.Do(func() {
+			close(stopc)
+		})
+		// enough time to gracefully shutdown and clean up spawned deployments
+		time.Sleep(30 * time.Second)
+		return
+	case <- terminateC:
+		fmt.Println("startWriteConfigMaps received signal from terminateC, stopping")
+		donecCloseOnce.Do(func() {
+			close(stopc)
+		})
+		// enough time to gracefully shutdown and clean up spawned config maps
+		time.Sleep(30 * time.Second)
+		return
+	}
+}
+
+func startWritePods(config *restclient.Config, wg *sync.WaitGroup, duration time.Duration, objectSize int, terminateC <-chan struct{}) {
+	defer wg.Done()
+
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	podNamespace := "pod-namespace"
+	_, err = clientset.CoreV1().Namespaces().Create(context.TODO(),  &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podNamespace,
+			Namespace: "",
+		},
+		Status: corev1.NamespaceStatus{},
+	}, metav1.CreateOptions{})
+
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		panic(fmt.Sprintf("fail create namespace %s due to (%+v)", podNamespace, err))
+	}
+	if err == nil {
+		fmt.Println(fmt.Sprintf("succeed created namespace %s with status", podNamespace))
+	}
+
+	// define the configmap client
+	podClient := clientset.CoreV1().Pods(podNamespace)
+	id := uuid.Must(uuid.NewRandom()).String()
+	podName := "demo-pod" + id
+	val := randutil.String(objectSize)
+
+	stopc := make(chan struct{})
+	donecCloseOnce := new(sync.Once)
+
+	go func() {
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <- stopc:
+				fmt.Println("received stop signal")
+				return
+			case <- ticker.C:
+				func() {
+					ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
+					defer cancel()
+					defer func() {
+						time.Sleep(2*time.Second)
+						fmt.Println("Deleting pod...")
+						err := podClient.Delete(context.TODO(), podName, metav1.DeleteOptions{})
+						if err != nil {
+							fmt.Printf("fail delete pod %s due to %v.\n", podName, err)
+						} else {
+							fmt.Printf("Deleted pod %s.\n", podName)
+						}
+					}()
+
+					// define the deployment object
+					po := &corev1.Pod{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "v1",
+							Kind: "Pod",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							// create random number to distinguish between multiple deployment
+							Name:      podName,
+							Namespace: podNamespace,
+							Labels: map[string]string{
+								"name": podName,
+							},
+						},
+						Spec: corev1.PodSpec{
+							// spec.template.spec.restartPolicy: Unsupported value: "Always": supported values: "OnFailure", "Never"
+							RestartPolicy: corev1.RestartPolicyOnFailure,
+							Containers: []corev1.Container{
+								{
+									Name:            podName,
+									Image:           "730249423355.dkr.ecr.us-west-2.amazonaws.com/busybox:latest",
+									ImagePullPolicy: corev1.PullAlways,
+									Command: []string{
+										"/bin/sh",
+										"-ec",
+										fmt.Sprintf("echo -n '%s' >> /config/output.txt", val),
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "config",
+											MountPath: "/config",
+										},
+									},
+								},
+							},
+
+							Volumes: []corev1.Volume{
+								{
+									Name: "config",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+							},
+						},
+					}
+					poRawData, err := yaml.Marshal(po)
+					if err != nil {
+						panic(fmt.Sprintf("fail marshal pod %v due to (%+v)", po, err))
+					}
+
+					// Create Secret
+					fmt.Println("Creating pod...")
+					result, _ := podClient.Create(context.TODO(), po, metav1.CreateOptions{})
+					fmt.Printf("Created pod %q with size %s.\n", result.GetObjectMeta().GetName(), humanize.Bytes(uint64(len(poRawData))))
+
+					// forever loop to update configmap
+					for {
+						select {
+						case <- ctx.Done():
+							fmt.Println(fmt.Sprintf("time out stop updating the pod %s", podName))
+							cancel()
+							return
+						case <- stopc:
+							fmt.Println("received stop signal")
+							return
+						default:
+						}
+						// Update Deployment
+						fmt.Printf("Updating pod %q.\n", podName)
+						//    You have two options to Update() this Pod:
+						//
+						//    1. Modify the "deployment" variable and call: Update(configmap).
+						//       This works like the "kubectl replace" command and it overwrites/loses changes
+						//       made by other clients between you Create() and Update() the object.
+						//    2. Modify the "result" returned by Get() and retry Update(result) until
+						//       you no longer get a conflict error. This way, you can preserve changes made
+						//       by other clients between Create() and Update(). This is implemented below
+						//			 using the retry utility package included with client-go. (RECOMMENDED)
+						//
+						// More Info:
+						// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+
+						retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+							// Retrieve the latest version of Deployment before attempting update
+							// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+							result, getErr := podClient.Get(context.TODO(), podName, metav1.GetOptions{})
+							if getErr != nil {
+								fmt.Printf("The error message is: %q", getErr.Error())
+							}
+
+							// update annotation
+							if result.Annotations == nil {
+								newAnnotation := make(map[string]string)
+								newAnnotation["KEY"] = "value"
+								result.Annotations = newAnnotation
+								fmt.Println("Add Annotations for secret")
+							} else {
+								result.Annotations = nil
+								fmt.Println("Reset Annotations for secret")
+							}
+
+							_, updateErr := podClient.Update(context.TODO(), result, metav1.UpdateOptions{})
+							return updateErr
+						})
+						if retryErr != nil {
+							fmt.Printf("Update failed: %v", retryErr)
+						}
+						fmt.Println("Updated pod...")
+					}
+				}()
+			}
+		}
+	}()
+
+	select {
+	case <- time.After(duration):
+		fmt.Println(fmt.Sprintf("exit after timeout %v", duration))
+		donecCloseOnce.Do(func() {
+			close(stopc)
+		})
+		// enough time to gracefully shutdown and clean up spawned deployments
+		time.Sleep(30 * time.Second)
+
+		err = clientset.CoreV1().Namespaces().Delete(context.TODO(), podNamespace, metav1.DeleteOptions{})
+		if err != nil {
+			fmt.Println(fmt.Sprintf("fail delete namespace %s due to (%+v)", podNamespace, err))
+		}
+		return
+
+	case <- terminateC:
+		fmt.Println("startWritePods received signal from terminateC, stopping")
+		donecCloseOnce.Do(func() {
+			close(stopc)
+		})
+		// enough time to gracefully shutdown and clean up spawned deployments
+		time.Sleep(30 * time.Second)
+
+		err = clientset.CoreV1().Namespaces().Delete(context.TODO(), podNamespace, metav1.DeleteOptions{})
+		if err != nil {
+			fmt.Println(fmt.Sprintf("fail delete namespace %s", podNamespace))
+		}
+		return
+	}
+}

--- a/cmd/aws-k8s-tester/eks/create.go
+++ b/cmd/aws-k8s-tester/eks/create.go
@@ -15,6 +15,7 @@ func newCreate() *cobra.Command {
 		newCreateConfigMaps(),
 		newCreateSecrets(),
 		newCreateStresser(),
+		newCreateStresserV2(),
 		newCreateClusterLoader(),
 	)
 	return ac

--- a/eks/eks.go
+++ b/eks/eks.go
@@ -1129,6 +1129,7 @@ func (ts *Tester) Up() (err error) {
 		ts.cfg.Parameters.KubeControllerManagerBurst != "" &&
 		ts.cfg.Parameters.KubeSchedulerQPS != "" &&
 		ts.cfg.Parameters.KubeSchedulerBurst != "" &&
+		ts.cfg.Parameters.KubeAPIServerMaxRequestsInflight != "" &&
 		ts.cfg.Parameters.FEUpdateMasterFlagsURL != "" {
 
 		time.Sleep(5 * time.Minute)

--- a/eks/eks.go
+++ b/eks/eks.go
@@ -1123,13 +1123,14 @@ func (ts *Tester) Up() (err error) {
 		ts.cfg.Parameters.KubeSchedulerBurst != "" &&
 		ts.cfg.Parameters.FEUpdateMasterFlagsURL != "" {
 
-		time.Sleep(5*time.Minute)
+		time.Sleep(5 * time.Minute)
 		fmt.Fprintf(ts.logWriter, ts.color("[light_green]waiting 5 minutes for another control plane instance in service\n"))
 
 		fmt.Fprintf(ts.logWriter, ts.color("\n\n[yellow]*********************************\n"))
 		fmt.Fprintf(ts.logWriter, ts.color("[light_green]run awscurl Command.CommandAfterCreateCluster\n"))
 		curl := awscurl.New(awscurl.Config{
 			ClusterArn:                 ts.cfg.Status.ClusterARN,
+			MaxRequestsInflight:        ts.cfg.Parameters.KubeAPIServerMaxRequestsInflight,
 			KubeControllerManagerQPS:   ts.cfg.Parameters.KubeControllerManagerQPS,
 			KubeControllerManagerBurst: ts.cfg.Parameters.KubeControllerManagerBurst,
 			KubeSchedulerQPS:           ts.cfg.Parameters.KubeSchedulerQPS,

--- a/eks/eks.go
+++ b/eks/eks.go
@@ -65,6 +65,7 @@ import (
 	secrets_remote "github.com/aws/aws-k8s-tester/eks/secrets/remote"
 	stresser_local "github.com/aws/aws-k8s-tester/eks/stresser/local"
 	stresser_remote "github.com/aws/aws-k8s-tester/eks/stresser/remote"
+	stresser_remote_v2 "github.com/aws/aws-k8s-tester/eks/stresser2"
 	"github.com/aws/aws-k8s-tester/eks/tester"
 	eks_tester "github.com/aws/aws-k8s-tester/eks/tester"
 	"github.com/aws/aws-k8s-tester/eks/wordpress"
@@ -921,6 +922,13 @@ func (ts *Tester) createTesters() (err error) {
 			S3API:     ts.s3API,
 			CWAPI:     ts.cwAPI,
 			ECRAPI:    ecr.New(ts.awsSession, aws.NewConfig().WithRegion(ts.cfg.GetAddOnStresserRemoteRepositoryRegion())),
+		}),
+		stresser_remote_v2.New(stresser_remote_v2.Config{
+			Logger:    ts.lg,
+			Stopc:     ts.stopCreationCh,
+			EKSConfig: ts.cfg,
+			K8SClient: ts.k8sClient,
+			ECRAPI:    ecr.New(ts.awsSession, aws.NewConfig().WithRegion(ts.cfg.GetAddOnStresserRemoteV2RepositoryRegion())),
 		}),
 		cluster_version_upgrade.New(cluster_version_upgrade.Config{
 			Logger:    ts.lg,

--- a/eks/eks.go
+++ b/eks/eks.go
@@ -1123,6 +1123,9 @@ func (ts *Tester) Up() (err error) {
 		ts.cfg.Parameters.KubeSchedulerBurst != "" &&
 		ts.cfg.Parameters.FEUpdateMasterFlagsURL != "" {
 
+		time.Sleep(5*time.Minute)
+		fmt.Fprintf(ts.logWriter, ts.color("[light_green]waiting 5 minutes for another control plane instance in service\n"))
+
 		fmt.Fprintf(ts.logWriter, ts.color("\n\n[yellow]*********************************\n"))
 		fmt.Fprintf(ts.logWriter, ts.color("[light_green]run awscurl Command.CommandAfterCreateCluster\n"))
 		curl := awscurl.New(awscurl.Config{

--- a/eks/stresser2/stresser.go
+++ b/eks/stresser2/stresser.go
@@ -445,11 +445,17 @@ func (ts *tester) createCronJob() (err error) {
 	return nil
 }
 func (ts *tester) createObject() (batch_v1beta1.CronJob, string, error) {
-	testerCmd := fmt.Sprintf("/aws-k8s-tester eks create stresser2 --number=%s --duration=%s --object-size=%s --secret-num=%s",
+	testerCmd := fmt.Sprintf("/aws-k8s-tester eks create stresser2 --number=%d --duration=%s --object-size=%d --secret-num=%d --busybox-image=%s",
 		ts.cfg.EKSConfig.AddOnStresserRemoteV2.Coroutine,
 		ts.cfg.EKSConfig.AddOnStresserRemoteV2.Duration,
 		ts.cfg.EKSConfig.AddOnStresserRemoteV2.ObjectSize,
-		ts.cfg.EKSConfig.AddOnStresserRemoteV2.SecretNum)
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.SecretNum,
+		fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
+			ts.cfg.EKSConfig.AddOnStresserRemoteV2.RepositoryAccountID,
+			ts.cfg.EKSConfig.AddOnStresserRemoteV2.RepositoryRegion,
+			ts.cfg.EKSConfig.AddOnStresserRemoteV2.RepositoryBusyBoxName,
+			ts.cfg.EKSConfig.AddOnStresserRemoteV2.RepositoryBusyBoxImageTag),
+	)
 
 	dirOrCreate := v1.HostPathDirectoryOrCreate
 	podSpec := v1.PodTemplateSpec{

--- a/eks/stresser2/stresser.go
+++ b/eks/stresser2/stresser.go
@@ -210,7 +210,7 @@ func (ts *tester) createServiceAccount() (err error) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      stresserV2ServiceAccountName,
-					Namespace: ts.cfg.EKSConfig.AddOnStresserRemote.Namespace,
+					Namespace: ts.cfg.EKSConfig.AddOnStresserRemoteV2.Namespace,
 					Labels: map[string]string{
 						"app.kubernetes.io/name": stresserV2AppName,
 					},
@@ -373,7 +373,7 @@ func (ts *tester) createRBACClusterRoleBinding() (err error) {
 						APIGroup:  "",
 						Kind:      "ServiceAccount",
 						Name:      stresserV2ServiceAccountName,
-						Namespace: ts.cfg.EKSConfig.AddOnStresserRemote.Namespace,
+						Namespace: ts.cfg.EKSConfig.AddOnStresserRemoteV2.Namespace,
 					},
 					{
 						APIGroup: "rbac.authorization.k8s.io",

--- a/eks/stresser2/stresser.go
+++ b/eks/stresser2/stresser.go
@@ -1,0 +1,551 @@
+package stresser2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"reflect"
+	"strings"
+	"time"
+
+	eks_tester "github.com/aws/aws-k8s-tester/eks/tester"
+	"github.com/aws/aws-k8s-tester/eksconfig"
+	aws_ecr "github.com/aws/aws-k8s-tester/pkg/aws/ecr"
+	k8s_client "github.com/aws/aws-k8s-tester/pkg/k8s-client"
+	"github.com/aws/aws-k8s-tester/pkg/timeutil"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
+	"github.com/dustin/go-humanize"
+	"go.uber.org/zap"
+	batch_v1 "k8s.io/api/batch/v1"
+	batch_v1beta1 "k8s.io/api/batch/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/exec"
+	"sigs.k8s.io/yaml"
+)
+
+type Config struct {
+	Logger     *zap.Logger
+	LogWriter  io.Writer
+
+	Stopc     chan struct{}
+	EKSConfig *eksconfig.Config
+	K8SClient k8s_client.EKS
+	ECRAPI      ecriface.ECRAPI
+}
+
+var pkgName = reflect.TypeOf(tester{}).PkgPath()
+
+func (ts *tester) Name() string { return pkgName }
+
+func New(cfg Config) eks_tester.Tester {
+	cfg.Logger.Info("creating tester", zap.String("tester", pkgName))
+	return &tester{cfg: cfg}
+}
+
+type tester struct {
+	cfg      Config
+	ecrImage string
+}
+
+const (
+	stresserV2AppName = "stresser2-app"
+	stresserV2ServiceAccountName          = "stresser2-remote-service-account"
+	stresserV2RBACRoleName                = "stresser2-remote-rbac-role"
+	stresserV2RBACClusterRoleBindingName  = "stresser2-remote-rbac-role-binding"
+)
+
+func (ts *tester) Create() (err error) {
+	if !ts.cfg.EKSConfig.IsEnabledAddOnStresserRemoteV2() {
+		ts.cfg.Logger.Info("skipping tester.Create", zap.String("tester", pkgName))
+		return nil
+	}
+	if ts.cfg.EKSConfig.AddOnStresserRemoteV2.Created {
+		ts.cfg.Logger.Info("skipping tester.Create", zap.String("tester", pkgName))
+		return nil
+	}
+
+	ts.cfg.Logger.Info("starting tester.Create", zap.String("tester", pkgName))
+	ts.cfg.EKSConfig.AddOnStresserRemoteV2.Created = true
+	ts.cfg.EKSConfig.Sync()
+	createStart := time.Now()
+	defer func() {
+		createEnd := time.Now()
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.TimeFrameCreate = timeutil.NewTimeFrame(createStart, createEnd)
+		ts.cfg.EKSConfig.Sync()
+	}()
+
+	if ts.ecrImage, _, err = aws_ecr.Check(
+		ts.cfg.Logger,
+		ts.cfg.ECRAPI,
+		ts.cfg.EKSConfig.Partition,
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.RepositoryAccountID,
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.RepositoryRegion,
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.RepositoryName,
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.RepositoryImageTag,
+	); err != nil {
+		return err
+	}
+
+	if err = k8s_client.CreateNamespace(
+		ts.cfg.Logger,
+		ts.cfg.K8SClient.KubernetesClientSet(),
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.Namespace,
+	); err != nil {
+		return err
+	}
+	if err = ts.createServiceAccount(); err != nil {
+		return err
+	}
+	if err = ts.createRBACClusterRole(); err != nil {
+		return err
+	}
+	if err = ts.createRBACClusterRoleBinding(); err != nil {
+		return err
+	}
+	if err = ts.createCronJob(); err != nil {
+		return err
+	}
+
+	// TODO waits for all the job spawned by cronJob up and running
+
+
+	ts.cfg.EKSConfig.Sync()
+	return nil
+}
+
+func (ts *tester) Delete() (err error) {
+	if !ts.cfg.EKSConfig.IsEnabledAddOnStresserRemoteV2() {
+		ts.cfg.Logger.Info("skipping tester.Delete", zap.String("tester", pkgName))
+		return nil
+	}
+	if !ts.cfg.EKSConfig.AddOnStresserRemoteV2.Created {
+		ts.cfg.Logger.Info("skipping tester.Delete", zap.String("tester", pkgName))
+		return nil
+	}
+
+	ts.cfg.Logger.Info("starting tester.Delete", zap.String("tester", pkgName))
+	deleteStart := time.Now()
+	defer func() {
+		deleteEnd := time.Now()
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.TimeFrameDelete = timeutil.NewTimeFrame(deleteStart, deleteEnd)
+		ts.cfg.EKSConfig.Sync()
+	}()
+
+	var errs []string
+
+	if err := ts.deleteCronJob(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	time.Sleep(2 * time.Minute)
+
+	if err := ts.deleteRBACClusterRoleBinding(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := ts.deleteRBACClusterRole(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := ts.deleteServiceAccount(); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	getAllArgs := []string{
+		ts.cfg.EKSConfig.KubectlPath,
+		"--kubeconfig=" + ts.cfg.EKSConfig.KubeConfigPath,
+		"--namespace=" + ts.cfg.EKSConfig.AddOnStresserRemoteV2.Namespace,
+		"get",
+		"all",
+	}
+	getAllCmd := strings.Join(getAllArgs, " ")
+
+	if err := k8s_client.DeleteNamespaceAndWait(
+		ts.cfg.Logger,
+		ts.cfg.K8SClient.KubernetesClientSet(),
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.Namespace,
+		k8s_client.DefaultNamespaceDeletionInterval,
+		k8s_client.DefaultNamespaceDeletionTimeout,
+		k8s_client.WithQueryFunc(func() {
+			fmt.Fprintf(ts.cfg.LogWriter, "\n")
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			output, err := exec.New().CommandContext(ctx, getAllArgs[0], getAllArgs[1:]...).CombinedOutput()
+			cancel()
+			out := strings.TrimSpace(string(output))
+			if err != nil {
+				ts.cfg.Logger.Warn("'kubectl get all' failed", zap.Error(err))
+			}
+			fmt.Fprintf(ts.cfg.LogWriter, "\n\n'%s' output:\n\n%s\n\n", getAllCmd, out)
+		}),
+		k8s_client.WithForceDelete(true),
+	); err != nil {
+		errs = append(errs, fmt.Sprintf("failed to delete remote stresser2 namespace (%v)", err))
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ", "))
+	}
+
+	ts.cfg.EKSConfig.AddOnStresserRemoteV2.Created = false
+	ts.cfg.EKSConfig.Sync()
+	return
+}
+
+// ref. https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+// ref. https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#foreground-cascading-deletion
+func (ts *tester) createServiceAccount() (err error) {
+	ts.cfg.Logger.Info("creating stresser2 ServiceAccount")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err = ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ServiceAccounts(ts.cfg.EKSConfig.AddOnStresserRemoteV2.Namespace).
+		Create(
+			ctx,
+			&v1.ServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      stresserV2ServiceAccountName,
+					Namespace: ts.cfg.EKSConfig.AddOnStresserRemote.Namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": stresserV2AppName,
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create stresser2 ServiceAccount (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created stresser2 ServiceAccount")
+	ts.cfg.EKSConfig.Sync()
+	return
+}
+func (ts *tester) deleteServiceAccount() (err error) {
+	ts.cfg.Logger.Info("deleting stresser2 ServiceAccount")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err = ts.cfg.K8SClient.KubernetesClientSet().
+		CoreV1().
+		ServiceAccounts(ts.cfg.EKSConfig.AddOnStresserRemoteV2.Namespace).
+		Delete(
+			ctx,
+			stresserV2ServiceAccountName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete", zap.Error(err))
+		return fmt.Errorf("failed to delete stresser2 ServiceAccount (%v)", err)
+	}
+	ts.cfg.Logger.Info("deleted stresser2 ServiceAccount", zap.Error(err))
+
+	ts.cfg.EKSConfig.Sync()
+	return
+}
+func (ts *tester) createRBACClusterRole() (err error) {
+	ts.cfg.Logger.Info("creating stresser RBAC ClusterRole")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err = ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoles().
+		Create(
+			ctx,
+			&rbacv1.ClusterRole{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "ClusterRole",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      stresserV2RBACRoleName,
+					Namespace: "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name": stresserV2AppName,
+					},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{
+							"*",
+						},
+						Resources: []string{
+							"configmaps",
+							"leases",
+							"nodes",
+							"pods",
+							"secrets",
+							"services",
+							"namespaces",
+							"stresser",
+							"endpoints",
+							"events",
+							"ingresses",
+							"ingresses/status",
+							"services",
+							"jobs",
+							"cronjobs",
+						},
+						Verbs: []string{
+							"create",
+							"get",
+							"list",
+							"update",
+							"watch",
+							"patch",
+						},
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create stresser2 RBAC ClusterRole (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created stresser2 RBAC ClusterRole")
+	ts.cfg.EKSConfig.Sync()
+	return
+}
+func (ts *tester) deleteRBACClusterRole() (err error) {
+	ts.cfg.Logger.Info("deleting stresser2 RBAC ClusterRole")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err = ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoles().
+		Delete(
+			ctx,
+			stresserV2RBACRoleName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete", zap.Error(err))
+		return fmt.Errorf("failed to delete stresser2 RBAC ClusterRole (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("deleted stresser2 RBAC ClusterRole", zap.Error(err))
+	ts.cfg.EKSConfig.Sync()
+	return
+}
+
+// https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+func (ts *tester) createRBACClusterRoleBinding() (err error) {
+	ts.cfg.Logger.Info("creating stresser2 RBAC ClusterRoleBinding")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err = ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoleBindings().
+		Create(
+			ctx,
+			&rbacv1.ClusterRoleBinding{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "ClusterRoleBinding",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      stresserV2RBACClusterRoleBindingName,
+					Namespace: "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name": stresserV2AppName,
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     stresserV2RBACRoleName,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						APIGroup:  "",
+						Kind:      "ServiceAccount",
+						Name:      stresserV2ServiceAccountName,
+						Namespace: ts.cfg.EKSConfig.AddOnStresserRemote.Namespace,
+					},
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "system:node",
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create stresser2 RBAC ClusterRoleBinding (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created stresser2 RBAC ClusterRoleBinding")
+	ts.cfg.EKSConfig.Sync()
+	return
+}
+func (ts *tester) deleteRBACClusterRoleBinding() (err error) {
+	ts.cfg.Logger.Info("deleting stresser2 RBAC ClusterRoleBinding")
+	foreground := metav1.DeletePropagationForeground
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err = ts.cfg.K8SClient.KubernetesClientSet().
+		RbacV1().
+		ClusterRoleBindings().
+		Delete(
+			ctx,
+			stresserV2RBACClusterRoleBindingName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &foreground,
+			},
+		)
+	cancel()
+	if err != nil && !apierrs.IsNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		ts.cfg.Logger.Warn("failed to delete", zap.Error(err))
+		return fmt.Errorf("failed to delete stresser2 RBAC ClusterRoleBinding (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("deleted stresser2 RBAC ClusterRoleBinding", zap.Error(err))
+	ts.cfg.EKSConfig.Sync()
+	return
+}
+
+func (ts *tester) createCronJob() (err error) {
+	obj, b, err := ts.createObject()
+	if err != nil {
+		return err
+	}
+
+	ts.cfg.Logger.Info("creating CronJob",
+		zap.String("name", stresserV2AppName),
+		zap.Int("completes", ts.cfg.EKSConfig.AddOnStresserRemoteV2.Completes),
+		zap.Int("parallels", ts.cfg.EKSConfig.AddOnStresserRemoteV2.Parallels),
+		zap.String("object-size", humanize.Bytes(uint64(len(b)))),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	_, err = ts.cfg.K8SClient.KubernetesClientSet().
+		BatchV1beta1().
+		CronJobs(ts.cfg.EKSConfig.AddOnStresserRemoteV2.Namespace).
+		Create(ctx, &obj, metav1.CreateOptions{})
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to create CronJob (%v)", err)
+	}
+
+	ts.cfg.Logger.Info("created CronJob")
+	return nil
+}
+func (ts *tester) createObject() (batch_v1beta1.CronJob, string, error) {
+	testerCmd := fmt.Sprintf("/aws-k8s-tester eks create stresser2 --number=%s --duration=%s --object-size=%s --secret-num=%s",
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.Coroutine,
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.Duration,
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.ObjectSize,
+		ts.cfg.EKSConfig.AddOnStresserRemoteV2.SecretNum)
+
+	dirOrCreate := v1.HostPathDirectoryOrCreate
+	podSpec := v1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app.kubernetes.io/name": stresserV2AppName,
+			},
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyOnFailure,
+			Containers: []v1.Container{
+				{
+					Name:            stresserV2AppName,
+					Image:           ts.ecrImage,
+					ImagePullPolicy: v1.PullAlways,
+					Command: []string{
+						"/bin/sh",
+						"-ec",
+						testerCmd,
+					},
+					// ref. https://kubernetes.io/docs/concepts/cluster-administration/logging/
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "logging",
+							MountPath: "/var/log",
+							ReadOnly:  false,
+						},
+					},
+				},
+			},
+			// ref. https://kubernetes.io/docs/concepts/cluster-administration/logging/
+			Volumes: []v1.Volume{
+				{
+					Name: "logging",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/var/log",
+							Type: &dirOrCreate,
+						},
+					},
+				},
+			},
+		},
+	}
+	jobSpec := batch_v1beta1.JobTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stresserV2AppName,
+			Namespace: ts.cfg.EKSConfig.AddOnStresserRemoteV2.Namespace,
+		},
+		Spec: batch_v1.JobSpec{
+			Completions: aws.Int32(int32(ts.cfg.EKSConfig.AddOnStresserRemoteV2.Completes)),
+			Parallelism: aws.Int32(int32(ts.cfg.EKSConfig.AddOnStresserRemoteV2.Parallels)),
+			Template:    podSpec,
+		},
+	}
+	cronObj := batch_v1beta1.CronJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1beta1",
+			Kind:       "CronJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stresserV2AppName,
+			Namespace: ts.cfg.EKSConfig.AddOnStresserRemoteV2.Namespace,
+		},
+		Spec: batch_v1beta1.CronJobSpec{
+			Schedule:                   ts.cfg.EKSConfig.AddOnStresserRemoteV2.Schedule,
+			SuccessfulJobsHistoryLimit: aws.Int32(ts.cfg.EKSConfig.AddOnStresserRemoteV2.SuccessfulJobsHistoryLimit),
+			FailedJobsHistoryLimit:     aws.Int32(ts.cfg.EKSConfig.AddOnStresserRemoteV2.FailedJobsHistoryLimit),
+			JobTemplate:                jobSpec,
+			ConcurrencyPolicy:          batch_v1beta1.ReplaceConcurrent,
+		},
+	}
+	b, err := yaml.Marshal(cronObj)
+	return cronObj, string(b), err
+}
+func (ts *tester) deleteCronJob() (err error) {
+	propagationBackground := metav1.DeletePropagationBackground
+	ts.cfg.Logger.Info("deleting CronJob", zap.String("name", stresserV2AppName))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	err = ts.cfg.
+		K8SClient.KubernetesClientSet().
+		BatchV1beta1().
+		CronJobs(ts.cfg.EKSConfig.AddOnCronJobs.Namespace).
+		Delete(
+			ctx,
+			stresserV2AppName,
+			metav1.DeleteOptions{
+				GracePeriodSeconds: aws.Int64(0),
+				PropagationPolicy:  &propagationBackground,
+			},
+		)
+	cancel()
+	if err != nil {
+		return err
+	}
+	ts.cfg.Logger.Info("deleted CronJob", zap.String("name", stresserV2AppName))
+	return nil
+}
+

--- a/eksconfig/add-on-stresser-remote-v2.go
+++ b/eksconfig/add-on-stresser-remote-v2.go
@@ -1,0 +1,146 @@
+package eksconfig
+
+import (
+	"errors"
+	"github.com/aws/aws-k8s-tester/pkg/timeutil"
+	"time"
+)
+
+type AddOnStresserRemoteV2 struct {
+	// Enable is 'true' to create this add-on.
+	Enable bool `json:"enable"`
+	// Created is true when the resource has been created.
+	// Used for delete operations.
+	Created         bool               `json:"created" read-only:"true"`
+	TimeFrameCreate timeutil.TimeFrame `json:"time-frame-create" read-only:"true"`
+	TimeFrameDelete timeutil.TimeFrame `json:"time-frame-delete" read-only:"true"`
+
+	// Namespace is the namespace to create objects in.
+	Namespace string `json:"namespace"`
+
+	// RepositoryAccountID is the account ID for tester ECR image.
+	// e.g. "aws/aws-k8s-tester" for "[ACCOUNT_ID].dkr.ecr.[REGION].amazonaws.com/aws/aws-k8s-tester"
+	RepositoryAccountID string `json:"repository-account-id,omitempty"`
+	// RepositoryRegion is the ECR repository region to pull from.
+	RepositoryRegion string `json:"repository-region,omitempty"`
+	// RepositoryName is the repositoryName for tester ECR image.
+	// e.g. "aws/aws-k8s-tester" for "[ACCOUNT_ID].dkr.ecr.[REGION].amazonaws.com/aws/aws-k8s-tester"
+	RepositoryName string `json:"repository-name,omitempty"`
+	// RepositoryImageTag is the image tag for tester ECR image.
+	// e.g. "latest" for image URI "[ACCOUNT_ID].dkr.ecr.[REGION].amazonaws.com/aws/aws-k8s-tester:latest"
+	RepositoryImageTag string `json:"repository-image-tag,omitempty"`
+
+	// RepositoryBusyBoxName is the repositoryName for busybox ECR image.
+	// e.g. "busybox" for image URI "[ACCOUNT_ID].dkr.ecr.[REGION].amazonaws.com/aws/busybox:latest"
+	RepositoryBusyBoxName string `json:"repository-busybox-name,omitempty"`
+	// RepositoryBusyBoxImageTag is the image tag for busybox ECR image.
+	// e.g. "latest" for image URI "[ACCOUNT_ID].dkr.ecr.[REGION].amazonaws.com/aws/busybox:latest"
+	RepositoryBusyBoxImageTag string `json:"repository-busybox-image-tag,omitempty"`
+
+	// Schedule is the cron schedule (e.g. "*/5 * * * *").
+	Schedule  string `json:"schedule"`
+	// Completes is the desired number of successfully finished pods.
+	Completes int `json:"completes"`
+	// Parallels is the the maximum desired number of pods the
+	// job should run at any given time.
+	Parallels int `json:"parallels"`
+	// SuccessfulJobsHistoryLimit is the number of successful finished
+	// jobs to retain. Defaults to 3.
+	SuccessfulJobsHistoryLimit int32 `json:"successful-jobs-history-limit"`
+	// FailedJobsHistoryLimit is the number of failed finished jobs
+	// to retain. Defaults to 1.
+	FailedJobsHistoryLimit int32 `json:"failed-jobs-history-limit"`
+
+	// ObjectSize is the value size in bytes for write objects.
+	// If 0, do not write anything.
+	ObjectSize int `json:"object-size"`
+
+	// Duration is the duration to run stress2 testing.
+	Duration   time.Duration `json:"duration,omitempty"`
+	DurationString string    `json:"duration-string,omitempty" read-only:"true"`
+
+	// Coroutine is the number of concurrent go routines run per job
+	Coroutine  int `json:"coroutine"`
+	// SecretNum is the number of secrets generated per job
+	SecretNum  int `json:"secret-num"`
+}
+
+// EnvironmentVariablePrefixAddOnStresserRemoteV2 is the environment variable prefix used for "eksconfig".
+const EnvironmentVariablePrefixAddOnStresserRemoteV2 = AWS_K8S_TESTER_EKS_PREFIX + "ADD_ON_STRESSER_REMOTE_V2_"
+
+// IsEnabledAddOnStresserRemote returns true if "AddOnStresserRemote" is enabled.
+// Otherwise, nil the field for "omitempty".
+func (cfg *Config) IsEnabledAddOnStresserRemoteV2() bool {
+	if cfg.AddOnStresserRemoteV2 == nil {
+		return false
+	}
+	if cfg.AddOnStresserRemoteV2.Enable {
+		return true
+	}
+	cfg.AddOnStresserRemoteV2 = nil
+	return false
+}
+
+func getDefaultAddOnStresserRemoteV2() *AddOnStresserRemoteV2 {
+	return &AddOnStresserRemoteV2{
+		Enable:                                false,
+		Schedule:                              "0 */6 * * *", // every 6 hours align with etcd defrag interval
+		Completes:                             10,
+		Parallels:                             10,
+		SuccessfulJobsHistoryLimit:            3,
+		FailedJobsHistoryLimit:                1,
+		ObjectSize:                            8, // 8 bytes
+		Duration:                              10*time.Minute,
+		Coroutine:                             10,
+		SecretNum:                             10,
+	}
+}
+
+func (cfg *Config) GetAddOnStresserRemoteV2RepositoryRegion() string {
+	if !cfg.IsEnabledAddOnStresserRemoteV2() {
+		return cfg.Region
+	}
+	return cfg.AddOnStresserRemoteV2.RepositoryRegion
+}
+
+func (cfg *Config) validateAddOnStresserRemoteV2() error {
+	if !cfg.IsEnabledAddOnStresserRemoteV2() {
+		return nil
+	}
+
+	if cfg.AddOnStresserRemoteV2.Namespace == "" {
+		cfg.AddOnStresserRemoteV2.Namespace = cfg.Name + "-stresser-remote-v2"
+	}
+
+	if cfg.AddOnStresserRemoteV2.RepositoryAccountID == "" {
+		return errors.New("AddOnStresserRemoteV2.RepositoryAccountID empty")
+	}
+	if cfg.AddOnStresserRemoteV2.RepositoryRegion == "" {
+		cfg.AddOnStresserRemoteV2.RepositoryRegion = cfg.Region
+	}
+	if cfg.AddOnStresserRemoteV2.RepositoryName == "" {
+		return errors.New("AddOnStresserRemoteV2.RepositoryName empty")
+	}
+	if cfg.AddOnStresserRemoteV2.RepositoryImageTag == "" {
+		return errors.New("AddOnStresserRemoteV2.RepositoryImageTag empty")
+	}
+	if cfg.AddOnStresserRemoteV2.RepositoryBusyBoxName == "" {
+		return errors.New("AddOnStresserRemoteV2.RepositoryBusyBoxName empty")
+	}
+	if cfg.AddOnStresserRemoteV2.RepositoryBusyBoxImageTag == "" {
+		return errors.New("AddOnStresserRemoteV2.RepositoryBusyBoxImageTag empty")
+	}
+
+	if cfg.AddOnStresserRemoteV2.Duration == time.Duration(0) {
+		cfg.AddOnStresserRemoteV2.Duration = 10*time.Minute
+	}
+	cfg.AddOnStresserRemoteV2.DurationString = cfg.AddOnStresserRemoteV2.Duration.String()
+	if cfg.AddOnStresserRemoteV2.Coroutine <= 0 {
+		cfg.AddOnStresserRemoteV2.Coroutine = 10
+	}
+	if cfg.AddOnStresserRemoteV2.SecretNum >= 0 {
+		cfg.AddOnStresserRemoteV2.SecretNum = 10
+	}
+
+	return nil
+}

--- a/eksconfig/add-on-stresser-remote-v2.go
+++ b/eksconfig/add-on-stresser-remote-v2.go
@@ -2,8 +2,9 @@ package eksconfig
 
 import (
 	"errors"
-	"github.com/aws/aws-k8s-tester/pkg/timeutil"
 	"time"
+
+	"github.com/aws/aws-k8s-tester/pkg/timeutil"
 )
 
 type AddOnStresserRemoteV2 struct {
@@ -38,7 +39,7 @@ type AddOnStresserRemoteV2 struct {
 	RepositoryBusyBoxImageTag string `json:"repository-busybox-image-tag,omitempty"`
 
 	// Schedule is the cron schedule (e.g. "*/5 * * * *").
-	Schedule  string `json:"schedule"`
+	Schedule string `json:"schedule"`
 	// Completes is the desired number of successfully finished pods.
 	Completes int `json:"completes"`
 	// Parallels is the the maximum desired number of pods the
@@ -56,13 +57,13 @@ type AddOnStresserRemoteV2 struct {
 	ObjectSize int `json:"object-size"`
 
 	// Duration is the duration to run stress2 testing.
-	Duration   time.Duration `json:"duration,omitempty"`
-	DurationString string    `json:"duration-string,omitempty" read-only:"true"`
+	Duration       time.Duration `json:"duration,omitempty"`
+	DurationString string        `json:"duration-string,omitempty" read-only:"true"`
 
-	// Coroutine is the number of concurrent go routines run per job
-	Coroutine  int `json:"coroutine"`
-	// SecretNum is the number of secrets generated per job
-	SecretNum  int `json:"secret-num"`
+	// Coroutines is the number of concurrent go routines run per job
+	Coroutines int `json:"coroutines"`
+	// Secrets is the number of secrets generated per job
+	Secrets int `json:"secrets"`
 }
 
 // EnvironmentVariablePrefixAddOnStresserRemoteV2 is the environment variable prefix used for "eksconfig".
@@ -83,16 +84,16 @@ func (cfg *Config) IsEnabledAddOnStresserRemoteV2() bool {
 
 func getDefaultAddOnStresserRemoteV2() *AddOnStresserRemoteV2 {
 	return &AddOnStresserRemoteV2{
-		Enable:                                false,
-		Schedule:                              "0 */6 * * *", // every 6 hours align with etcd defrag interval
-		Completes:                             10,
-		Parallels:                             10,
-		SuccessfulJobsHistoryLimit:            3,
-		FailedJobsHistoryLimit:                1,
-		ObjectSize:                            8, // 8 bytes
-		Duration:                              10*time.Minute,
-		Coroutine:                             10,
-		SecretNum:                             10,
+		Enable:                     false,
+		Schedule:                   "0 */6 * * *", // every 6 hours align with etcd defrag interval
+		Completes:                  10,
+		Parallels:                  10,
+		SuccessfulJobsHistoryLimit: 3,
+		FailedJobsHistoryLimit:     1,
+		ObjectSize:                 8, // 8 bytes
+		Duration:                   10 * time.Minute,
+		Coroutines:                 10,
+		Secrets:                    10,
 	}
 }
 
@@ -132,14 +133,14 @@ func (cfg *Config) validateAddOnStresserRemoteV2() error {
 	}
 
 	if cfg.AddOnStresserRemoteV2.Duration == time.Duration(0) {
-		cfg.AddOnStresserRemoteV2.Duration = 10*time.Minute
+		cfg.AddOnStresserRemoteV2.Duration = 10 * time.Minute
 	}
 	cfg.AddOnStresserRemoteV2.DurationString = cfg.AddOnStresserRemoteV2.Duration.String()
-	if cfg.AddOnStresserRemoteV2.Coroutine <= 0 {
-		cfg.AddOnStresserRemoteV2.Coroutine = 10
+	if cfg.AddOnStresserRemoteV2.Coroutines <= 0 {
+		cfg.AddOnStresserRemoteV2.Coroutines = 10
 	}
-	if cfg.AddOnStresserRemoteV2.SecretNum >= 0 {
-		cfg.AddOnStresserRemoteV2.SecretNum = 10
+	if cfg.AddOnStresserRemoteV2.Secrets >= 0 {
+		cfg.AddOnStresserRemoteV2.Secrets = 10
 	}
 
 	return nil

--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -338,6 +338,11 @@ type Config struct {
 	// It generates loads from the remote workers (Pod) in the cluster.
 	// ref. https://github.com/kubernetes/perf-tests
 	AddOnStresserRemote *AddOnStresserRemote `json:"add-on-stresser-remote,omitempty"`
+	// AddOnStresserRemoteV2 defines parameters for EKS cluster
+	// add-on cluster loader remote v2.
+	// It generates loads from the remote workers (Pod) in the cluster.
+	// ref. https://github.com/kubernetes/perf-tests
+	AddOnStresserRemoteV2 *AddOnStresserRemoteV2 `json:"add-on-stresser-remote-v2,omitempty"`
 
 	// AddOnClusterVersionUpgrade defines parameters
 	// for EKS cluster version upgrade add-on.
@@ -894,6 +899,7 @@ func NewDefault() *Config {
 		AddOnHollowNodesRemote:     getDefaultAddOnHollowNodesRemote(),
 		AddOnStresserLocal:         getDefaultAddOnStresserLocal(),
 		AddOnStresserRemote:        getDefaultAddOnStresserRemote(),
+		AddOnStresserRemoteV2:      getDefaultAddOnStresserRemoteV2(),
 		AddOnClusterVersionUpgrade: getDefaultAddOnClusterVersionUpgrade(),
 		AddOnAmiSoftLockupIssue454: getDefaultAddOnAmiSoftLockupIssue454(),
 
@@ -1097,6 +1103,9 @@ func (cfg *Config) ValidateAndSetDefaults() error {
 	}
 	if err := cfg.validateAddOnStresserRemote(); err != nil {
 		return fmt.Errorf("validateAddOnStresserRemote failed [%v]", err)
+	}
+	if err := cfg.validateAddOnStresserRemoteV2(); err != nil {
+		return fmt.Errorf("validateAddOnStresserRemoteV2 failed [%v]", err)
 	}
 
 	if err := cfg.validateAddOnClusterVersionUpgrade(); err != nil {

--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -463,20 +463,24 @@ type Parameters struct {
 	// ref. https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
 	// ref. https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/
 
+	// KubeAPIServerMaxRequestsInflight is the EKS kube-apiserver max-requests-inflight
+	// The maximum number of non-mutating requests in flight at a given time. When the server exceeds this, it rejects requests. Zero for no limit.
+	// --max-requests-inflight int     Default: 400
+	KubeAPIServerMaxRequestsInflight string `json:"kube-apiserver-max-requests-inflight"`
 	// KubeControllerManagerQPS is the EKS kube-controller-manager qps
 	// --kube-api-qps float32     Default: 20
-	KubeControllerManagerQPS   string `json:"kube-controller-manager-qps,omitempty"`
+	KubeControllerManagerQPS string `json:"kube-controller-manager-qps,omitempty"`
 	// KubeControllerManagerBurst is the EKS kube-controller-manager burst
 	// --kube-api-burst int32     Default: 30
 	KubeControllerManagerBurst string `json:"kube-controller-manager-burst,omitempty"`
 	// KubeSchedulerQPS is the internal EKS kube-scheduler qps
 	// --kube-api-qps float32     Default: 50
-	KubeSchedulerQPS           string `json:"kube-scheduler-qps,omitempty"`
+	KubeSchedulerQPS string `json:"kube-scheduler-qps,omitempty"`
 	// KubeSchedulerBurst is the internal EKS kube-scheduler burst
 	// --kube-api-burst int32     Default: 100
-	KubeSchedulerBurst         string `json:"kube-scheduler-burst,omitempty"`
+	KubeSchedulerBurst string `json:"kube-scheduler-burst,omitempty"`
 	// FEUpdateMasterFlagsURL is the internal EKS update master flags endpoint
-	FEUpdateMasterFlagsURL     string `json:"fe-update-master-flags-url,omitempty"`
+	FEUpdateMasterFlagsURL string `json:"fe-update-master-flags-url,omitempty"`
 }
 
 func getDefaultParameters() *Parameters {

--- a/eksconfig/env.go
+++ b/eksconfig/env.go
@@ -541,6 +541,16 @@ func (cfg *Config) UpdateFromEnvs() (err error) {
 		return fmt.Errorf("expected *AddOnStresserRemote, got %T", vv)
 	}
 
+	vv, err = parseEnvs(EnvironmentVariablePrefixAddOnStresserRemoteV2, cfg.AddOnStresserRemoteV2)
+	if err != nil {
+		return err
+	}
+	if av, ok := vv.(*AddOnStresserRemoteV2); ok {
+		cfg.AddOnStresserRemoteV2 = av
+	} else {
+		return fmt.Errorf("expected *AddOnStresserRemoteV2, got %T", vv)
+	}
+
 	if cfg.AddOnClusterVersionUpgrade == nil {
 		cfg.AddOnClusterVersionUpgrade = &AddOnClusterVersionUpgrade{}
 	}

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -125,6 +125,8 @@ spec:
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_CREATE")
 	os.Setenv("AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_ARN", "key-arn")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_ARN")
+	os.Setenv("AWS_K8S_TESTER_EKS_PARAMETERS_KUBE_APISERVER_MAX_REQUESTS_INFLIGHT", "3000")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_PARAMETERS_KUBE_APISERVER_MAX_REQUESTS_INFLIGHT")
 	os.Setenv("AWS_K8S_TESTER_EKS_PARAMETERS_KUBE_CONTROLLER_MANAGER_QPS", "500")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_PARAMETERS_KUBE_CONTROLLER_MANAGER_QPS")
 	os.Setenv("AWS_K8S_TESTER_EKS_PARAMETERS_KUBE_CONTROLLER_MANAGER_BURST", "500")
@@ -748,6 +750,9 @@ spec:
 	}
 	if cfg.Parameters.EncryptionCMKARN != "key-arn" {
 		t.Fatalf("unexpected Parameters.EncryptionCMKARN %q", cfg.Parameters.EncryptionCMKARN)
+	}
+	if cfg.Parameters.KubeAPIServerMaxRequestsInflight != "3000" {
+		t.Fatalf("unexpected Parameters.KubeAPIServerMaxRequestsInflight %s", cfg.Parameters.KubeAPIServerMaxRequestsInflight)
 	}
 	if cfg.Parameters.KubeControllerManagerQPS != "500" {
 		t.Fatalf("unexpected Parameters.KubeControllerManagerQPS %s", cfg.Parameters.KubeControllerManagerQPS)

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -586,6 +586,38 @@ spec:
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_REQUESTS_SUMMARY_READS_OUTPUT_NAME_PREFIX", "stresser-out-pfx")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_REQUESTS_SUMMARY_READS_OUTPUT_NAME_PREFIX")
 
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_ENABLE", "true")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_ENABLE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_NAMESPACE", "hello")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_NAMESPACE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_ACCOUNT_ID", "uri")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_ACCOUNT_ID")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_NAME", "stresser-repo-name")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_NAME")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_IMAGE_TAG", "stresser-repo-image-tag")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_IMAGE_TAG")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_BUSYBOX_NAME", "stresser-busybox-name")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_BUSYBOX_NAME")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_BUSYBOX_IMAGE_TAG", "stresser-busybox-image-tag")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_BUSYBOX_IMAGE_TAG")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SCHEDULE", "*/1 * * * *")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SCHEDULE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_COMPLETES", "500")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_COMPLETES")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_PARALLELS", "500")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_PARALLELS")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SUCCESSFUL_JOBS_HISTORY_LIMIT", "500")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SUCCESSFUL_JOBS_HISTORY_LIMIT")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_FAILED_JOBS_HISTORY_LIMIT", "500")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_FAILED_JOBS_HISTORY_LIMIT")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_OBJECT_SIZE", "512")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_OBJECT_SIZE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_DURATION", "7m30s")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_DURATION")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_COROUTINE", "10")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_COROUTINE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SECRET_NUM", "10")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SECRET_NUM")
 	if err := cfg.UpdateFromEnvs(); err != nil {
 		t.Fatal(err)
 	}
@@ -1549,6 +1581,55 @@ spec:
 	}
 	if cfg.AddOnStresserRemote.RequestsSummaryReadsOutputNamePrefix != "stresser-out-pfx" {
 		t.Fatalf("unexpected cfg.AddOnStresserRemote.RequestsSummaryReadsOutputNamePrefix %v", cfg.AddOnStresserRemote.RequestsSummaryReadsOutputNamePrefix)
+	}
+
+	if !cfg.AddOnStresserRemoteV2.Enable {
+		t.Fatalf("unexpected AddOnStresserRemoteV2.Enable %v", cfg.AddOnStresserRemoteV2.Enable)
+	}
+	if cfg.AddOnStresserRemoteV2.Namespace != "hello" {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.Namespace %q", cfg.AddOnStresserRemoteV2.Namespace)
+	}
+	if cfg.AddOnStresserRemoteV2.RepositoryAccountID != "uri" {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.RepositoryAccountID %s", cfg.AddOnStresserRemoteV2.RepositoryAccountID)
+	}
+	if cfg.AddOnStresserRemoteV2.RepositoryName != "stresser-repo-name" {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.RepositoryName %s", cfg.AddOnStresserRemoteV2.RepositoryName)
+	}
+	if cfg.AddOnStresserRemoteV2.RepositoryImageTag != "stresser-repo-image-tag" {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.RepositoryImageTag %s", cfg.AddOnStresserRemoteV2.RepositoryImageTag)
+	}
+	if cfg.AddOnStresserRemoteV2.RepositoryBusyBoxName != "stresser-busybox-name" {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.RepositoryBusyBoxName %s", cfg.AddOnStresserRemoteV2.RepositoryBusyBoxName)
+	}
+	if cfg.AddOnStresserRemoteV2.RepositoryBusyBoxImageTag != "stresser-busybox-image-tag" {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.RepositoryBusyBoxImageTag %s", cfg.AddOnStresserRemoteV2.RepositoryBusyBoxImageTag)
+	}
+	if cfg.AddOnStresserRemoteV2.Schedule != "*/1 * * * *" {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.Schedule %s", cfg.AddOnStresserRemoteV2.Schedule)
+	}
+	if cfg.AddOnStresserRemoteV2.Completes != 500 {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.Completes %d", cfg.AddOnStresserRemoteV2.Completes)
+	}
+	if cfg.AddOnStresserRemoteV2.Parallels != 500 {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.Parallels %d", cfg.AddOnStresserRemoteV2.Parallels)
+	}
+	if cfg.AddOnStresserRemoteV2.SuccessfulJobsHistoryLimit != 500 {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.SuccessfulJobsHistoryLimit %d", cfg.AddOnStresserRemoteV2.SuccessfulJobsHistoryLimit)
+	}
+	if cfg.AddOnStresserRemoteV2.FailedJobsHistoryLimit != 500 {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.FailedJobsHistoryLimit %d", cfg.AddOnStresserRemoteV2.FailedJobsHistoryLimit)
+	}
+	if cfg.AddOnStresserRemoteV2.ObjectSize != 512 {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.ObjectSize %d", cfg.AddOnStresserRemoteV2.ObjectSize)
+	}
+	if cfg.AddOnStresserRemoteV2.Duration != 7*time.Minute+30*time.Second {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.Duration %v", cfg.AddOnStresserRemoteV2.Duration)
+	}
+	if cfg.AddOnStresserRemoteV2.Coroutine != 10{
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.Coroutine %d", cfg.AddOnStresserRemoteV2.Coroutine)
+	}
+	if cfg.AddOnStresserRemoteV2.SecretNum != 10 {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.SecretNum %d", cfg.AddOnStresserRemoteV2.SecretNum)
 	}
 
 	cfg.Parameters.RoleManagedPolicyARNs = nil

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -614,10 +614,10 @@ spec:
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_OBJECT_SIZE")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_DURATION", "7m30s")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_DURATION")
-	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_COROUTINE", "10")
-	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_COROUTINE")
-	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SECRET_NUM", "10")
-	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SECRET_NUM")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_COROUTINES", "10")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_COROUTINES")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SECRETS", "10")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SECRETS")
 	if err := cfg.UpdateFromEnvs(); err != nil {
 		t.Fatal(err)
 	}
@@ -1625,11 +1625,11 @@ spec:
 	if cfg.AddOnStresserRemoteV2.Duration != 7*time.Minute+30*time.Second {
 		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.Duration %v", cfg.AddOnStresserRemoteV2.Duration)
 	}
-	if cfg.AddOnStresserRemoteV2.Coroutine != 10{
-		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.Coroutine %d", cfg.AddOnStresserRemoteV2.Coroutine)
+	if cfg.AddOnStresserRemoteV2.Coroutines != 10 {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.Coroutines %d", cfg.AddOnStresserRemoteV2.Coroutines)
 	}
-	if cfg.AddOnStresserRemoteV2.SecretNum != 10 {
-		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.SecretNum %d", cfg.AddOnStresserRemoteV2.SecretNum)
+	if cfg.AddOnStresserRemoteV2.Secrets != 10 {
+		t.Fatalf("unexpected cfg.AddOnStresserRemoteV2.Secrets %d", cfg.AddOnStresserRemoteV2.Secrets)
 	}
 
 	cfg.Parameters.RoleManagedPolicyARNs = nil

--- a/pkg/aws/awscurl/awscurl.go
+++ b/pkg/aws/awscurl/awscurl.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
 )
 
@@ -73,7 +73,7 @@ func (c *client) signRequest() (*http.Request, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to load SDK config, %v", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5 *time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	creds, err := cfg.Credentials.Retrieve(ctx)
 	if err != nil {
 		return nil, err
@@ -105,12 +105,15 @@ func (c *client) makeRequest(method string) (req *http.Request, err error) {
 
 func (c *client) preparePayload() (payloadData []byte, err error) {
 	customFlagsConfig := customFlagsConfig{
+		Apiserver: apiserverCustomFlag{
+			MaxRequestsInflight: c.cfg.MaxRequestsInflight,
+		},
 		ControllerManager: qpsBurst{
-			KubeApiQps: c.cfg.KubeControllerManagerQPS,
+			KubeApiQps:   c.cfg.KubeControllerManagerQPS,
 			KubeApiBurst: c.cfg.KubeControllerManagerBurst,
 		},
-		Scheduler:         qpsBurst{
-			KubeApiQps: c.cfg.KubeSchedulerQPS,
+		Scheduler: qpsBurst{
+			KubeApiQps:   c.cfg.KubeSchedulerQPS,
 			KubeApiBurst: c.cfg.KubeSchedulerBurst,
 		},
 	}
@@ -121,7 +124,7 @@ func (c *client) preparePayload() (payloadData []byte, err error) {
 	}
 
 	payload := payload{
-		ClusterArn: c.cfg.ClusterArn,
+		ClusterArn:        c.cfg.ClusterArn,
 		CustomFlagsConfig: string(customFlagsConfigData),
 	}
 	payloadData, err = json.Marshal(payload)

--- a/pkg/aws/awscurl/types.go
+++ b/pkg/aws/awscurl/types.go
@@ -1,16 +1,17 @@
 package awscurl
 
 type Config struct {
-	ClusterArn string
-	KubeControllerManagerQPS string
+	ClusterArn                 string
+	MaxRequestsInflight        string
+	KubeControllerManagerQPS   string
 	KubeControllerManagerBurst string
-	KubeSchedulerQPS string
-	KubeSchedulerBurst string
-	URI string
+	KubeSchedulerQPS           string
+	KubeSchedulerBurst         string
+	URI                        string
 
 	Service string
-	Region string
-	Method string
+	Region  string
+	Method  string
 }
 
 // awscurl -X POST \
@@ -20,6 +21,10 @@ type Config struct {
 //       "clusterArn": "GetRef.ClusterARN",
 //       "customFlagsConfig":
 //          "{
+//             \"apiServer\":
+//               {
+//                 \"maxRequestsInflight\":\"3000\"
+//               }
 //             \"controllerManager\":
 //               {
 //                 \"kubeApiQps\":\"500\",
@@ -27,7 +32,7 @@ type Config struct {
 //               },
 //             \"scheduler\":
 //               { \"kubeApiQps\":\"500\",
-//                 \"kubeApiBurst\":\"501\"
+//                 \"kubeApiBurst\":\"500\"
 //               }
 //            }"
 //     }' \
@@ -38,8 +43,13 @@ type payload struct {
 }
 
 type customFlagsConfig struct {
-	ControllerManager qpsBurst `json:"controllerManager"`
-	Scheduler         qpsBurst `json:"scheduler"`
+	Apiserver         apiserverCustomFlag `json:"apiServer"`
+	ControllerManager qpsBurst            `json:"controllerManager"`
+	Scheduler         qpsBurst            `json:"scheduler"`
+}
+
+type apiserverCustomFlag struct {
+	MaxRequestsInflight string `json:"maxRequestsInflight"`
 }
 
 type qpsBurst struct {


### PR DESCRIPTION
*Description of changes:*

Added stresser v2 add on to keep updating one k8s resource until reaching etcd limit. 

```bash
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_ENABLE=true \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_ACCOUNT_ID=730249423355 \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_NAME=aws/aws-k8s-tester \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_IMAGE_TAG=latest \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_BUSYBOX_NAME=busybox \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_REPOSITORY_BUSYBOX_IMAGE_TAG=latest \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SCHEDULE='0 */6 * * *' \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_PARALLELS=10 \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_COMPLETES=10 \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_OBJECT_SIZE=8 \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_DURATION=15m \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_COROUTINE=10 \
AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_REMOTE_V2_SECRET_NUM=10 \
aws-k8s-tester eks create cluster --enable-prompt=true --auto-path
```

```bash
ESC[33m*********************************
ESC[0mESC[92mtesters[34].Create ESC[36m"github.com/aws/aws-k8s-tester/eks/stresser2" ESC[39m("/tmp/eks-2021022507-spheres8fvv3.yaml", "/tmp/kubectl-test-v1.18.9 --kubeconfig=/tmp/eks-2021022507-spheres8fvv3.kubeconfig.yaml")
ESC[0m{"level":"info","ts":"2021-02-25T08:46:47.473Z","caller":"stresser2/stresser.go:72","msg":"starting tester.Create","tester":"github.com/aws/aws-k8s-tester/eks/stresser2"}
{"level":"info","ts":"2021-02-25T08:46:47.487Z","caller":"ecr/ecr.go:39","msg":"describing an ECR repository","repo-account-id":"730249423355","repo-region":"us-west-2","repo-name":"aws/aws-k8s-tester","image-tag":"latest","image":"730249423355.dkr.ecr.us-west-2.amazona
ws.com/aws/aws-k8s-tester:latest"}
{"level":"info","ts":"2021-02-25T08:46:47.510Z","caller":"ecr/ecr.go:72","msg":"described an ECR repository","repo-arn":"arn:aws:ecr:us-west-2:730249423355:repository/aws/aws-k8s-tester","repo-region":"us-west-2","repo-name":"aws/aws-k8s-tester","repo-uri":"730249423355
.dkr.ecr.us-west-2.amazonaws.com/aws/aws-k8s-tester","image":"730249423355.dkr.ecr.us-west-2.amazonaws.com/aws/aws-k8s-tester:latest"}
{"level":"info","ts":"2021-02-25T08:46:47.510Z","caller":"ecr/ecr.go:90","msg":"describing images","repo-name":"aws/aws-k8s-tester","repo-uri":"730249423355.dkr.ecr.us-west-2.amazonaws.com/aws/aws-k8s-tester","image-tag":"latest"}
{"level":"info","ts":"2021-02-25T08:46:47.525Z","caller":"ecr/ecr.go:111","msg":"described images","repo-name":"aws/aws-k8s-tester","image-tag":"latest","images":1}
{"level":"info","ts":"2021-02-25T08:46:47.525Z","caller":"ecr/ecr.go:117","msg":"found an image","index":0,"requested-tag":"latest","returned-tags":["latest"],"digest":"sha256:6b8a0b877bda31756deaf663d5ee3c4448998f8132b6aa2cee3ce77cde58f0ff","pushed-at":"2021-02-25 03:4
3:38 +0000 UTC","size":"319 MB"}
{"level":"info","ts":"2021-02-25T08:46:47.525Z","caller":"k8s-client/k8s.go:209","msg":"creating namespace","namespace":"eks-2021022507-spheres8fvv3-stresser-remote-v2"}
{"level":"info","ts":"2021-02-25T08:46:47.532Z","caller":"k8s-client/k8s.go:218","msg":"namespace already exists","namespace":"eks-2021022507-spheres8fvv3-stresser-remote-v2","error":"namespaces \"eks-2021022507-spheres8fvv3-stresser-remote-v2\" already exists"}
{"level":"info","ts":"2021-02-25T08:46:47.532Z","caller":"stresser2/stresser.go:199","msg":"creating stresser2 ServiceAccount"}
{"level":"info","ts":"2021-02-25T08:46:47.540Z","caller":"stresser2/stresser.go:226","msg":"created stresser2 ServiceAccount"}
{"level":"info","ts":"2021-02-25T08:46:47.552Z","caller":"stresser2/stresser.go:256","msg":"creating stresser RBAC ClusterRole"}
{"level":"info","ts":"2021-02-25T08:46:47.561Z","caller":"stresser2/stresser.go:315","msg":"created stresser2 RBAC ClusterRole"}
{"level":"info","ts":"2021-02-25T08:46:47.573Z","caller":"stresser2/stresser.go:347","msg":"creating stresser2 RBAC ClusterRoleBinding"}
{"level":"info","ts":"2021-02-25T08:46:47.580Z","caller":"stresser2/stresser.go:392","msg":"created stresser2 RBAC ClusterRoleBinding"}
{"level":"info","ts":"2021-02-25T08:46:47.593Z","caller":"stresser2/stresser.go:428","msg":"creating CronJob","name":"stresser2-app","completes":10,"parallels":10,"object-size":"1.4 kB"}
{"level":"info","ts":"2021-02-25T08:46:47.603Z","caller":"stresser2/stresser.go:444","msg":"created CronJob"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
