### PR TITLE
Only sweep detached ENIs of type `interface`

### DIFF
--- a/kubetest2/internal/deployer/eksapi/infra.go
+++ b/kubetest2/internal/deployer/eksapi/infra.go
@@ -163,6 +163,14 @@ func deleteLeakedENIs(clients *awsClients, resourceID string) error {
 				Name:   aws.String("vpc-id"),
 				Values: []string{infra.vpc},
 			},
+			{
+				Name:   aws.String("attachment.status"),
+				Values: []string{"detached"},
+			},
+			{
+				Name:   aws.String("interface-type"),
+				Values: []string{"interface"},
+			},
 		},
 	})
 	deleted := 0


### PR DESCRIPTION
*Description of changes:*

Filters ENIs for `detached` status before trying to delete them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
