### PR TITLE
fix misformatted eks/cluster-loader/configs/cluster-autoscaler/config

### DIFF
--- a/eks/cluster-loader/configs/cluster-autoscaler/config.yaml
+++ b/eks/cluster-loader/configs/cluster-autoscaler/config.yaml
@@ -90,7 +90,7 @@ steps:
             MemoryRequest: {{ $POD_MEMORY_MB }}Mi
 
 - name: wait-for-scale-up-complete
-- measurements:
+  measurements:
     - Identifier: WaitingForPods
       Method: WaitForRunningPods
       Params:
@@ -99,7 +99,7 @@ steps:
         timeout: 4h
 
 - name: stop-timing-for-scale-up
-- measurements:
+  measurements:
     - Identifier: ScaleUpTimer
       Method: Timer
       Params:
@@ -111,7 +111,7 @@ steps:
         action: gather
 
 - name: start-timing-for-scale-down
-- measurements:
+  measurements:
     - Identifier: ScaleDownTimer
       Method: Timer
       Params:
@@ -130,7 +130,7 @@ steps:
           objectTemplatePath: deployment.yaml
 
 - name: wait-for-scale-down-complete
-- measurements:
+  measurements:
     - Identifier: WaitingForPods
       Method: WaitForRunningPods
       Params:
@@ -139,7 +139,7 @@ steps:
         timeout: 4h
 
 - name: stop-measurements
-- measurements:
+  measurements:
     - Identifier: ScaleDownTimer
       Method: Timer
       Params:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Was getting the following error when running clusterloader:
```
F0720 09:26:45.223452   72877 clusterloader.go:337] Test compilation failed: [steps[2].measurements: Invalid value: []*api.Measurement(nil): can't be empty with empty phases
steps[4].measurements: Invalid value: []*api.Measurement(nil): can't be empty with empty phases
steps[6].measurements: Invalid value: []*api.Measurement(nil): can't be empty with empty phases
steps[9].measurements: Invalid value: []*api.Measurement(nil): can't be empty with empty phases
steps[11].measurements: Invalid value: []*api.Measurement(nil): can't be empty with empty phases]
```

Just fixing the yaml formatting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
