### PR TITLE
Remove AMISSMParameter option from unmanaged nodegroup template

### DIFF
--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup.yaml.template
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup.yaml.template
@@ -19,13 +19,7 @@ Parameters:
 
   AMIId:
     Type: String
-    Default: ""
     Description: Specify AMI id for the node instances.
-
-  AMISSMParameter:
-    Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
-    Default: /aws/service/eks/optimized-ami/{{.KubernetesVersion}}/amazon-linux-2/recommended/image_id
-    Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances. Only used if AMIId is not specified.
 
   NodeDiskSize:
     Type: Number
@@ -68,9 +62,6 @@ Parameters:
 
   SSHSecurityGroup:
     Type: String
-
-Conditions:
-  HasAMIId: !Not [ !Equals [ !Ref AMIId, "" ] ]
 
 Resources:
   NodeInstanceProfile:
@@ -139,11 +130,7 @@ Resources:
                      --region ${AWS::Region}
         IamInstanceProfile: 
           Arn: !GetAtt NodeInstanceProfile.Arn
-        ImageId:
-          !If
-            - HasAMIId
-            - !Ref AMIId    
-            - Ref: AMISSMParameter
+        ImageId: !Ref AMIId
         InstanceType: "{{index .InstanceTypes 0}}"
         BlockDeviceMappings:
           - DeviceName: /dev/xvda


### PR DESCRIPTION
*Description of changes:*

Even when this CFN template parameter is not required (`AMIId` is defined), the default value is resolved. This will fail for Kubernetes versions that aren't GA on EKS yet (i.e. the SSM parameter doesn't exist yet).

We intend to always pass an AMI ID to this template, so I'm just removing this template parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
