### PR TITLE
Provision IPv6 clusters via eks api deployer

### DIFF
--- a/kubetest2/internal/deployers/eksapi/cloudformation/infra.yaml
+++ b/kubetest2/internal/deployers/eksapi/cloudformation/infra.yaml
@@ -259,7 +259,6 @@ Resources:
 
   #
   # Public subnets
-  # Note: AssignIpv6AddressOnCreation: true is required but a CFN limitation right now, need to add this manually
   SubnetPublic01:
     Type: AWS::EC2::Subnet
     Metadata:
@@ -275,6 +274,7 @@ Resources:
         Ref: PublicSubnet01Block
       Ipv6CidrBlock:
         !Select [0, !Cidr [!Select [0, !GetAtt VPC.Ipv6CidrBlocks], 8, 64]]
+      AssignIpv6AddressOnCreation: true
       MapPublicIpOnLaunch: true
       Tags:
         - Key: kubernetes.io/role/elb
@@ -297,6 +297,7 @@ Resources:
         Ref: PublicSubnet02Block
       Ipv6CidrBlock:
         !Select [1, !Cidr [!Select [0, !GetAtt VPC.Ipv6CidrBlocks], 8, 64]]
+      AssignIpv6AddressOnCreation: true
       MapPublicIpOnLaunch: true
       Tags:
         - Key: kubernetes.io/role/elb

--- a/kubetest2/internal/deployers/eksapi/cluster.go
+++ b/kubetest2/internal/deployers/eksapi/cluster.go
@@ -29,7 +29,7 @@ func createCluster(clients *awsClients, infra *infra, opts *deployerOptions, res
 		},
 		RoleArn: aws.String(infra.clusterRole),
 		KubernetesNetworkConfig: &ekstypes.KubernetesNetworkConfigRequest{
-			IpFamily: ekstypes.IpFamilyIpv4,
+			IpFamily: ekstypes.IpFamily(opts.IPFamily),
 		},
 		Version: aws.String(opts.KubernetesVersion),
 	}

--- a/kubetest2/internal/deployers/eksapi/deployer.go
+++ b/kubetest2/internal/deployers/eksapi/deployer.go
@@ -49,6 +49,7 @@ type deployerOptions struct {
 	KubeconfigPath              string   `flag:"kubeconfig" desc:"Path to kubeconfig"`
 	EKSEndpointURL              string   `flag:"endpoint-url" desc:"Endpoint URL for the EKS API"`
 	UpClusterHeaders            []string `flag:"up-cluster-header" desc:"Additional header to add to eks:CreateCluster requests. Specified in the same format as curl's -H flag."`
+	IPFamily                    string   `flag:"ip-family" desc:"IP family for the cluster (ipv4 or ipv6)"`
 }
 
 // NewDeployer implements deployer.New for EKS using the EKS (and other AWS) API(s) directly (no cloudformation)
@@ -144,6 +145,10 @@ func (d *deployer) verifyUpFlags() error {
 	if d.Nodes == 0 {
 		d.Nodes = 3
 		klog.V(2).Infof("Using default number of nodes: %d", d.Nodes)
+	}
+	if d.IPFamily == "" {
+		d.IPFamily = string(ekstypes.IpFamilyIpv4)
+		klog.V(2).Infof("Using default IP family: %s", d.IPFamily)
 	}
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Enable eks api deployer to provision an ipv6 cluster.  By default it falls back to `ipv4` if `--ip-family` option is not  passed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
