### PR TITLE
Making VolumeType configurable in AddonNodeGroups

### DIFF
--- a/ec2config/config.go
+++ b/ec2config/config.go
@@ -353,6 +353,10 @@ type ASG struct {
 	// a volume size, the default is the snapshot size.
 	VolumeSize int32 `json:"volume-size"`
 
+	// VolumeType is the type of volume for the underlying EBS volume.
+	// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
+	VolumeType aws_ec2_v2_types.VolumeType `json:"volume-type"`
+
 	// ASGMinSize is the minimum size of ASG.
 	ASGMinSize int32 `json:"asg-min-size,omitempty"`
 	// ASGMaxSize is the maximum size of ASG.

--- a/ec2config/env_test.go
+++ b/ec2config/env_test.go
@@ -48,7 +48,7 @@ func TestEnv(t *testing.T) {
 	defer os.Unsetenv("AWS_K8S_TESTER_EC2_ASGS_FETCH_LOGS")
 	os.Setenv("AWS_K8S_TESTER_EC2_ASGS_LOGS_DIR", "hello")
 	defer os.Unsetenv("AWS_K8S_TESTER_EC2_ASGS_LOGS_DIR")
-	os.Setenv("AWS_K8S_TESTER_EC2_ASGS", `{"test-asg":{"name":"test-asg","ssm":{"document-create":true,"document-name":"my-doc","document-commands":"echo 123; echo 456;","document-execution-timeout-in-seconds":10},"remote-access-user-name":"my-user","image-id":"123","image-id-ssm-parameter":"777","asg-launch-configuration-cfn-stack-id":"none","asg-cfn-stack-id":"bbb","ami-type":"BOTTLEROCKET_x86_64","asg-min-size":30,"asg-max-size":30,"asg-desired-capacity":30,"volume-size":120,"instance-type":"c5.xlarge"}}`)
+	os.Setenv("AWS_K8S_TESTER_EC2_ASGS", `{"test-asg":{"name":"test-asg","ssm":{"document-create":true,"document-name":"my-doc","document-commands":"echo 123; echo 456;","document-execution-timeout-in-seconds":10},"remote-access-user-name":"my-user","image-id":"123","image-id-ssm-parameter":"777","asg-launch-configuration-cfn-stack-id":"none","asg-cfn-stack-id":"bbb","ami-type":"BOTTLEROCKET_x86_64","asg-min-size":30,"asg-max-size":30,"asg-desired-capacity":30,"volume-size":120,"volume-type":"io1","instance-type":"c5.xlarge"}}`)
 	defer os.Unsetenv("AWS_K8S_TESTER_EC2_ASGS")
 
 	if err := cfg.UpdateFromEnvs(); err != nil {
@@ -127,6 +127,7 @@ func TestEnv(t *testing.T) {
 			ASGDesiredCapacity:  30,
 			InstanceType:        "c5.xlarge",
 			VolumeSize:          120,
+			VolumeType:          "io1",
 		},
 	}
 	if !reflect.DeepEqual(cfg.ASGs, expectedASGs) {

--- a/eks/ng/asg.go
+++ b/eks/ng/asg.go
@@ -91,7 +91,7 @@ func (ts *tester) _createASGs() (tss tupleTimes, err error) {
 							Ebs: &aws_ec2_v2_types.LaunchTemplateEbsBlockDeviceRequest{
 								DeleteOnTermination: aws_v2.Bool(true),
 								Encrypted:           aws_v2.Bool(true),
-								VolumeType:          aws_ec2_v2_types.VolumeTypeGp3,
+								VolumeType:          cur.VolumeType,
 								VolumeSize:          aws_v2.Int32(cur.VolumeSize),
 							},
 						},

--- a/eksconfig/add-on-node-groups.go
+++ b/eksconfig/add-on-node-groups.go
@@ -112,6 +112,7 @@ func getDefaultAddOnNodeGroups(name string) *AddOnNodeGroups {
 					ImageIDSSMParameter:  "/aws/service/eks/optimized-ami/1.20/amazon-linux-2/recommended/image_id",
 					InstanceType:         DefaultNodeInstanceTypeCPU,
 					VolumeSize:           DefaultNodeVolumeSize,
+					VolumeType:           DefaultNodeVolumeType,
 					ASGMinSize:           1,
 					ASGMaxSize:           1,
 					ASGDesiredCapacity:   1,
@@ -195,6 +196,9 @@ func (cfg *Config) validateAddOnNodeGroups() error {
 
 		if cur.VolumeSize == 0 {
 			cur.VolumeSize = DefaultNodeVolumeSize
+		}
+		if cur.VolumeType == "" {
+			cur.VolumeType = DefaultNodeVolumeType
 		}
 		if cur.RemoteAccessUserName == "" {
 			cur.RemoteAccessUserName = "ec2-user"

--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-k8s-tester/pkg/logutil"
 	"github.com/aws/aws-k8s-tester/pkg/randutil"
 	"github.com/aws/aws-k8s-tester/pkg/terminal"
+	aws_ec2_v2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/mitchellh/colorstring"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml" // must use "sigs.k8s.io/yaml"
@@ -843,6 +844,9 @@ const (
 
 	// DefaultNodeVolumeSize is the default EC2 instance volume size for a worker node.
 	DefaultNodeVolumeSize = 40
+
+	// DefaultNodeVolumeType is the default EC2 instance volume type for a worker node.
+	DefaultNodeVolumeType = aws_ec2_v2_types.VolumeTypeGp3
 
 	// NGsMaxLimit is the maximum number of "Node Group"s per a EKS cluster.
 	NGsMaxLimit = 10

--- a/eksconfig/env_test.go
+++ b/eksconfig/env_test.go
@@ -152,7 +152,7 @@ spec:
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_FETCH_LOGS", "false")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_FETCH_LOGS")
-	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS", `{"ng-test-name-cpu":{"name":"ng-test-name-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.30/amazon-linux-2/recommended/image_id","asg-min-size":17,"kubelet-extra-args":"bbb qq","bootstrap-args":"--pause-container-account 012345678901", "cluster-autoscaler" : {"enable" : false}, "asg-max-size":99,"asg-desired-capacity":77,"instance-type":"type-cpu-2","volume-size":40},"ng-test-name-gpu":{"name":"ng-test-name-gpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64_GPU","asg-min-size":30,"asg-max-size":35,"asg-desired-capacity":34,"instance-type":"type-gpu-2","image-id":"my-gpu-ami","volume-size":500, "cluster-autoscaler": {"enable":false},"kubelet-extra-args":"aaa aa"}}`)
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS", `{"ng-test-name-cpu":{"name":"ng-test-name-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.30/amazon-linux-2/recommended/image_id","asg-min-size":17,"kubelet-extra-args":"bbb qq","bootstrap-args":"--pause-container-account 012345678901", "cluster-autoscaler" : {"enable" : false}, "asg-max-size":99,"asg-desired-capacity":77,"instance-type":"type-cpu-2","volume-size":40,"volume-type":"gp2"},"ng-test-name-gpu":{"name":"ng-test-name-gpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64_GPU","asg-min-size":30,"asg-max-size":35,"asg-desired-capacity":34,"instance-type":"type-gpu-2","image-id":"my-gpu-ami","volume-size":500,"volume-type":"gp3","cluster-autoscaler": {"enable":false},"kubelet-extra-args":"aaa aa"}}`)
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_NAME", "a")
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_NAME")
@@ -831,6 +831,7 @@ spec:
 				ASGDesiredCapacity:   77,
 				InstanceType:         "type-cpu-2",
 				VolumeSize:           40,
+				VolumeType:           "gp2",
 			},
 			BootstrapArgs:     "--pause-container-account 012345678901",
 			KubeletExtraArgs:  "bbb qq",
@@ -847,6 +848,7 @@ spec:
 				ASGDesiredCapacity:   34,
 				InstanceType:         "type-gpu-2",
 				VolumeSize:           500,
+				VolumeType:           "gp3",
 			},
 			KubeletExtraArgs:  "aaa aa",
 			ClusterAutoscaler: &NGClusterAutoscaler{Enable: false},
@@ -1674,7 +1676,7 @@ func TestEnvAddOnNodeGroupsGetRef(t *testing.T) {
 
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE", `true`)
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE")
-	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS", `{"GetRef.Name-ng-for-cni":{"name":"GetRef.Name-ng-for-cni","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","asg-min-size":30,"asg-max-size":35,"asg-desired-capacity":34, "instance-type":"type-2", "image-id":"my-ami",  "ssm":{"document-create":true,    "document-name":"GetRef.Name-document", "document-commands":"echo 1"}, "kubelet-extra-args":"aaa aa", "cluster-autoscaler": {"enable" : true}, "volume-size":500}}`)
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS", `{"GetRef.Name-ng-for-cni":{"name":"GetRef.Name-ng-for-cni","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","asg-min-size":30,"asg-max-size":35,"asg-desired-capacity":34, "instance-type":"type-2", "image-id":"my-ami",  "ssm":{"document-create":true,    "document-name":"GetRef.Name-document", "document-commands":"echo 1"}, "kubelet-extra-args":"aaa aa", "cluster-autoscaler": {"enable" : true}, "volume-size":500, "volume-type":"gp3"}}`)
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS")
 	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ENABLE", `true`)
 	defer os.Unsetenv("AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ENABLE")
@@ -1705,6 +1707,7 @@ func TestEnvAddOnNodeGroupsGetRef(t *testing.T) {
 				AMIType:            eks.AMITypesAl2X8664,
 				InstanceType:       "type-2",
 				VolumeSize:         500,
+				VolumeType:         "gp3",
 				ASGMinSize:         30,
 				ASGMaxSize:         35,
 				ASGDesiredCapacity: 34,


### PR DESCRIPTION
*Description of changes:*

Making VolumeType configurable in AddonNodeGroups. Currently instance types in node groups default to gp3 for the EBS volume type and this volume type is not available in all regions including DCA and LCK. 

*Testing*
Unit tests:
eksconfig/env_test.go:
```
$ go test -v -run Test*
...
PASS
ok      github.com/aws/aws-k8s-tester/eksconfig 0.814s
```
ec2config/env_test.go:
```
$ go test -v -run Test*
...
PASS
ok      github.com/aws/aws-k8s-tester/ec2config 0.076s
```
Testing that we can explicitly set gp2:
```
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS='{"GetRef.Name-ng-al2-cpu":{"name":"GetRef.Name-ng-al2-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id":"","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.19/amazon-linux-2/recommended/image_id","asg-min-size":10,"asg-max-size":10,"asg-desired-capacity":10,"instance-type":"c5.xlarge","volume-size":40,"volume-type":"gp2","kubelet-extra-args":"","cluster-autoscaler":{"enable":false}}}' \
...
./aws-k8s-tester-v20210819.155910-darwin-amd64 eks create cluster --enable-prompt=false -p test2.yaml
...
"asgs": {
	"volume-type-gp2-ng-al2-cpu": {
	    "name": "volume-type-gp2-ng-al2-cpu",
	    "time-frame-create": {
	        "start-utc": "0001-01-01T00:00:00Z",
	        "start-utc-rfc3339-nano": "",
	        "complete-utc": "0001-01-01T00:00:00Z",
	        "complete-utc-rfc3339-nano": "",
	        "took": 0,
	        "took-string": ""
	    },
	    "time-frame-delete": {
	        "start-utc": "0001-01-01T00:00:00Z",
	        "start-utc-rfc3339-nano": "",
	        "complete-utc": "0001-01-01T00:00:00Z",
	        "complete-utc-rfc3339-nano": "",
	        "took": 0,
	        "took-string": ""
	    },
	    "remote-access-user-name": "ec2-user",
	    "ssm": null,
	    "ami-type": "AL2_x86_64",
	    "image-id": "",
	    "image-id-ssm-parameter": "/aws/service/eks/optimized-ami/1.19/amazon-linux-2/recommended/image_id",
	    "instance-type": "c5.xlarge",
	    "volume-size": 40,
	    "volume-type": "gp2",
	    "asg-min-size": 10,
	    "asg-max-size": 10,
	    "asg-desired-capacity": 10,
	    "instanaces": null,
	    "logs": null,
	    "launch-template-name": "volume-type-gp2-ng-al2-cpu-launch-template",
	    "kubelet-extra-args": "",
	    "bootstrap-args": "",
	    "cluster-autoscaler": {
	        "enable": false,
	        "created": false,
	        "time-frame-create": {
	            "start-utc": "0001-01-01T00:00:00Z",
	            "start-utc-rfc3339-nano": "",
	            "complete-utc": "0001-01-01T00:00:00Z",
	            "complete-utc-rfc3339-nano": "",
	            "took": 0,
	            "took-string": ""
	        }
	    }
	}
   }
```
Testing that not setting volume-type defaults to gp3:
```
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS='{"GetRef.Name-ng-al2-cpu":{"name":"GetRef.Name-ng-al2-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id":"","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.19/amazon-linux-2/recommended/image_id","asg-min-size":10,"asg-max-size":10,"asg-desired-capacity":10,"instance-type":"c5.xlarge","volume-size":40,"kubelet-extra-args":"","cluster-autoscaler":{"enable":false}}}' \
...
./aws-k8s-tester-v20210819.155910-darwin-amd64 eks create cluster --enable-prompt=false -p test1.yaml
...
 "asgs": {
        "volume-type-gp3-default-ng-al2-cpu": {
            "name": "volume-type-gp3-default-ng-al2-cpu",
            "time-frame-create": {
                "start-utc": "0001-01-01T00:00:00Z",
                "start-utc-rfc3339-nano": "",
                "complete-utc": "0001-01-01T00:00:00Z",
                "complete-utc-rfc3339-nano": "",
                "took": 0,
                "took-string": ""
            },
            "time-frame-delete": {
                "start-utc": "0001-01-01T00:00:00Z",
                "start-utc-rfc3339-nano": "",
                "complete-utc": "0001-01-01T00:00:00Z",
                "complete-utc-rfc3339-nano": "",
                "took": 0,
                "took-string": ""
            },
            "remote-access-user-name": "ec2-user",
            "ssm": null,
            "ami-type": "AL2_x86_64",
            "image-id": "",
            "image-id-ssm-parameter": "/aws/service/eks/optimized-ami/1.19/amazon-linux-2/recommended/image_id",
            "instance-type": "c5.xlarge",
            "volume-size": 40,
            "volume-type": "gp3",
            "asg-min-size": 10,
            "asg-max-size": 10,
            "asg-desired-capacity": 10,
            "instanaces": null,
            "logs": null,
            "launch-template-name": "volume-type-gp3-default-ng-al2-cpu-launch-template",
            "kubelet-extra-args": "",
            "bootstrap-args": "",
            "cluster-autoscaler": {
                "enable": false,
                "created": false,
                "time-frame-create": {
                    "start-utc": "0001-01-01T00:00:00Z",
                    "start-utc-rfc3339-nano": "",
                    "complete-utc": "0001-01-01T00:00:00Z",
                    "complete-utc-rfc3339-nano": "",
                    "took": 0,
                    "took-string": ""
                }
            }
        }
```
Confirmed in console that underlying volumes were created with the correct type in both cases.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
