### PR TITLE
Refactor eksapi deployer with initializer, managers

### DIFF
--- a/kubetest2/go.mod
+++ b/kubetest2/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.100.1
-	sigs.k8s.io/kubetest2 v0.0.0-20231113220322-d7fcb799ce84
+	sigs.k8s.io/kubetest2 v0.0.0-20231217201311-35c2bb42e641
 )
 
 require (

--- a/kubetest2/go.sum
+++ b/kubetest2/go.sum
@@ -2927,6 +2927,8 @@ sigs.k8s.io/kubetest2 v0.0.0-20231014151303-89f09b65e8dd h1:HqAkTCyXnlhZA3GMTVy7
 sigs.k8s.io/kubetest2 v0.0.0-20231014151303-89f09b65e8dd/go.mod h1:Mk/GvoOSrhOvqIg90OmoHnj72i1NApWnmvTTXy86b3g=
 sigs.k8s.io/kubetest2 v0.0.0-20231113220322-d7fcb799ce84 h1:r1v5iHjx9A4b6vSXntNtTcskAvLh1RkaVYPpWhNK3SM=
 sigs.k8s.io/kubetest2 v0.0.0-20231113220322-d7fcb799ce84/go.mod h1:Mk/GvoOSrhOvqIg90OmoHnj72i1NApWnmvTTXy86b3g=
+sigs.k8s.io/kubetest2 v0.0.0-20231217201311-35c2bb42e641 h1:fXHKMtnV4QUs0zuaStEX7ihR/LGi9BJbZDyS0y4hk4Y=
+sigs.k8s.io/kubetest2 v0.0.0-20231217201311-35c2bb42e641/go.mod h1:Mk/GvoOSrhOvqIg90OmoHnj72i1NApWnmvTTXy86b3g=
 sigs.k8s.io/mdtoc v1.0.1/go.mod h1:COYBtOjsaCg7o7SC4eaLwEXPuVRSuiVuLLRrHd7kShw=
 sigs.k8s.io/promo-tools/v3 v3.5.2 h1:xYmYJb2/TXIHBq8rlQZx6C3ESsayiPjp+cMYAlSodEY=
 sigs.k8s.io/promo-tools/v3 v3.5.2/go.mod h1:AYQ3wu2ESWY4UQqHtRUXnzj7V9/gP11kRKoykVQ6Oek=

--- a/kubetest2/internal/deployers/eksapi/kubeconfig.go
+++ b/kubetest2/internal/deployers/eksapi/kubeconfig.go
@@ -45,7 +45,7 @@ type kubeconfigTemplateParameters struct {
 	ClusterName                 string
 }
 
-func writeKubeconfig(cluster *cluster, kubeconfigPath string) error {
+func writeKubeconfig(cluster *Cluster, kubeconfigPath string) error {
 	klog.Infof("writing kubeconfig to %s for cluster: %s", kubeconfigPath, cluster.arn)
 	templateParams := kubeconfigTemplateParameters{
 		ClusterCertificateAuthority: cluster.certificateAuthorityData,


### PR DESCRIPTION
*Description of changes:*

Reorganizes infra/cluster/nodegroup logic into "managers". Also uses the DeployerWithInit interface from kubetest2 to clean up the lifecycle of the awsClients, etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
