### PR TITLE
Update default EKS version to 1.27

### DIFF
--- a/eksconfig/config.go
+++ b/eksconfig/config.go
@@ -903,7 +903,7 @@ func NewDefault() *Config {
 		VPC:        getDefaultVPC(),
 
 		SigningName: "eks",
-		Version:     "1.20",
+		Version:     "1.27",
 
 		RemoteAccessKeyCreate: true,
 		// keep in-sync with the default value in https://pkg.go.dev/k8s.io/kubernetes/test/e2e/framework#GetSigner

--- a/eksconfig/default.yaml
+++ b/eksconfig/default.yaml
@@ -117,8 +117,8 @@ status:
   up: false
 tags: null
 total-nodes: 0
-version: "1.20"
-version-value: 1.2
+version: "1.27"
+version-value: 1.27
 vpc:
   cidrs:
   - 10.0.0.0/16


### PR DESCRIPTION
*Description of changes:*

Updates the default EKS version to 1.27, from 1.20 (🕸️).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
