### PR TITLE
Add ssh-keygen to kubetest2 image

### DIFF
--- a/Dockerfile.kubetest2
+++ b/Dockerfile.kubetest2
@@ -23,7 +23,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /workdir
-RUN yum install -y tar gzip unzip wget
+RUN yum install -y tar gzip unzip wget openssh
 RUN wget -O awscli.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip && \
     unzip awscli.zip && \
     ./aws/install


### PR DESCRIPTION
*Description of changes:*

So the `--generate-ssh-key` flag for the `eksapi` deployer is functional in the container image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
