### PR TITLE
updating-opencontainers/runc

### DIFF
--- a/k8s-tester/go.mod
+++ b/k8s-tester/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/onsi/ginkgo v1.16.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/opencontainers/runc v1.0.0-rc93 // indirect
+	github.com/opencontainers/runc v1.1.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.0.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
updating-opencontainers/runc to 1.1.4

Tested using using the hack/build.sh script to build new binaries, and was successfully able to create a test cluster using newly created binaries.

```


{"level":"info","ts":"2023-01-03T21:11:07.150Z","caller":"eks/eks.go:1102","msg":"Up succeeded","started":"13 minutes ago"}
{"level":"info","ts":"2023-01-03T21:11:07.150Z","caller":"eks/eks.go:1106","msg":"Up.defer end (/tmp/jdevmane-test-prod2-eks.yaml, /tmp/kubectl-test-v1.20.7 --kubeconfig=/tmp/jdevmane-test-prod2-eks.kubeconfig.yaml)"}


*********************************


💯 😁 👍 :) UP SUCCESS




# to delete cluster
aws-k8s-tester eks delete cluster --path /tmp/jdevmane-test-prod2-eks.yaml




*********************************
aws-k8s-tester eks create cluster SUCCESS
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
