### PR TITLE
Delete leaked ENIs before cluster

### DIFF
--- a/kubetest2/internal/deployers/eksapi/deployer.go
+++ b/kubetest2/internal/deployers/eksapi/deployer.go
@@ -220,10 +220,13 @@ func deleteResources(im *InfrastructureManager, cm *ClusterManager, nm *Nodegrou
 	if err := nm.deleteNodegroup(); err != nil {
 		return err
 	}
-	if err := cm.deleteCluster(); err != nil {
+	// the EKS-managed cluster security group may be associated with a leaked ENI
+	// so we need to make sure we've deleted leaked ENIs before we delete the cluster
+	// otherwise, the cluster security group will be left behind and will block deletion of our VPC
+	if err := im.deleteLeakedENIs(); err != nil {
 		return err
 	}
-	if err := im.deleteLeakedENIs(); err != nil {
+	if err := cm.deleteCluster(); err != nil {
 		return err
 	}
 	return im.deleteInfrastructureStack()


### PR DESCRIPTION
*Description of changes:*

This performs leaked ENI cleanup before cluster deletion. The security group created by EKS will be associated with leaked ENIs, and the async cluster deletion process will leave the security group behind. This, in turn, will prevent VPC deletion when the infra stack is torn down.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
