### PR TITLE
Add metrics registry to kubetest2-eksapi

### DIFF
--- a/kubetest2/go.mod
+++ b/kubetest2/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.100.1
-	sigs.k8s.io/kubetest2 v0.0.0-20231217201311-35c2bb42e641
+	sigs.k8s.io/kubetest2 v0.0.0-20240112190112-02e669d0b9b7
 )
 
 require (
@@ -53,12 +53,14 @@ require (
 	github.com/alibabacloud-go/tea-xml v1.1.2 // indirect
 	github.com/aliyun/credentials-go v1.2.3 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
+	github.com/aws/aws-sdk-go v1.46.4 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.9 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.9 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.30 // indirect
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.36.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.32.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.15.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.12.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.1 // indirect

--- a/kubetest2/go.sum
+++ b/kubetest2/go.sum
@@ -293,6 +293,8 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.37.6/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.46.4 h1:48tKgtm9VMPkb6y7HuYlsfhQmoIRAsTEXTsWLVlty4M=
+github.com/aws/aws-sdk-go v1.46.4/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v1.7.1/go.mod h1:L5LuPC1ZgDr2xQS7AmIec/Jlc7O/Y1u2KxJyNVab250=
 github.com/aws/aws-sdk-go-v2 v1.14.0/go.mod h1:ZA3Y8V0LrlWj63MQAnRHgKf/5QB//LSZCPNWlWrNGLU=
@@ -329,6 +331,8 @@ github.com/aws/aws-sdk-go-v2/service/autoscaling v1.36.6 h1:xLETNIzlbzqb/ZFir6l1
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.36.6/go.mod h1:ldeYLrGhWz2aMgCEL7He3+YbJAG5xn1K/fFFKRkyzd0=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.40.1 h1:gcJzqFpFy6no/GvMkA8L8ld3Wt/MygcJzj5xmpwfJuM=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.40.1/go.mod h1:swqr+Ayq2Mv+l32CXjtrYrdNqMu5d0aSKeM63ud7G8M=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.32.0 h1:f426fLs4hcrLuczLBqWf1Ob6FKJhISaR4e9Iw3Scr5A=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.32.0/go.mod h1:G63GKqSBLpBmO3tN1/PwM2NC65XvSd00zJWTZk202bc=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.137.1 h1:J/N4ydefXQZIwKBDPtvrhxrIuP/vaaYKnAsy3bKVIvU=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.137.1/go.mod h1:hrBzQzlQQRmiaeYRQPr0SdSx6fdqP+5YcGhb97LCt8M=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.4.1/go.mod h1:FglZcyeiBqcbvyinl+n14aT/EWC7S1MIH+Gan2iizt0=
@@ -2939,6 +2943,8 @@ sigs.k8s.io/kubetest2 v0.0.0-20231113220322-d7fcb799ce84 h1:r1v5iHjx9A4b6vSXntNt
 sigs.k8s.io/kubetest2 v0.0.0-20231113220322-d7fcb799ce84/go.mod h1:Mk/GvoOSrhOvqIg90OmoHnj72i1NApWnmvTTXy86b3g=
 sigs.k8s.io/kubetest2 v0.0.0-20231217201311-35c2bb42e641 h1:fXHKMtnV4QUs0zuaStEX7ihR/LGi9BJbZDyS0y4hk4Y=
 sigs.k8s.io/kubetest2 v0.0.0-20231217201311-35c2bb42e641/go.mod h1:Mk/GvoOSrhOvqIg90OmoHnj72i1NApWnmvTTXy86b3g=
+sigs.k8s.io/kubetest2 v0.0.0-20240112190112-02e669d0b9b7 h1:NoijosFvhxKMZzzzfpUQ91cueAUct9swQw3IH5fBxIQ=
+sigs.k8s.io/kubetest2 v0.0.0-20240112190112-02e669d0b9b7/go.mod h1:L1g0hoUkaxD1+3bU+3eqbmoOHaW1xj5bTtjivDSl1OE=
 sigs.k8s.io/mdtoc v1.0.1/go.mod h1:COYBtOjsaCg7o7SC4eaLwEXPuVRSuiVuLLRrHd7kShw=
 sigs.k8s.io/promo-tools/v3 v3.5.2 h1:xYmYJb2/TXIHBq8rlQZx6C3ESsayiPjp+cMYAlSodEY=
 sigs.k8s.io/promo-tools/v3 v3.5.2/go.mod h1:AYQ3wu2ESWY4UQqHtRUXnzj7V9/gP11kRKoykVQ6Oek=

--- a/kubetest2/internal/metrics/cloudwatch.go
+++ b/kubetest2/internal/metrics/cloudwatch.go
@@ -1,0 +1,93 @@
+package metrics
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go/aws"
+	"k8s.io/klog"
+)
+
+// NewCloudWatchRegistry creates a new metric registry that will emit values using the specified cloudwatch client
+func NewCloudWatchRegistry(cw *cloudwatch.Client) MetricRegistry {
+	return &cloudwatchRegistry{
+		cw:              cw,
+		lock:            &sync.Mutex{},
+		dataByNamespace: make(map[string][]*cloudwatchMetricDatum),
+	}
+}
+
+type cloudwatchRegistry struct {
+	cw              *cloudwatch.Client
+	lock            *sync.Mutex
+	dataByNamespace map[string][]*cloudwatchMetricDatum
+}
+
+type cloudwatchMetricDatum struct {
+	spec       *MetricSpec
+	value      float64
+	dimensions map[string]string
+	timestamp  time.Time
+}
+
+func (r *cloudwatchRegistry) Record(spec *MetricSpec, value float64, dimensions map[string]string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.dataByNamespace[spec.Namespace] = append(r.dataByNamespace[spec.Namespace], &cloudwatchMetricDatum{
+		spec:       spec,
+		value:      value,
+		dimensions: dimensions,
+		timestamp:  time.Now(),
+	})
+}
+
+func (r *cloudwatchRegistry) Emit() error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	for namespace, data := range r.dataByNamespace {
+		for i := 0; i < len(data); {
+			var metricData []types.MetricDatum
+			// we can emit up to 1000 values per PutMetricData
+			for j := 0; j < len(data) && j < 1000; j++ {
+				datum := data[i]
+				var dimensions []types.Dimension
+				for key, val := range datum.dimensions {
+					dimensions = append(dimensions, types.Dimension{
+						Name:  aws.String(key),
+						Value: aws.String(val),
+					})
+				}
+				metricData = append(metricData, types.MetricDatum{
+					MetricName: aws.String(datum.spec.Metric),
+					Value:      aws.Float64(datum.value),
+					Dimensions: dimensions,
+					Timestamp:  &datum.timestamp,
+				})
+				i++
+			}
+			_, err := r.cw.PutMetricData(context.TODO(), &cloudwatch.PutMetricDataInput{
+				Namespace:  aws.String(namespace),
+				MetricData: metricData,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		klog.Infof("emitted %d metrics to namespace: %s", len(data), namespace)
+	}
+	r.dataByNamespace = make(map[string][]*cloudwatchMetricDatum)
+	return nil
+}
+
+func (r *cloudwatchRegistry) GetRegistered() int {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	registered := 0
+	for _, data := range r.dataByNamespace {
+		registered += len(data)
+	}
+	return registered
+}

--- a/kubetest2/internal/metrics/noop.go
+++ b/kubetest2/internal/metrics/noop.go
@@ -1,0 +1,13 @@
+package metrics
+
+func NewNoopMetricRegistry() MetricRegistry {
+	return &noopRegistry{}
+}
+
+type noopRegistry struct{}
+
+func (r *noopRegistry) Record(spec *MetricSpec, value float64, dimensions map[string]string) {}
+
+func (r *noopRegistry) Emit() error {
+	return nil
+}

--- a/kubetest2/internal/metrics/registry.go
+++ b/kubetest2/internal/metrics/registry.go
@@ -1,0 +1,18 @@
+package metrics
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+type MetricRegistry interface {
+	// Record adds a new metric value to the registry
+	Record(spec *MetricSpec, value float64, dimensions map[string]string)
+	// Emit sends all registered metric values to cloudwatch, emptying the registry
+	Emit() error
+}
+
+type MetricSpec struct {
+	Namespace string
+	Metric    string
+	Unit      types.StandardUnit
+}

--- a/kubetest2/kubetest2-eksapi-janitor/main.go
+++ b/kubetest2/kubetest2-eksapi-janitor/main.go
@@ -12,8 +12,10 @@ import (
 func main() {
 	var maxResourceAge time.Duration
 	flag.DurationVar(&maxResourceAge, "max-resource-age", time.Hour*3, "Maximum resource age")
+	var emitMetrics bool
+	flag.BoolVar(&emitMetrics, "emit-metrics", false, "Send metrics to CloudWatch")
 	flag.Parse()
-	j := eksapi.NewJanitor(maxResourceAge)
+	j := eksapi.NewJanitor(maxResourceAge, emitMetrics)
 	if err := j.Sweep(context.Background()); err != nil {
 		klog.Fatalf("failed to sweep resources: %v", err)
 	}


### PR DESCRIPTION
*Description of changes:*

Adds a metric registry that collects all values and emits then when called. A cloudwatch and no-op implementation are provided.

CloudWatch charges per-PutMetricData call, so the registry is intended to minimize these calls.

Metrics are also added in this PR for the `eksapi` deployer:
- infrasructure stack deletion failures
- leaked ENI's found when deleting infrastructure stack

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
