### PR TITLE
Adding CLUSTER_LOADER_REMOTE_CL2_SCHEDULER_THROUGHPUT_THRESHOLD and C…

### DIFF
--- a/cmd/aws-k8s-tester/eks/create-cluster-loader.go
+++ b/cmd/aws-k8s-tester/eks/create-cluster-loader.go
@@ -22,31 +22,32 @@ var (
 	clusterLoaderRegion       string
 	clusterLoaderS3BucketName string
 
-	clusterLoaderKubeConfigPath                 string
-	clusterLoaderPath                           string
-	clusterLoaderTestConfigPath                 string
-	clusterLoaderReportDir                      string
-	clusterLoaderReportTarGzPath                string
-	clusterLoaderReportTarGzS3Key               string
-	clusterLoaderLogPath                        string
-	clusterLoaderLogS3Key                       string
-	clusterLoaderPodStartupLatencyPath          string
-	clusterLoaderPodStartupLatencyS3Key         string
-	clusterLoaderRuns                           int
-	clusterLoaderTimeout                        time.Duration
-	clusterLoaderNodes                          int
-	clusterLoaderNodesPerNamespace              int
-	clusterLoaderPodsPerNode                    int
-	clusterLoaderBigGroupSize                   int
-	clusterLoaderMediumGroupSize                int
-	clusterLoaderSmallGroupSize                 int
-	clusterLoaderSmallStatefulSetsPerNamespace  int
-	clusterLoaderMediumStatefulSetsPerNamespace int
-	clusterLoaderCL2UseHostNetworkPods          bool
-	clusterLoaderCL2LoadTestThroughput          int
-	clusterLoaderCL2EnablePVS                   bool
-	clusterLoaderPrometheusScrapeKubeProxy      bool
-	clusterLoaderEnableSystemPodMetrics         bool
+	clusterLoaderKubeConfigPath                  string
+	clusterLoaderPath                            string
+	clusterLoaderTestConfigPath                  string
+	clusterLoaderReportDir                       string
+	clusterLoaderReportTarGzPath                 string
+	clusterLoaderReportTarGzS3Key                string
+	clusterLoaderLogPath                         string
+	clusterLoaderLogS3Key                        string
+	clusterLoaderPodStartupLatencyPath           string
+	clusterLoaderPodStartupLatencyS3Key          string
+	clusterLoaderRuns                            int
+	clusterLoaderTimeout                         time.Duration
+	clusterLoaderNodes                           int
+	clusterLoaderNodesPerNamespace               int
+	clusterLoaderPodsPerNode                     int
+	clusterLoaderBigGroupSize                    int
+	clusterLoaderMediumGroupSize                 int
+	clusterLoaderSmallGroupSize                  int
+	clusterLoaderSmallStatefulSetsPerNamespace   int
+	clusterLoaderMediumStatefulSetsPerNamespace  int
+	clusterLoaderCL2UseHostNetworkPods           bool
+	clusterLoaderCL2LoadTestThroughput           int
+	clusterLoaderCL2EnablePVS                    bool
+	clusterLoaderCL2SchedulerThroughputThreshold int
+	clusterLoaderPrometheusScrapeKubeProxy       bool
+	clusterLoaderEnableSystemPodMetrics          bool
 )
 
 func newCreateClusterLoader() *cobra.Command {
@@ -83,6 +84,7 @@ func newCreateClusterLoader() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&clusterLoaderCL2UseHostNetworkPods, "cl2-use-host-network-pods", false, "clusterloader2 use host network pods to bypass CNI")
 	cmd.PersistentFlags().IntVar(&clusterLoaderCL2LoadTestThroughput, "cl2-load-test-throughput", 20, "clusterloader2 test throughput")
 	cmd.PersistentFlags().BoolVar(&clusterLoaderCL2EnablePVS, "cl2-enable-pvs", false, "'true' to enable CL2 PVS")
+	cmd.PersistentFlags().IntVar(&clusterLoaderCL2SchedulerThroughputThreshold, "cl2-scheduler-throughput-threshold", 100, "threshold for scheduler throughput")
 	cmd.PersistentFlags().BoolVar(&clusterLoaderPrometheusScrapeKubeProxy, "prometheus-scrape-kube-proxy", false, "'true' to enable Prometheus scrape kube-proxy")
 	cmd.PersistentFlags().BoolVar(&clusterLoaderEnableSystemPodMetrics, "enable-system-pod-metrics", false, "'true' to enable system pod metrics")
 
