### PR TITLE
fix link to the KEP 2313

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Releases](https://img.shields.io/github/release/aws/aws-k8s-tester/all.svg?style=flat-square)](https://github.com/aws/aws-k8s-tester/releases)
 [![LICENSE](https://img.shields.io/github/license/aws/aws-k8s-tester.svg?style=flat-square)](https://github.com/aws/aws-k8s-tester/blob/master/LICENSE)
 
-https://github.com/kubernetes/enhancements/blob/master/keps/provider-aws/20181126-aws-k8s-tester.md
+https://github.com/kubernetes/enhancements/blob/master/keps/provider-aws/2313-aws-k8s-tester/README.md
 
 `aws-k8s-tester` is a set of utilities and libraries for "testing" Kubernetes on AWS.
 


### PR DESCRIPTION
*Description of changes:*

The PR is a quick fix updating the link to the [KEP 2313: aws-k8s-tester - kubetest plugin for AWS and EKS](https://github.com/kubernetes/enhancements/blob/master/keps/provider-aws/2313-aws-k8s-tester/README.md)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
