### PR TITLE
Filter zone-type to only get availability-zones

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -21,6 +21,7 @@ import (
 	aws_v2 "github.com/aws/aws-sdk-go-v2/aws"
 	aws_asg_v2 "github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	aws_ec2_v2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	aws_ec2_v2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	aws_elbv2_v2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	aws_iam_v2 "github.com/aws/aws-sdk-go-v2/service/iam"
 	aws_kms_v2 "github.com/aws/aws-sdk-go-v2/service/kms"
@@ -168,6 +169,12 @@ func New(cfg *ec2config.Config) (*Tester, error) {
 		&aws_ec2_v2.DescribeAvailabilityZonesInput{
 			// TODO: include opt-in zones?
 			AllAvailabilityZones: aws_v2.Bool(false),
+			Filters: []aws_ec2_v2_types.Filter{
+				{
+					Name:   aws_v2.String("zone-type"),
+					Values: []string{"availability-zone"},
+				},
+			},
 		},
 	)
 	cancel()

--- a/eks/eks.go
+++ b/eks/eks.go
@@ -83,6 +83,7 @@ import (
 	aws_cfn_v2 "github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	aws_cw_v2 "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	aws_ec2_v2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	aws_ec2_v2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	aws_ecr_v2 "github.com/aws/aws-sdk-go-v2/service/ecr"
 	aws_eks_v2 "github.com/aws/aws-sdk-go-v2/service/eks"
 	aws_elbv2_v2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
@@ -430,6 +431,12 @@ func New(cfg *eksconfig.Config) (ts *Tester, err error) {
 		&aws_ec2_v2.DescribeAvailabilityZonesInput{
 			// TODO: include opt-in zones?
 			AllAvailabilityZones: aws_v2.Bool(false),
+			Filters: []aws_ec2_v2_types.Filter{
+				{
+					Name:   aws_v2.String("zone-type"),
+					Values: []string{"availability-zone"},
+				},
+			},
 		},
 	)
 	cancel()


### PR DESCRIPTION
*Description of changes:*
Add zone-type=availability-zone filter to DescribeAvailabilityZones request to not consider local zones nor wavelength zones. If an account is opted-in to use wavelength zones, creating the VPC will fail when we call ModifySubnetAttribute with MapPublicIpOnLaunch set to true on the wavelength zone.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*Testing*
Ran against an account which is allow-listed for a wavelength zone in PDX:
```
#!/bin/bash

AWS_K8S_TESTER_EKS_NAME=zone-test \
AWS_DEFAULT_REGION=us-west-2 \
AWS_K8S_TESTER_EKS_PARTITION=aws \
AWS_K8S_TESTER_EKS_REGION=us-west-2 \
AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE=true \
AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE_KEEP=false \
AWS_K8S_TESTER_EKS_KUBECTL_PATH=/usr/local/bin/kubectl \
AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_SERVICE_PRINCIPALS="ec2.amazonaws.com,eks.amazonaws.com,eks-fargate-pods.amazonaws.com,eks-dev.aws.internal,eks-beta-pdx.aws.internal,eks-fargate-pods.aws.internal" \
AWS_K8S_TESTER_EKS_PARAMETERS_VERSION="1.19" \
AWS_K8S_TESTER_EKS_CLIENTS="5" \
AWS_K8S_TESTER_EKS_CLIENT_QPS="30" \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE="true" \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_CREATE="true" \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ROLE_SERVICE_PRINCIPALS="ec2.amazonaws.com,eks.amazonaws.com,eks-fargate-pods.amazonaws.com,eks-dev.aws.internal,eks-beta-pdx.aws.internal,eks-fargate-pods.aws.internal" \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_FETCH_LOGS="false" \
AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ASGS='{"GetRef.Name-ng-al2-cpu":{"name":"GetRef.Name-ng-al2-cpu","remote-access-user-name":"ec2-user","ami-type":"AL2_x86_64","image-id":"","image-id-ssm-parameter":"/aws/service/eks/optimized-ami/1.19/amazon-linux-2/recommended/image_id","asg-min-size":10,"asg-max-size":10,"asg-desired-capacity":10,"instance-type":"c5.xlarge","volume-size":40,"kubelet-extra-args":"","cluster-autoscaler":{"enable":false}}}' \
AWS_K8S_TESTER_EKS_ON_FAILURE_DELETE="true" \
./aws-k8s-tester eks create cluster -p test.yaml
```
Using old binary will fail VPC creation:
```
{"level":"info","ts":"2021-08-27T13:12:43.565-0700","caller":"eks/eks.go:440","msg":"availability zone","zone-name":"us-west-2a","zone-id":"usw2-az1","zone-type":"availability-zone","zone-opt-in-status":"opt-in-not-required"}
{"level":"info","ts":"2021-08-27T13:12:43.565-0700","caller":"eks/eks.go:440","msg":"availability zone","zone-name":"us-west-2b","zone-id":"usw2-az2","zone-type":"availability-zone","zone-opt-in-status":"opt-in-not-required"}
{"level":"info","ts":"2021-08-27T13:12:43.565-0700","caller":"eks/eks.go:440","msg":"availability zone","zone-name":"us-west-2c","zone-id":"usw2-az3","zone-type":"availability-zone","zone-opt-in-status":"opt-in-not-required"}
{"level":"info","ts":"2021-08-27T13:12:43.565-0700","caller":"eks/eks.go:440","msg":"availability zone","zone-name":"us-west-2d","zone-id":"usw2-az4","zone-type":"availability-zone","zone-opt-in-status":"opt-in-not-required"}
{"level":"info","ts":"2021-08-27T13:12:43.565-0700","caller":"eks/eks.go:440","msg":"availability zone","zone-name":"us-west-2-lax-1a","zone-id":"usw2-lax1-az1","zone-type":"local-zone","zone-opt-in-status":"opted-in"}
{"level":"info","ts":"2021-08-27T13:12:43.565-0700","caller":"eks/eks.go:440","msg":"availability zone","zone-name":"us-west-2-lax-1b","zone-id":"usw2-lax1-az2","zone-type":"local-zone","zone-opt-in-status":"opted-in"}
{"level":"info","ts":"2021-08-27T13:12:43.565-0700","caller":"eks/eks.go:440","msg":"availability zone","zone-name":"us-west-2-wl1-sfo-wlz-1","zone-id":"usw2-wl1-sfo-wlz1","zone-type":"wavelength-zone","zone-opt-in-status":"opted-in"}

...
*********************************
createVPC ("/Users/natherz/go/src/github.com/aws-k8s-tester/bin/test7.yaml")
...
{"level":"info","ts":"2021-08-27T13:13:20.543-0700","caller":"cluster/vpc.go:611","msg":"creating public subnets","availability-zones":["us-west-2-lax-1a","us-west-2-lax-1b","us-west-2-wl1-sfo-wlz-1"]}
{"level":"info","ts":"2021-08-27T13:13:20.884-0700","caller":"cluster/vpc.go:657","msg":"created a public subnet","availability-zone":"us-west-2-lax-1a","subnet-id":"subnet-0208fce3213dca0e2"}
{"level":"info","ts":"2021-08-27T13:13:21.300-0700","caller":"cluster/vpc.go:670","msg":"modified the public subnet with MapPublicIpOnLaunch","availability-zone":"us-west-2-lax-1a","subnet-id":"subnet-0208fce3213dca0e2"}
{"level":"info","ts":"2021-08-27T13:13:21.709-0700","caller":"cluster/vpc.go:657","msg":"created a public subnet","availability-zone":"us-west-2-lax-1b","subnet-id":"subnet-061756243f7b583f3"}
{"level":"info","ts":"2021-08-27T13:13:22.118-0700","caller":"cluster/vpc.go:670","msg":"modified the public subnet with MapPublicIpOnLaunch","availability-zone":"us-west-2-lax-1b","subnet-id":"subnet-061756243f7b583f3"}
{"level":"info","ts":"2021-08-27T13:13:22.612-0700","caller":"cluster/vpc.go:657","msg":"created a public subnet","availability-zone":"us-west-2-wl1-sfo-wlz-1","subnet-id":"subnet-071dca0f0bd04e80c"}
{"level":"warn","ts":"2021-08-27T13:13:22.893-0700","caller":"cluster/vpc.go:667","msg":"failed to modify subnet attribute","availability-zone":"us-west-2-wl1-sfo-wlz-1","error":"operation error EC2: ModifySubnetAttribute, https response error StatusCode: 400, RequestID: b989ec6e-d9a1-4e2f-937b-4cf3629036ca, api error InvalidParameterValue: invalid value for parameter map-public-ip-on-launch: true"}
```
Creating the VPC succeeds when only considering availability zones:
```
checking availability zones...
{"level":"info","ts":"2021-08-27T13:56:40.217-0700","caller":"eks/eks.go:447","msg":"availability zone","zone-name":"us-west-2a","zone-id":"usw2-az1","zone-type":"availability-zone","zone-opt-in-status":"opt-in-not-required"}
{"level":"info","ts":"2021-08-27T13:56:40.218-0700","caller":"eks/eks.go:447","msg":"availability zone","zone-name":"us-west-2b","zone-id":"usw2-az2","zone-type":"availability-zone","zone-opt-in-status":"opt-in-not-required"}
{"level":"info","ts":"2021-08-27T13:56:40.218-0700","caller":"eks/eks.go:447","msg":"availability zone","zone-name":"us-west-2c","zone-id":"usw2-az3","zone-type":"availability-zone","zone-opt-in-status":"opt-in-not-required"}
{"level":"info","ts":"2021-08-27T13:56:40.218-0700","caller":"eks/eks.go:447","msg":"availability zone","zone-name":"us-west-2d","zone-id":"usw2-az4","zone-type":"availability-zone","zone-opt-in-status":"opt-in-not-required"}
{"level":"info","ts":"2021-08-27T13:56:40.221-0700","caller":"eks/eks.go:476","msg":"checking ECR API v1 availability; listing repositories"}

...
*********************************
createVPC ("/Users/natherz/go/src/github.com/aws-k8s-tester/bin/test7.yaml")
...
{"level":"info","ts":"2021-08-27T13:57:28.659-0700","caller":"cluster/vpc.go:611","msg":"creating public subnets","availability-zones":["us-west-2a","us-west-2b","us-west-2c"]}
{"level":"info","ts":"2021-08-27T13:57:28.978-0700","caller":"cluster/vpc.go:657","msg":"created a public subnet","availability-zone":"us-west-2a","subnet-id":"subnet-028b68140f1e2e010"}
{"level":"info","ts":"2021-08-27T13:57:29.257-0700","caller":"cluster/vpc.go:670","msg":"modified the public subnet with MapPublicIpOnLaunch","availability-zone":"us-west-2a","subnet-id":"subnet-028b68140f1e2e010"}
{"level":"info","ts":"2021-08-27T13:57:29.661-0700","caller":"cluster/vpc.go:657","msg":"created a public subnet","availability-zone":"us-west-2b","subnet-id":"subnet-056d127fc55cf0497"}
{"level":"info","ts":"2021-08-27T13:57:29.896-0700","caller":"cluster/vpc.go:670","msg":"modified the public subnet with MapPublicIpOnLaunch","availability-zone":"us-west-2b","subnet-id":"subnet-056d127fc55cf0497"}
{"level":"info","ts":"2021-08-27T13:57:30.309-0700","caller":"cluster/vpc.go:657","msg":"created a public subnet","availability-zone":"us-west-2c","subnet-id":"subnet-07e23045ab607e1c6"}
{"level":"info","ts":"2021-08-27T13:57:30.627-0700","caller":"cluster/vpc.go:670","msg":"modified the public subnet with MapPublicIpOnLaunch","availability-zone":"us-west-2c","subnet-id":"subnet-07e23045ab607e1c6"}
{"level":"info","ts":"2021-08-27T13:57:30.634-0700","caller":"cluster/vpc.go:673","msg":"created public subnets","availability-zones":["us-west-2a","us-west-2b","us-west-2c"]}
...
{"level":"info","ts":"2021-08-27T14:00:11.423-0700","caller":"cluster/vpc.go:200","msg":"created a VPC","vpc-id":"vpc-001d175aeee3a2d83","vpc-cidr-blocks":["10.0.0.0/16","10.1.0.0/16","10.2.0.0/16","10.3.0.0/16"],"public-subnet-ids":["subnet-028b68140f1e2e010","subnet-056d127fc55cf0497","subnet-07e23045ab607e1c6"],"private-subnet-ids":["subnet-0cf490cf80c6f8af1","subnet-03b226d68184da2fc"],"control-plane-security-group-id":"sg-04d0ce7a8bfb7e081"}
```
