### PR TITLE
Add src to Dockerfile.kubetest2, use AWS CLI v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,3 +11,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: make build
+  build-kubetest2:
+    runs-on: ubuntu-latest
+    strategy:
+      # don't bail out of all sub-tasks if one fails
+      fail-fast: false
+      matrix:
+        k8s_version: ["1.23", "1.24", "1.25", "1.26", "1.27", "1.28"]
+    steps:
+    - uses: actions/checkout@v3
+    - run: docker build --build-arg=KUBERNETES_MINOR_VERSION=${{ matrix.k8s_version }} --file Dockerfile.kubetest2 .

--- a/Dockerfile.kubetest2
+++ b/Dockerfile.kubetest2
@@ -2,10 +2,14 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /workdir
-RUN yum install -y git tar gzip make unzip gcc rsync wget jq aws-cli && amazon-linux-extras install python3.8
+RUN yum install -y git tar gzip make unzip gcc rsync wget jq && amazon-linux-extras install python3.8
 
 RUN mkdir /info
 ENV PATH=$PATH:/info
+
+RUN wget -O awscli.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip && \
+    unzip awscli.zip && \
+    ./aws/install
 
 ARG GO_MINOR_VERSION="1.21"
 RUN curl https://go.dev/dl/?mode=json | jq -r .[].version | grep "^go${GO_MINOR_VERSION}" | head -n1 > go-version.txt
@@ -52,5 +56,8 @@ RUN ls -la
 RUN go install ./kubetest2-eksctl
 
 RUN rm -rf /workdir
+
+WORKDIR $GOPATH/src/github.com/aws/aws-k8s-tester
+COPY . .
 
 ENTRYPOINT ["kubetest2"]

--- a/e2e2/.dockerignore
+++ b/e2e2/.dockerignore
@@ -1,1 +1,3 @@
 _bin/
+bin/
+_rundir/

--- a/go.work
+++ b/go.work
@@ -1,6 +1,7 @@
 go 1.21
 
 use (
+	.
 	./e2e2
 	./kubetest2
 )

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,7 @@
+github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea h1:VcIYpAGBae3Z6BVncE0OnTE/ZjlDXqtYhOZky88neLM=
+github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,7 +1,0 @@
-github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea h1:VcIYpAGBae3Z6BVncE0OnTE/ZjlDXqtYhOZky88neLM=
-github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
-golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
-k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
-k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
-k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -39,7 +39,7 @@ for arch in ${ARCHS}; do
         GOARCH=${arch} \
         GOOS=${os} \
         go build \
-        -mod=mod -v \
+        -v \
         -ldflags "-s -w \
         -X ${PACKAGE_NAME}/version.GitCommit=${GIT_COMMIT} \
         -X ${PACKAGE_NAME}/version.ReleaseVersion=${RELEASE_VERSION} \

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -38,6 +38,7 @@ for arch in ${ARCHS}; do
       CGO_ENABLED=0 \
         GOARCH=${arch} \
         GOOS=${os} \
+        GOWORK=off \
         go build \
         -v \
         -ldflags "-s -w \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds the entire source tree to the kubetest2 docker image, so that `go test` can be used with the `exec` tester.

Also switches to the v2 AWS CLI, so that `aws eks get-token` returns the correct `apiVersion`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
