### PR TITLE
Add required tags to ASG for 1.25-

### DIFF
--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup.yaml.template
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup.yaml.template
@@ -107,6 +107,11 @@ Resources:
             {{- end}}
       VPCZoneIdentifier:
         !Ref SubnetIds
+      Tags:
+        # necessary for kubelet's legacy, in-tree cloud provider
+        - Key: !Sub kubernetes.io/cluster/${ClusterName}
+          Value: owned
+          PropagateAtLaunch: true
 
   NodeLifecycleHook:
     Type: AWS::AutoScaling::LifecycleHook


### PR DESCRIPTION
*Description of changes:*

The `kubernetes.io/cluster/$CLUSTER_NAME: owned` tag is required by Kubelet's legacy in-tree cloud provider, which is used on the EKS AMI for Kubernetes 1.25 and below.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