@@ -152,9 +154,11 @@ func createClusterLoaderFunc(cmd *cobra.Command, args []string) {
 		SmallStatefulSetsPerNamespace:  clusterLoaderSmallStatefulSetsPerNamespace,
 		MediumStatefulSetsPerNamespace: clusterLoaderMediumStatefulSetsPerNamespace,
 
-		CL2UseHostNetworkPods:     clusterLoaderCL2UseHostNetworkPods,
-		CL2LoadTestThroughput:     clusterLoaderCL2LoadTestThroughput,
-		CL2EnablePVS:              clusterLoaderCL2EnablePVS,
+		CL2UseHostNetworkPods:           clusterLoaderCL2UseHostNetworkPods,
+		CL2LoadTestThroughput:           clusterLoaderCL2LoadTestThroughput,
+		CL2EnablePVS:                    clusterLoaderCL2EnablePVS,
+		CL2SchedulerThroughputThreshold: clusterLoaderCL2SchedulerThroughputThreshold,
+
 		PrometheusScrapeKubeProxy: clusterLoaderPrometheusScrapeKubeProxy,
 		EnableSystemPodMetrics:    clusterLoaderEnableSystemPodMetrics,
 	})

--- a/eks/cluster-loader/cluster-loader.go
+++ b/eks/cluster-loader/cluster-loader.go
@@ -84,11 +84,12 @@ type Config struct {
 	SmallStatefulSetsPerNamespace  int
 	MediumStatefulSetsPerNamespace int
 
-	CL2UseHostNetworkPods     bool
-	CL2LoadTestThroughput     int
-	CL2EnablePVS              bool
-	PrometheusScrapeKubeProxy bool
-	EnableSystemPodMetrics    bool
+	CL2UseHostNetworkPods           bool
+	CL2LoadTestThroughput           int
+	CL2EnablePVS                    bool
+	CL2SchedulerThroughputThreshold int
+	PrometheusScrapeKubeProxy       bool
+	EnableSystemPodMetrics          bool
 }
 
 // Loader defines cluster loader operations.
@@ -530,6 +531,7 @@ MEDIUM_STATEFUL_SETS_PER_NAMESPACE: {{ .MediumStatefulSetsPerNamespace }}
 CL2_USE_HOST_NETWORK_PODS: {{ .CL2UseHostNetworkPods }}
 CL2_LOAD_TEST_THROUGHPUT: {{ .CL2LoadTestThroughput }}
 CL2_ENABLE_PVS: {{ .CL2EnablePVS }}
