### PR TITLE
Add CI/build workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,13 @@
+name: "CI"
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: make build


### PR DESCRIPTION
Adds a workflow that will ensure PR's don't break the build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
