### PR TITLE
Adding e2e focus and skip for sonobuoy as flags.

### DIFF
--- a/eks/conformance/conformance.go
+++ b/eks/conformance/conformance.go
@@ -240,6 +240,8 @@ func (ts *tester) runSonobuoy() (err error) {
 		"--namespace=" + ts.cfg.EKSConfig.AddOnConformance.Namespace,
 		"--mode=" + ts.cfg.EKSConfig.AddOnConformance.SonobuoyRunMode,
 		"--kube-conformance-image=" + ts.cfg.EKSConfig.AddOnConformance.SonobuoyRunKubeConformanceImage,
+		"--e2e-focus=" + ts.cfg.EKSConfig.AddOnConformance.SonobuoyRunE2eFocus,
+		"--e2e-skip=" + ts.cfg.EKSConfig.AddOnConformance.SonobuoyRunE2eSkip,
 		"--show-default-podspec=true",
 		fmt.Sprintf("--timeout=%d", timeoutSeconds), // default "10800", 3-hour
 	}

--- a/eksconfig/README.md
+++ b/eksconfig/README.md
@@ -280,6 +280,8 @@ AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_VERSION_UPGRADE_ENABLE=true \
 | AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_RUN_TIMEOUT                | read-only "false" | *eksconfig.AddOnConformance.SonobuoyRunTimeout              | time.Duration      |
 | AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_RUN_TIMEOUT_STRING         | read-only "true"  | *eksconfig.AddOnConformance.SonobuoyRunTimeoutString        | string             |
 | AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_RUN_MODE                   | read-only "false" | *eksconfig.AddOnConformance.SonobuoyRunMode                 | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_E2E_FOCUS                  | read-only "false" | *eksconfig.AddOnConformance.SonobuoyRunE2eFocus             | string             |
+| AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_E2E_SKIP                   | read-only "false" | *eksconfig.AddOnConformance.SonobuoyRunE2eSkip              | string             |
 | AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_RUN_KUBE_CONFORMANCE_IMAGE | read-only "false" | *eksconfig.AddOnConformance.SonobuoyRunKubeConformanceImage | string             |
 | AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_RESULT_TAR_GZ_PATH         | read-only "true"  | *eksconfig.AddOnConformance.SonobuoyResultTarGzPath         | string             |
 | AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_RESULT_TAR_GZ_S3_KEY       | read-only "true"  | *eksconfig.AddOnConformance.SonobuoyResultTarGzS3Key        | string             |

--- a/eksconfig/add-on-conformance.go
+++ b/eksconfig/add-on-conformance.go
@@ -58,6 +58,9 @@ type AddOnConformance struct {
 	SonobuoyRunMode                 string `json:"sonobuoy-run-mode"`
 	SonobuoyRunKubeConformanceImage string `json:"sonobuoy-run-kube-conformance-image"`
 
+	SonobuoyRunE2eFocus                string `json:"sonobuoy-e2e-focus"`
+	SonobuoyRunE2eSkip                 string `json:"sonobuoy-e2e-skip"`
+
 	SonobuoyResultTarGzPath     string `json:"sonobuoy-result-tar-gz-path" read-only:"true"`
 	SonobuoyResultTarGzS3Key    string `json:"sonobuoy-result-tar-gz-s3-key" read-only:"true"`
 	SonobuoyResultDir           string `json:"sonobuoy-result-dir" read-only:"true"`

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -1823,6 +1823,10 @@ func TestEnvAddOnConformance(t *testing.T) {
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SYSTEMD_LOGS_IMAGE")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_E2E_REPO_CONFIG", "/path/to/config.yml")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_E2E_REPO_CONFIG")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_E2E_FOCUS", "sig-network")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_E2E_FOCUS")
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_E2E_SKIP", "sig-network")
+	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_E2E_SKIP")
 
 	if err := cfg.UpdateFromEnvs(); err != nil {
 		t.Fatal(err)
@@ -1863,6 +1867,12 @@ func TestEnvAddOnConformance(t *testing.T) {
 	}
 	if cfg.AddOnConformance.SonobuoyE2eRepoConfig != "/path/to/config.yml" {
 		t.Fatalf("unexpected cfg.AddOnConformance.SonobuoyE2eRepoConfig %q", cfg.AddOnConformance.SonobuoyE2eRepoConfig)
+	}
+	if cfg.AddOnConformance.SonobuoyRunE2eFocus != "sig-network" {
+		t.Fatalf("unexpected cfg.AddOnConformance.SonobuoyRunE2eFocus %q", cfg.AddOnConformance.SonobuoyRunE2eFocus)
+	}
+	if cfg.AddOnConformance.SonobuoyRunE2eSkip != "sig-network" {
+		t.Fatalf("unexpected cfg.AddOnConformance.SonobuoyRunE2eSkip %q", cfg.AddOnConformance.SonobuoyRunE2eSkip)
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If we need run upstream conformance test against to specific groups, we need add focus or skip as [flags for sonobuoy](https://sonobuoy.io/docs/master/e2eplugin/).

*Tests*
```
{"msg":"Test Suite completed","total":32,"completed":32,"skipped":5635,"failed":0}

Ran 32 of 5667 Specs in 468.099 seconds
SUCCESS! -- 32 Passed | 0 Failed | 0 Pending | 5635 Skipped
PASS
```
```
Focus on sig-network tests

AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_SONOBUOY_E2E_FOCUS="sig-network.*\[Conformance\]"
sonobuoy-e2e-focus: sig-network.*\[Conformance\]
  sonobuoy-e2e-repo-config: ""
  sonobuoy-e2e-skip: ""

Plugin: e2e
Status: passed
Total: 5667
Passed: 32
Failed: 0
Skipped: 5635

Plugin: systemd-logs
Status: passed
Total: 5
Passed: 5
Failed: 0
Skipped: 0

*********************************************************
General tests

AWS_K8S_TESTER_EKS_ADD_ON_CONFORMANCE_ENABLE=true

Plugin: e2e
Status: passed
Total: 5667
Passed: 311
Failed: 0
Skipped: 5356

Plugin: systemd-logs
Status: passed
Total: 5
Passed: 5
Failed: 0
Skipped: 0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
