### PR TITLE
Use latest marker for Kubernetes release

### DIFF
--- a/Dockerfile.kubetest2
+++ b/Dockerfile.kubetest2
@@ -44,7 +44,7 @@ RUN wget -O eksctl.tar.gz "https://github.com/eksctl-io/eksctl/releases/${EKSCTL
     tar xzf eksctl.tar.gz -C /bin/ && \
     rm eksctl.tar.gz
 ARG KUBERNETES_MINOR_VERSION
-RUN wget -O kubernetes-version.txt https://storage.googleapis.com/kubernetes-release/release/stable-${KUBERNETES_MINOR_VERSION}.txt
+RUN wget -O kubernetes-version.txt https://storage.googleapis.com/kubernetes-release/release/latest-${KUBERNETES_MINOR_VERSION}.txt
 RUN mkdir /info
 ENV PATH=$PATH:/info
 RUN cp kubernetes-version.txt /info/


### PR DESCRIPTION
*Description of changes:*

Switches to the `latest` Kubernetes release marker so that release candidates (e.g. `v1.29.0-rc.1`) can be used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
