### PR TITLE
Kubetest2-eks support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ ACCOUNT_ID ?= $(shell aws sts get-caller-identity --query Account --output text)
 REGION ?= us-west-2
 ECR_HOST ?= amazonaws.com
 
+INSTALL?=cp
+# make install will place binaries here
+INSTALL_DIR?=$(GOPATH)/bin
+
+DEPLOYER_BIN=kubetest2-aws
+
 # build custom "busybox" image
 ORIGINAL_BUSYBOX_IMG ?= gcr.io/google-containers/busybox:latest
 ECR_BUSYBOX_IMG_NAME ?= busybox
@@ -33,7 +39,14 @@ k8s-tester-stress:
 	eval $$(aws ecr get-login --registry-ids $(ACCOUNT_ID) --no-include-email --region $(REGION))
 	docker push $(ACCOUNT_ID).dkr.ecr.$(REGION).$(ECR_HOST)/$(ECR_K8S_TESTER_STRESS_IMG_NAME):$(ECR_K8S_TESTER_STRESS_TAG);
 
+# build deployer for kubtest2
+deployer:
+	mkdir -p bin
+	go mod tidy -compat=1.17
+	go build -v -o bin/$(DEPLOYER_BIN) cmd/kubetest2-aws/main.go
 
+install: deployer
+	$(INSTALL) bin/$(DEPLOYER_BIN) $(INSTALL_DIR)/$(BINARY_NAME)
 
 
 

--- a/cmd/kubetest2-aws/README.md
+++ b/cmd/kubetest2-aws/README.md
@@ -1,0 +1,26 @@
+# kubetest2-aws
+
+This directory contains source code to build kubetest2-aws to provison and delete eks clusters that can act as a deployer for kubetest2.
+
+## Commands
+Run the following commands from the top level of repo
+
+Build kubetest2-aws binary in bin. 
+
+```
+make deployer
+```
+
+Install kubetest2-aws to $GOPATH/bin
+
+```
+make install
+```
+
+### Useful enviroment variables
+
+`AWS_K8S_TESTER_EKS_CONFIG_INPUT` - Path to the eks configuration as explained in the repo README.md
+
+`AWS_K8S_TESTER_EKS_VERSION` - K8s major version
+
+`AWS_K8S_TESTER_EKS_NAME` - Cluster name, by default if `AWS_K8S_TESTER_EKS_CONFIG_INPUT` is not set a config with the $(AWS_K8S_TESTER_EKS_NAME).yml will be created in /tmp

--- a/cmd/kubetest2-aws/deployer/deployer.go
+++ b/cmd/kubetest2-aws/deployer/deployer.go
@@ -83,7 +83,10 @@ func bindFlags(d *deployer) *pflag.FlagSet {
 
 func newEKSTester() (*eks.Tester, error) {
 	cfg := eksconfig.NewDefault()
-	path := filepath.Join(os.TempDir(), cfg.Name+".yaml")
+	path := os.Getenv("AWS_K8S_TESTER_EKS_CONFIG_INPUT")
+	if path == "" {
+		path = filepath.Join(os.TempDir(), cfg.Name+".yaml")
+	}
 	cfg.ConfigPath = path
 
 	err := cfg.UpdateFromEnvs()

--- a/cmd/kubetest2-aws/deployer/deployer.go
+++ b/cmd/kubetest2-aws/deployer/deployer.go
@@ -1,0 +1,123 @@
+package deployer
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/octago/sflags/gen/gpflag"
+	"github.com/spf13/pflag"
+	"k8s.io/klog"
+	"sigs.k8s.io/kubetest2/pkg/artifacts"
+	"sigs.k8s.io/kubetest2/pkg/types"
+
+	"github.com/aws/aws-k8s-tester/eks"
+	"github.com/aws/aws-k8s-tester/eksconfig"
+)
+
+// Name is the name of the deployer
+const Name = "eks"
+
+// assert that New implements types.NewDeployer
+var _ types.NewDeployer = New
+
+// New implements deployer.New for eks
+func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
+	tester, err := newEKSTester()
+	if err != nil {
+		fmt.Printf("Failed to create EKS Tester based on Configuration: %v \n", err)
+		os.Exit(1)
+	}
+
+	d := &deployer{
+		tester:        tester,
+		commonOptions: opts,
+		logsDir:       filepath.Join(artifacts.BaseDir(), "logs"),
+	}
+	// register flags and return
+	return d, bindFlags(d)
+}
+
+type deployer struct {
+	commonOptions types.Options
+	tester        *eks.Tester
+	logsDir       string
+}
+
+func (d *deployer) Up() error {
+	return d.tester.Up()
+}
+
+func (d *deployer) Down() error {
+	return d.tester.Down()
+}
+
+func (d *deployer) IsUp() (bool, error) {
+	return d.tester.IsUp()
+}
+
+func (d *deployer) DumpClusterLogs() error {
+	return d.tester.DownloadClusterLogs(d.logsDir, "")
+}
+
+func (d *deployer) Build() error {
+	return d.tester.Build()
+}
+
+// helper used to create & bind a flagset to the deployer
+func bindFlags(d *deployer) *pflag.FlagSet {
+	flags, err := gpflag.Parse(d)
+	if err != nil {
+		klog.Fatalf("unable to generate flags from deployer")
+		return nil
+	}
+
+	klog.InitFlags(nil)
+	flags.AddGoFlagSet(flag.CommandLine)
+
+	return flags
+}
+
+func newEKSTester() (*eks.Tester, error) {
+	cfg := eksconfig.NewDefault()
+	path := filepath.Join(os.TempDir(), cfg.Name+".yaml")
+	cfg.ConfigPath = path
+
+	err := cfg.UpdateFromEnvs()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load configuration from environment variables: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err = cfg.ValidateAndSetDefaults(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to validate configuration %q (%v)\n", path, err)
+		os.Exit(1)
+	}
+
+	if cfg.IsEnabledAddOnNodeGroups() {
+		body, err := json.MarshalIndent(cfg.AddOnNodeGroups, "", "    ")
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("AddOnNodeGroups:\n\n%s\n\n\n", string(body))
+	}
+	if cfg.IsEnabledAddOnManagedNodeGroups() {
+		body, err := json.MarshalIndent(cfg.AddOnManagedNodeGroups, "", "    ")
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("AddOnManagedNodeGroups:\n\n%s\n\n\n", string(body))
+	}
+
+	time.Sleep(5 * time.Second)
+	tester, err := eks.New(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create EKS deployer %v\n", err)
+		os.Exit(1)
+	}
+
+	return tester, nil
+}

