### PR TITLE
cluster: remove AWS::EC2::EIP.Properties.Tags in isolated partitions

### DIFF
--- a/eks/cluster/vpc_test.go
+++ b/eks/cluster/vpc_test.go
@@ -1,0 +1,31 @@
+package cluster
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestTemplateVPCPublicPrivate(t *testing.T) {
+	tpl := template.Must(template.New("TemplateVPCPublicPrivate").Parse(TemplateVPCPublicPrivate))
+	buf := bytes.NewBuffer(nil)
+	if err := tpl.Execute(buf, templateVPCPublicPrivate{}); err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(buf.String())
+
+	buf.Reset()
+	if err := tpl.Execute(buf, templateVPCPublicPrivate{
+		IsIsolated: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(buf.String(), "Value: !Sub '${AWS::StackName}-EIP2") {
+		t.Fail()
+	}
+
+	fmt.Println(buf.String())
+}


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

Tags are not supported when creating EIPs via CFN in isolated partitions.

Successfully ran conformance tests in region with these changes.

Manually tested setting `IsIsolated` to false and it produces valid EIPs w/ tag:

```yaml
NATGatewayEIP1:
  Type: AWS::EC2::EIP
  DependsOn:
  - VPC
  - VPCGatewayAttachment
  Properties:
    Domain: vpc
    Tags:
    - Key: Name
      Value: !Sub '${AWS::StackName}-EIP1'
```

`'aws-k8s-tester eks create config --path "./eksconfig/default.yaml"' success`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
