### PR TITLE
EKS-A conformance fix

### DIFF
--- a/k8s-tester/conformance/sonobuoy.go
+++ b/k8s-tester/conformance/sonobuoy.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	// ref. https://github.com/vmware-tanzu/sonobuoy/releases
-	defaultSonobuoyVersion = "0.50.0"
+	defaultSonobuoyVersion = "0.52.0"
 	defaultSonobuoyPath    = fmt.Sprintf("/tmp/sonobuoy-%s", defaultSonobuoyVersion)
 	// ref. https://github.com/vmware-tanzu/sonobuoy/releases
 	// e.g., https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.50.0/sonobuoy_0.50.0_linux_arm64.tar.gz

--- a/k8s-tester/conformance/tester.go
+++ b/k8s-tester/conformance/tester.go
@@ -154,7 +154,7 @@ func NewDefault() *Config {
 		SonobuoyRunE2ESkip:              "",
 		SonobuoyRunKubeConformanceImage: DefaultSonobuoyRunKubeConformanceImage,
 		SonobuoyRunE2ERepoConfig:        "",
-		SonobuoyRunImage:                "",
+		SonobuoyRunImage:                "public.ecr.aws/v3f2w6a4/sonobuoy:v0.52",
 		SonobuoyRunSystemdLogsImage:     "",
 
 		SonobuoyResultsTarGzPath:    file.GetTempFilePath("sonobuoy_results") + ".tar.gz",


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*

For EKS-A hitting docker pull limits since the control plane IP endpoint is likely the only input/output for docker pull from docker hub. This changes the test image to an ECR mirror to get around the throttling.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
