### PR TITLE
Remove m7i.large from default instance types

### DIFF
--- a/kubetest2/internal/deployers/eksapi/deployer.go
+++ b/kubetest2/internal/deployers/eksapi/deployer.go
@@ -182,7 +182,6 @@ func (d *deployer) verifyUpFlags() error {
 	}
 	if len(d.InstanceTypes) == 0 && d.UnmanagedNodes {
 		d.InstanceTypes = []string{
-			"m7i.large",
 			"m6i.large",
 			"m6a.large",
 			"m5.large",


### PR DESCRIPTION
*Description of changes:*

This instance type is not yet available in all partitions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