--- a/cmd/kubetest2-aws/main.go
+++ b/cmd/kubetest2-aws/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"sigs.k8s.io/kubetest2/pkg/app"
+
+	"github.com/aws/aws-k8s-tester/cmd/kubetest2-aws/deployer"
+)
+
+func main() {
+	app.Main(deployer.Name, deployer.New)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws/aws-k8s-tester
 go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.38.49
+	github.com/aws/aws-sdk-go v1.43.16
 	github.com/aws/aws-sdk-go-v2 v1.7.0
 	github.com/aws/aws-sdk-go-v2/config v1.0.0
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.1.0 // indirect
@@ -57,8 +57,11 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/perf-tests/clusterloader2 v0.0.0-20220805114947-bdcf75fa01d0
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
+	sigs.k8s.io/kubetest2 v0.0.0-20220728001911-c76fb417aa01
 	sigs.k8s.io/yaml v1.3.0
 )
+
+require github.com/octago/sflags v0.2.0
 
 require (
 	cloud.google.com/go v0.99.0 // indirect
@@ -132,6 +135,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/klauspost/pgzip v1.2.1 // indirect
 	github.com/kr/pretty v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,9 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go v1.38.3/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.38.49 h1:E31vxjCe6a5I+mJLmUGaZobiWmg9KdWaud9IfceYeYQ=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.43.16 h1:Y7wBby44f+tINqJjw5fLH3vA+gFq4uMITIKqditwM14=
+github.com/aws/aws-sdk-go v1.43.16/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v1.0.0/go.mod h1:smfAbmpW+tcRVuNUjo3MOArSZmW72t62rkCzc2i0TWM=
 github.com/aws/aws-sdk-go-v2 v1.7.0 h1:UYGnoIPIzed+ycmgw8Snb/0HK+KlMD+SndLTneG8ncE=
@@ -915,6 +916,8 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kevinburke/go-bindata v3.17.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi30bslSp9YqD9pysLxunQDdb2CPM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -1124,6 +1127,8 @@ github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWk
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/octago/sflags v0.2.0 h1:XceYzkRXGAHa/lSFmKLcaxSrsh4MTuOMQdIGsUD0wlk=
+github.com/octago/sflags v0.2.0/go.mod h1:G0bjdxh4qPRycF74a2B8pU36iTp9QHGx0w0dFZXPt80=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
@@ -2244,6 +2249,8 @@ rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
+sigs.k8s.io/kubetest2 v0.0.0-20220728001911-c76fb417aa01 h1:WYiH7R3KJw1+osbyp6AlZaE5EMmKFwFj5wRHSDDYyK8=
+sigs.k8s.io/kubetest2 v0.0.0-20220728001911-c76fb417aa01/go.mod h1:YPdzgDKlnoGYtZnH03w01YMSf6tpetPibc0xjNI3sOc=
 sigs.k8s.io/kustomize/api v0.11.4 h1:/0Mr3kfBBNcNPOW5Qwk/3eb8zkswCwnqQxxKtmrTkRo=
 sigs.k8s.io/kustomize/api v0.11.4/go.mod h1:k+8RsqYbgpkIrJ4p9jcdPqe8DprLxFUUO0yNOq8C+xI=
 sigs.k8s.io/kustomize/cmd/config v0.10.6/go.mod h1:/S4A4nUANUa4bZJ/Edt7ZQTyKOY9WCER0uBS1SW2Rco=


### PR DESCRIPTION
Adding kubetest2 aws deployer using the existing eks framework in this repository.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