+CL2_SCHEDULER_THROUGHPUT_THRESHOLD: {{ .CL2SchedulerThroughputThreshold }}
 PROMETHEUS_SCRAPE_KUBE_PROXY: {{ .PrometheusScrapeKubeProxy }}
 ENABLE_SYSTEM_POD_METRICS: {{ .EnableSystemPodMetrics }}
 `

--- a/eks/cluster-loader/local/cluster-loader.go
+++ b/eks/cluster-loader/local/cluster-loader.go
@@ -97,9 +97,11 @@ func (ts *tester) Create() (err error) {
 		SmallStatefulSetsPerNamespace:  ts.cfg.EKSConfig.AddOnClusterLoaderLocal.SmallStatefulSetsPerNamespace,
 		MediumStatefulSetsPerNamespace: ts.cfg.EKSConfig.AddOnClusterLoaderLocal.MediumStatefulSetsPerNamespace,
 
-		CL2UseHostNetworkPods:     ts.cfg.EKSConfig.AddOnClusterLoaderLocal.CL2UseHostNetworkPods,
-		CL2LoadTestThroughput:     ts.cfg.EKSConfig.AddOnClusterLoaderLocal.CL2LoadTestThroughput,
-		CL2EnablePVS:              ts.cfg.EKSConfig.AddOnClusterLoaderLocal.CL2EnablePVS,
+		CL2UseHostNetworkPods:           ts.cfg.EKSConfig.AddOnClusterLoaderLocal.CL2UseHostNetworkPods,
+		CL2LoadTestThroughput:           ts.cfg.EKSConfig.AddOnClusterLoaderLocal.CL2LoadTestThroughput,
+		CL2EnablePVS:                    ts.cfg.EKSConfig.AddOnClusterLoaderLocal.CL2EnablePVS,
+		CL2SchedulerThroughputThreshold: ts.cfg.EKSConfig.AddOnClusterLoaderLocal.CL2SchedulerThroughputThreshold,
+
 		PrometheusScrapeKubeProxy: ts.cfg.EKSConfig.AddOnClusterLoaderLocal.PrometheusScrapeKubeProxy,
 		EnableSystemPodMetrics:    ts.cfg.EKSConfig.AddOnClusterLoaderLocal.EnableSystemPodMetrics,
 	})

--- a/eks/cluster-loader/remote/cluster-loader.go
+++ b/eks/cluster-loader/remote/cluster-loader.go
@@ -540,7 +540,7 @@ func (ts *tester) createObject() (batchv1.Job, string, error) {
 	// ref. https://github.com/kubernetes/client-go/blob/master/examples/in-cluster-client-configuration/main.go
 
 	// ref. https://github.com/kubernetes/perf-tests/pull/1295
-	testerCmd := fmt.Sprintf("/aws-k8s-tester eks create cluster-loader --partition=%s --region=%s --s3-bucket-name=%s --cluster-loader-path=/clusterloader2 --test-config-path=/clusterloader2-test-config.yaml --report-dir=/var/log/cluster-loader-remote --report-tar-gz-path=/var/log/cluster-loader-remote.tar.gz --report-tar-gz-s3-path=%s --log-path=/var/log/cluster-loader-remote.log --log-s3-path=%s --pod-startup-latency-path=/var/log/cluster-loader-remote.pod-startup-latency-output.json --pod-startup-latency-s3-path=%s --runs=%d --timeout=%v --nodes=%d --nodes-per-namespace=%d --pods-per-node=%d --big-group-size=%d --medium-group-size=%d --small-group-size=%d --small-stateful-sets-per-namespace=%d --medium-stateful-sets-per-namespace=%d --cl2-use-host-network-pods=%v --cl2-load-test-throughput=%d --cl2-enable-pvs=%v --prometheus-scrape-kube-proxy=%v --enable-system-pod-metrics=%v",
+	testerCmd := fmt.Sprintf("/aws-k8s-tester eks create cluster-loader --partition=%s --region=%s --s3-bucket-name=%s --cluster-loader-path=/clusterloader2 --test-config-path=/clusterloader2-test-config.yaml --report-dir=/var/log/cluster-loader-remote --report-tar-gz-path=/var/log/cluster-loader-remote.tar.gz --report-tar-gz-s3-path=%s --log-path=/var/log/cluster-loader-remote.log --log-s3-path=%s --pod-startup-latency-path=/var/log/cluster-loader-remote.pod-startup-latency-output.json --pod-startup-latency-s3-path=%s --runs=%d --timeout=%v --nodes=%d --nodes-per-namespace=%d --pods-per-node=%d --big-group-size=%d --medium-group-size=%d --small-group-size=%d --small-stateful-sets-per-namespace=%d --medium-stateful-sets-per-namespace=%d --cl2-use-host-network-pods=%v --cl2-load-test-throughput=%d --cl2-enable-pvs=%v --prometheus-scrape-kube-proxy=%v --enable-system-pod-metrics=%v --cl2-scheduler-throughput-threshold=%d",
 		ts.cfg.EKSConfig.Partition,
 		ts.cfg.EKSConfig.Region,
 		ts.cfg.EKSConfig.S3BucketName,
@@ -562,6 +562,7 @@ func (ts *tester) createObject() (batchv1.Job, string, error) {
 		ts.cfg.EKSConfig.AddOnClusterLoaderRemote.CL2EnablePVS,
 		ts.cfg.EKSConfig.AddOnClusterLoaderRemote.PrometheusScrapeKubeProxy,
 		ts.cfg.EKSConfig.AddOnClusterLoaderRemote.EnableSystemPodMetrics,
+		ts.cfg.EKSConfig.AddOnClusterLoaderRemote.CL2SchedulerThroughputThreshold,
 	)
 
 	dirOrCreate := v1.HostPathDirectoryOrCreate

--- a/eksconfig/README.md
+++ b/eksconfig/README.md
@@ -848,81 +848,83 @@ AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_VERSION_UPGRADE_ENABLE=true \
 *-------------------------------------------------------------*-------------------*-----------------------------------------------*--------------------*
 
 
-*-----------------------------------------------------------------------------------*-------------------*-------------------------------------------------------------------*--------------------*
-|                              ENVIRONMENTAL VARIABLE                               |     READ ONLY     |                               TYPE                                |      GO TYPE       |
-*-----------------------------------------------------------------------------------*-------------------*-------------------------------------------------------------------*--------------------*
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_ENABLE                             | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.Enable                         | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CREATED                            | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.Created                        | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_TIME_FRAME_CREATE                  | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.TimeFrameCreate                | timeutil.TimeFrame |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_TIME_FRAME_DELETE                  | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.TimeFrameDelete                | timeutil.TimeFrame |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_S3_DIR                             | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.S3Dir                          | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CLUSTER_LOADER_PATH                | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.ClusterLoaderPath              | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CLUSTER_LOADER_DOWNLOAD_URL        | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.ClusterLoaderDownloadURL       | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_TEST_CONFIG_PATH                   | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.TestConfigPath                 | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_REPORT_DIR                         | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.ReportDir                      | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_REPORT_TAR_GZ_PATH                 | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.ReportTarGzPath                | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_REPORT_TAR_GZ_S3_KEY               | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.ReportTarGzS3Key               | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_LOG_PATH                           | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.LogPath                        | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_LOG_S3_KEY                         | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.LogS3Key                       | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_POD_STARTUP_LATENCY_PATH           | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.PodStartupLatencyPath          | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_POD_STARTUP_LATENCY_S3_KEY         | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.PodStartupLatencyS3Key         | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_RUNS                               | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.Runs                           | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_TIMEOUT                            | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.Timeout                        | time.Duration      |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_NODES                              | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.Nodes                          | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_NODES_PER_NAMESPACE                | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.NodesPerNamespace              | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_PODS_PER_NODE                      | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.PodsPerNode                    | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_BIG_GROUP_SIZE                     | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.BigGroupSize                   | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_MEDIUM_GROUP_SIZE                  | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.MediumGroupSize                | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_SMALL_GROUP_SIZE                   | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.SmallGroupSize                 | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_SMALL_STATEFUL_SETS_PER_NAMESPACE  | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.SmallStatefulSetsPerNamespace  | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_MEDIUM_STATEFUL_SETS_PER_NAMESPACE | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.MediumStatefulSetsPerNamespace | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_USE_HOST_NETWORK_PODS          | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.CL2UseHostNetworkPods          | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_LOAD_TEST_THROUGHPUT           | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.CL2LoadTestThroughput          | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_ENABLE_PVS                     | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.CL2EnablePVS                   | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_PROMETHEUS_SCRAPE_KUBE_PROXY       | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.PrometheusScrapeKubeProxy      | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_ENABLE_SYSTEM_POD_METRICS          | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.EnableSystemPodMetrics         | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_POD_STARTUP_LATENCY                | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.PodStartupLatency              | util.PerfData      |
-*-----------------------------------------------------------------------------------*-------------------*-------------------------------------------------------------------*--------------------*
+*-----------------------------------------------------------------------------------*-------------------*--------------------------------------------------------------------*--------------------*
+|                              ENVIRONMENTAL VARIABLE                               |     READ ONLY     |                               TYPE                                 |      GO TYPE       |
+*-----------------------------------------------------------------------------------*-------------------*--------------------------------------------------------------------*--------------------*
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_ENABLE                             | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.Enable                          | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CREATED                            | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.Created                         | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_TIME_FRAME_CREATE                  | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.TimeFrameCreate                 | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_TIME_FRAME_DELETE                  | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.TimeFrameDelete                 | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_S3_DIR                             | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.S3Dir                           | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CLUSTER_LOADER_PATH                | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.ClusterLoaderPath               | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CLUSTER_LOADER_DOWNLOAD_URL        | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.ClusterLoaderDownloadURL        | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_TEST_CONFIG_PATH                   | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.TestConfigPath                  | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_REPORT_DIR                         | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.ReportDir                       | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_REPORT_TAR_GZ_PATH                 | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.ReportTarGzPath                 | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_REPORT_TAR_GZ_S3_KEY               | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.ReportTarGzS3Key                | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_LOG_PATH                           | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.LogPath                         | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_LOG_S3_KEY                         | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.LogS3Key                        | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_POD_STARTUP_LATENCY_PATH           | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.PodStartupLatencyPath           | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_POD_STARTUP_LATENCY_S3_KEY         | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.PodStartupLatencyS3Key          | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_RUNS                               | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.Runs                            | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_TIMEOUT                            | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.Timeout                         | time.Duration      |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_NODES                              | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.Nodes                           | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_NODES_PER_NAMESPACE                | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.NodesPerNamespace               | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_PODS_PER_NODE                      | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.PodsPerNode                     | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_BIG_GROUP_SIZE                     | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.BigGroupSize                    | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_MEDIUM_GROUP_SIZE                  | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.MediumGroupSize                 | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_SMALL_GROUP_SIZE                   | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.SmallGroupSize                  | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_SMALL_STATEFUL_SETS_PER_NAMESPACE  | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.SmallStatefulSetsPerNamespace   | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_MEDIUM_STATEFUL_SETS_PER_NAMESPACE | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.MediumStatefulSetsPerNamespace  | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_USE_HOST_NETWORK_PODS          | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.CL2UseHostNetworkPods           | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_LOAD_TEST_THROUGHPUT           | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.CL2LoadTestThroughput           | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_ENABLE_PVS                     | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.CL2EnablePVS                    | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_SCHEDULER_THROUGHPUT_THRESHOLD | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.CL2SchedulerThroughputThreshold | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_PROMETHEUS_SCRAPE_KUBE_PROXY       | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.PrometheusScrapeKubeProxy       | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_ENABLE_SYSTEM_POD_METRICS          | read-only "false" | *eksconfig.AddOnClusterLoaderLocal.EnableSystemPodMetrics          | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_POD_STARTUP_LATENCY                | read-only "true"  | *eksconfig.AddOnClusterLoaderLocal.PodStartupLatency               | util.PerfData      |
+*-----------------------------------------------------------------------------------*-------------------*--------------------------------------------------------------------*--------------------*
 
 
-*------------------------------------------------------------------------------------*-------------------*--------------------------------------------------------------------*--------------------*
-|                               ENVIRONMENTAL VARIABLE                               |     READ ONLY     |                                TYPE                                |      GO TYPE       |
-*------------------------------------------------------------------------------------*-------------------*--------------------------------------------------------------------*--------------------*
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_ENABLE                             | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.Enable                         | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CREATED                            | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.Created                        | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_TIME_FRAME_CREATE                  | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.TimeFrameCreate                | timeutil.TimeFrame |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_TIME_FRAME_DELETE                  | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.TimeFrameDelete                | timeutil.TimeFrame |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_S3_DIR                             | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.S3Dir                          | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_NAMESPACE                          | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.Namespace                      | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPOSITORY_ACCOUNT_ID              | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.RepositoryAccountID            | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPOSITORY_REGION                  | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.RepositoryRegion               | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPOSITORY_NAME                    | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.RepositoryName                 | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPOSITORY_IMAGE_TAG               | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.RepositoryImageTag             | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CLUSTER_LOADER_PATH                | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.ClusterLoaderPath              | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CLUSTER_LOADER_DOWNLOAD_URL        | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.ClusterLoaderDownloadURL       | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPORT_TAR_GZ_PATH                 | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.ReportTarGzPath                | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPORT_TAR_GZ_S3_KEY               | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.ReportTarGzS3Key               | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_LOG_PATH                           | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.LogPath                        | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_LOG_S3_KEY                         | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.LogS3Key                       | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_POD_STARTUP_LATENCY_PATH           | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.PodStartupLatencyPath          | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_POD_STARTUP_LATENCY_S3_KEY         | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.PodStartupLatencyS3Key         | string             |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_RUNS                               | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.Runs                           | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_NODES                              | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.Nodes                          | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_TIMEOUT                            | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.Timeout                        | time.Duration      |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_NODES_PER_NAMESPACE                | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.NodesPerNamespace              | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_PODS_PER_NODE                      | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.PodsPerNode                    | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_BIG_GROUP_SIZE                     | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.BigGroupSize                   | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_MEDIUM_GROUP_SIZE                  | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.MediumGroupSize                | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_SMALL_GROUP_SIZE                   | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.SmallGroupSize                 | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_SMALL_STATEFUL_SETS_PER_NAMESPACE  | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.SmallStatefulSetsPerNamespace  | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_MEDIUM_STATEFUL_SETS_PER_NAMESPACE | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.MediumStatefulSetsPerNamespace | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CL2_USE_HOST_NETWORK_PODS          | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.CL2UseHostNetworkPods          | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CL2_LOAD_TEST_THROUGHPUT           | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.CL2LoadTestThroughput          | int                |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CL2_ENABLE_PVS                     | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.CL2EnablePVS                   | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_PROMETHEUS_SCRAPE_KUBE_PROXY       | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.PrometheusScrapeKubeProxy      | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_ENABLE_SYSTEM_POD_METRICS          | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.EnableSystemPodMetrics         | bool               |
-| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_POD_STARTUP_LATENCY                | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.PodStartupLatency              | util.PerfData      |
-*------------------------------------------------------------------------------------*-------------------*--------------------------------------------------------------------*--------------------*
+*------------------------------------------------------------------------------------*-------------------*---------------------------------------------------------------------*--------------------*
+|                               ENVIRONMENTAL VARIABLE                               |     READ ONLY     |                                TYPE                                 |      GO TYPE       |
+*------------------------------------------------------------------------------------*-------------------*---------------------------------------------------------------------*--------------------*
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_ENABLE                             | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.Enable                          | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CREATED                            | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.Created                         | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_TIME_FRAME_CREATE                  | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.TimeFrameCreate                 | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_TIME_FRAME_DELETE                  | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.TimeFrameDelete                 | timeutil.TimeFrame |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_S3_DIR                             | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.S3Dir                           | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_NAMESPACE                          | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.Namespace                       | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPOSITORY_ACCOUNT_ID              | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.RepositoryAccountID             | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPOSITORY_REGION                  | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.RepositoryRegion                | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPOSITORY_NAME                    | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.RepositoryName                  | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPOSITORY_IMAGE_TAG               | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.RepositoryImageTag              | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CLUSTER_LOADER_PATH                | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.ClusterLoaderPath               | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CLUSTER_LOADER_DOWNLOAD_URL        | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.ClusterLoaderDownloadURL        | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPORT_TAR_GZ_PATH                 | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.ReportTarGzPath                 | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_REPORT_TAR_GZ_S3_KEY               | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.ReportTarGzS3Key                | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_LOG_PATH                           | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.LogPath                         | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_LOG_S3_KEY                         | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.LogS3Key                        | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_POD_STARTUP_LATENCY_PATH           | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.PodStartupLatencyPath           | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_POD_STARTUP_LATENCY_S3_KEY         | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.PodStartupLatencyS3Key          | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_RUNS                               | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.Runs                            | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_NODES                              | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.Nodes                           | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_TIMEOUT                            | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.Timeout                         | time.Duration      |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_NODES_PER_NAMESPACE                | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.NodesPerNamespace               | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_PODS_PER_NODE                      | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.PodsPerNode                     | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_BIG_GROUP_SIZE                     | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.BigGroupSize                    | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_MEDIUM_GROUP_SIZE                  | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.MediumGroupSize                 | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_SMALL_GROUP_SIZE                   | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.SmallGroupSize                  | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_SMALL_STATEFUL_SETS_PER_NAMESPACE  | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.SmallStatefulSetsPerNamespace   | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_MEDIUM_STATEFUL_SETS_PER_NAMESPACE | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.MediumStatefulSetsPerNamespace  | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CL2_USE_HOST_NETWORK_PODS          | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.CL2UseHostNetworkPods           | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CL2_LOAD_TEST_THROUGHPUT           | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.CL2LoadTestThroughput           | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CL2_ENABLE_PVS                     | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.CL2EnablePVS                    | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CL2_SCHEDULER_THROUGHPUT_THRESHOLD | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.CL2SchedulerThroughputThreshold | int                |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_PROMETHEUS_SCRAPE_KUBE_PROXY       | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.PrometheusScrapeKubeProxy       | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_ENABLE_SYSTEM_POD_METRICS          | read-only "false" | *eksconfig.AddOnClusterLoaderRemote.EnableSystemPodMetrics          | bool               |
+| AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_POD_STARTUP_LATENCY                | read-only "true"  | *eksconfig.AddOnClusterLoaderRemote.PodStartupLatency               | util.PerfData      |
+*------------------------------------------------------------------------------------*-------------------*---------------------------------------------------------------------*--------------------*
 
 
 *-----------------------------------------------------------------*-------------------*---------------------------------------------------*--------------------*

--- a/eksconfig/add-on-cluster-loader-local.go
+++ b/eksconfig/add-on-cluster-loader-local.go
@@ -95,11 +95,12 @@ type AddOnClusterLoaderLocal struct {
 	MediumStatefulSetsPerNamespace int `json:"medium-stateful-sets-per-namespace"`
 
 	// ref. https://github.com/kubernetes/perf-tests/pull/1345
-	CL2UseHostNetworkPods     bool `json:"cl2-use-host-network-pods"`
-	CL2LoadTestThroughput     int  `json:"cl2-load-test-throughput"`
-	CL2EnablePVS              bool `json:"cl2-enable-pvs"`
-	PrometheusScrapeKubeProxy bool `json:"prometheus-scrape-kube-proxy"`
-	EnableSystemPodMetrics    bool `json:"enable-system-pod-metrics"`
+	CL2UseHostNetworkPods           bool `json:"cl2-use-host-network-pods"`
+	CL2LoadTestThroughput           int  `json:"cl2-load-test-throughput"`
+	CL2EnablePVS                    bool `json:"cl2-enable-pvs"`
+	CL2SchedulerThroughputThreshold int  `json:"cl2-scheduler-throughput-threshold"`
+	PrometheusScrapeKubeProxy       bool `json:"prometheus-scrape-kube-proxy"`
+	EnableSystemPodMetrics          bool `json:"enable-system-pod-metrics"`
 
 	PodStartupLatency measurement_util.PerfData `json:"pod-startup-latency" read-only:"true"`
 }
@@ -145,10 +146,11 @@ func getDefaultAddOnClusterLoaderLocal() *AddOnClusterLoaderLocal {
 		CL2UseHostNetworkPods: false,
 
 		// ref. https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/testing/load/kubemark/throughput_override.yaml
-		CL2LoadTestThroughput:     20,
-		CL2EnablePVS:              false,
-		PrometheusScrapeKubeProxy: false,
-		EnableSystemPodMetrics:    false,
+		CL2LoadTestThroughput:           20,
+		CL2EnablePVS:                    false,
+		CL2SchedulerThroughputThreshold: 100,
+		PrometheusScrapeKubeProxy:       false,
+		EnableSystemPodMetrics:          false,
 	}
 	if runtime.GOOS == "darwin" {
 		cfg.ClusterLoaderDownloadURL = strings.Replace(cfg.ClusterLoaderDownloadURL, "linux", "darwin", -1)
@@ -226,6 +228,9 @@ func (cfg *Config) validateAddOnClusterLoaderLocal() error {
 	}
 	if cfg.AddOnClusterLoaderLocal.EnableSystemPodMetrics {
 		return fmt.Errorf("unexpected AddOnClusterLoaderLocal.EnableSystemPodMetrics %v; not supported yet", cfg.AddOnClusterLoaderLocal.EnableSystemPodMetrics)
+	}
+	if cfg.AddOnClusterLoaderLocal.CL2SchedulerThroughputThreshold <= 0 {
+		cfg.AddOnClusterLoaderLocal.CL2SchedulerThroughputThreshold = 100
 	}
 
 	return nil

--- a/eksconfig/add-on-cluster-loader-remote.go
+++ b/eksconfig/add-on-cluster-loader-remote.go
@@ -104,11 +104,12 @@ type AddOnClusterLoaderRemote struct {
 	MediumStatefulSetsPerNamespace int `json:"medium-stateful-sets-per-namespace"`
 
 	// ref. https://github.com/kubernetes/perf-tests/pull/1345
-	CL2UseHostNetworkPods     bool `json:"cl2-use-host-network-pods"`
-	CL2LoadTestThroughput     int  `json:"cl2-load-test-throughput"`
-	CL2EnablePVS              bool `json:"cl2-enable-pvs"`
-	PrometheusScrapeKubeProxy bool `json:"prometheus-scrape-kube-proxy"`
-	EnableSystemPodMetrics    bool `json:"enable-system-pod-metrics"`
+	CL2UseHostNetworkPods           bool `json:"cl2-use-host-network-pods"`
+	CL2LoadTestThroughput           int  `json:"cl2-load-test-throughput"`
+	CL2EnablePVS                    bool `json:"cl2-enable-pvs"`
+	CL2SchedulerThroughputThreshold int  `json:"cl2-scheduler-throughput-threshold"`
+	PrometheusScrapeKubeProxy       bool `json:"prometheus-scrape-kube-proxy"`
+	EnableSystemPodMetrics          bool `json:"enable-system-pod-metrics"`
 
 	PodStartupLatency measurement_util.PerfData `json:"pod-startup-latency" read-only:"true"`
 }
@@ -154,10 +155,11 @@ func getDefaultAddOnClusterLoaderRemote() *AddOnClusterLoaderRemote {
 		CL2UseHostNetworkPods: false,
 
 		// ref. https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/testing/load/kubemark/throughput_override.yaml
-		CL2LoadTestThroughput:     20,
-		CL2EnablePVS:              false,
-		PrometheusScrapeKubeProxy: false,
-		EnableSystemPodMetrics:    false,
+		CL2LoadTestThroughput:           20,
+		CL2EnablePVS:                    false,
+		CL2SchedulerThroughputThreshold: 100,
+		PrometheusScrapeKubeProxy:       false,
+		EnableSystemPodMetrics:          false,
 	}
 	if runtime.GOOS == "darwin" {
 		cfg.ClusterLoaderDownloadURL = strings.Replace(cfg.ClusterLoaderDownloadURL, "linux", "darwin", -1)
@@ -254,6 +256,9 @@ func (cfg *Config) validateAddOnClusterLoaderRemote() error {
 	}
 	if cfg.AddOnClusterLoaderRemote.EnableSystemPodMetrics {
 		return fmt.Errorf("unexpected AddOnClusterLoaderRemote.EnableSystemPodMetrics %v; not supported yet", cfg.AddOnClusterLoaderRemote.EnableSystemPodMetrics)
+	}
+	if cfg.AddOnClusterLoaderRemote.CL2SchedulerThroughputThreshold <= 0 {
+		cfg.AddOnClusterLoaderRemote.CL2SchedulerThroughputThreshold = 100
 	}
 
 	return nil

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -522,6 +522,8 @@ spec:
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_SMALL_STATEFUL_SETS_PER_NAMESPACE")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_MEDIUM_STATEFUL_SETS_PER_NAMESPACE", "1")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_MEDIUM_STATEFUL_SETS_PER_NAMESPACE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_SCHEDULER_THROUGHPUT_THRESHOLD", "20")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_SCHEDULER_THROUGHPUT_THRESHOLD")
 
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_ENABLE", "true")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_ENABLE")
@@ -555,6 +557,8 @@ spec:
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_SMALL_STATEFUL_SETS_PER_NAMESPACE")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_MEDIUM_STATEFUL_SETS_PER_NAMESPACE", "1")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_MEDIUM_STATEFUL_SETS_PER_NAMESPACE")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CL2_SCHEDULER_THROUGHPUT_THRESHOLD", "30")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CL2_SCHEDULER_THROUGHPUT_THRESHOLD")
 
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_LOCAL_ENABLE", "true")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_LOCAL_ENABLE")
@@ -1498,6 +1502,9 @@ spec:
 	if cfg.AddOnClusterLoaderLocal.MediumStatefulSetsPerNamespace != 1 {
 		t.Fatalf("unexpected cfg.AddOnClusterLoaderLocal.MediumStatefulSetsPerNamespace %v", cfg.AddOnClusterLoaderLocal.MediumStatefulSetsPerNamespace)
 	}
+	if cfg.AddOnClusterLoaderLocal.CL2SchedulerThroughputThreshold != 20 {
+		t.Fatalf("unexpected cfg.AddOnClusterLoaderLocal.CL2SchedulerThroughputThreshold %v", cfg.AddOnClusterLoaderLocal.CL2SchedulerThroughputThreshold)
+	}
 
 	if !cfg.AddOnClusterLoaderRemote.Enable {
 		t.Fatalf("unexpected cfg.AddOnClusterLoaderRemote.Enable %v", cfg.AddOnClusterLoaderRemote.Enable)
@@ -1537,6 +1544,9 @@ spec:
 	}
 	if cfg.AddOnClusterLoaderRemote.MediumStatefulSetsPerNamespace != 1 {
 		t.Fatalf("unexpected cfg.AddOnClusterLoaderRemote.MediumStatefulSetsPerNamespace %v", cfg.AddOnClusterLoaderRemote.MediumStatefulSetsPerNamespace)
+	}
+	if cfg.AddOnClusterLoaderRemote.CL2SchedulerThroughputThreshold != 30 {
+		t.Fatalf("unexpected cfg.AddOnClusterLoaderRemote.CL2SchedulerThroughputThreshold %v", cfg.AddOnClusterLoaderRemote.CL2SchedulerThroughputThreshold)
 	}
 
 	if !cfg.AddOnStresserLocal.Enable {


### PR DESCRIPTION
*Description of changes:*

Adding environment variables for configuring CL2_SCHEDULER_THROUGHPUT_THRESHOLD in ClusterLoader tests:
```
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_SCHEDULER_THROUGHPUT_THRESHOLD 
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_REMOTE_CL2_SCHEDULER_THROUGHPUT_THRESHOLD
```
This parameter has a default value of 100 which we want to make configurable when running ClusterLoader using aws-k8s-tester.

Ref: https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/testing/load/config.yaml#L79

*Testing:*
Unit test for setting new env variables:
```
$ go test -v -run TestEnv$
...
--- PASS: TestEnv (0.19s)
PASS
ok      github.com/aws/aws-k8s-tester/eksconfig 0.416s
```
Ran aws-k8s-tester with setting ```AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_SCHEDULER_THROUGHPUT_THRESHOLD=2000``` which is expected to fail the ClusterLoader run:
```
AWS_K8S_TESTER_EKS_NAME=test-cluster \
AWS_DEFAULT_REGION=us-west-2 \
AWS_K8S_TESTER_EKS_PARTITION=aws \
AWS_K8S_TESTER_EKS_REGION=us-west-2 \
AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE=true \
AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE_KEEP=false \
AWS_K8S_TESTER_EKS_KUBECTL_PATH=/usr/local/bin/kubectl \
AWS_K8S_TESTER_EKS_PARAMETERS_VERSION="1.19" \
AWS_K8S_TESTER_EKS_CLIENTS="5" \
AWS_K8S_TESTER_EKS_CLIENT_QPS="30" \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE="true" \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_CREATE="true" \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_SERVICE_PRINCIPALS="ec2.amazonaws.com,eks.amazonaws.com,eks-fargate-pods.amazonaws.com,eks-dev.aws.internal,eks-beta-pdx.aws.internal,eks-fargate-pods.aws.internal" \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_FETCH_LOGS="false" \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS='{"GetRef.Name-ng-al2-cpu":{"name":"GetRef.Name-ng-al2-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id":"","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.19/amazon-linux-2/recommended/image_id","asg-min-size":100,"asg-max-size":100,"asg-desired-capacity":100,"instance-types":["c5.xlarge"],"volume-size":40,"kubelet-extra-args":"","cluster-autoscaler":{"enable":false}}}' \
AWS_K8S_TESTER_EKS_ON_FAILURE_DELETE="true" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_ENABLE="true" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CLUSTER_LOADER_PATH="/tmp/clusterloader" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_TEST_CONFIG_PATH="/Users/$USER/go/src/k8s.io/perf-tests/clusterloader2/testing/load/config.yaml" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_RUNS="1" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_NODES="100" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_ENABLE_PVS="false" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_PROMETHEUS_SCRAPE_KUBE_PROXY="false" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_ENABLE_SYSTEM_POD_METRICS="false" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_USE_HOST_NETWORK_PODS="false" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_NODES_PER_NAMESPACE="10" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_PODS_PER_NODE="20" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_BIG_GROUP_SIZE="25" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_MEDIUM_GROUP_SIZE="10" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_SMALL_GROUP_SIZE="5" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_SMALL_STATEFUL_SETS_PER_NAMESPACE="0" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_MEDIUM_STATEFUL_SETS_PER_NAMESPACE="0" \
AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_CL2_SCHEDULER_THROUGHPUT_THRESHOLD="2000" \
ENABLE_EXEC_SERVICE="false" \
./bin/aws-k8s-tester-v20210322.185631-darwin-amd64 eks create cluster --enable-prompt=false -p test.yaml && ./bin/aws-k8s-tester-v20210322.185631-darwin-amd64 eks delete cluster --enable-prompt=false -p test.yaml
```
We can see the override being applied from the ClusterLoader results:
```
     <testcase name="load: [step: 10] Collecting scheduler throughput measurements" classname="ClusterLoaderV2" time="1.335551876">
          <failure type="Failure">:0&#xA;[measurement call SchedulingThroughput - SchedulingThroughput error: scheduler throughput: actual throughput 51.000000 lower than threshold 2000.000000]&#xA;:0</failure>
      </testcase>
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
