### PR TITLE
Add `--user-data-format` option, nodeadm support

### DIFF
--- a/kubetest2/internal/deployers/eksapi/deployer.go
+++ b/kubetest2/internal/deployers/eksapi/deployer.go
@@ -72,6 +72,7 @@ type deployerOptions struct {
 	Region                      string        `flag:"region" desc:"AWS region for EKS cluster"`
 	UnmanagedNodes              bool          `flag:"unmanaged-nodes" desc:"Use an AutoScalingGroup instead of an EKS-managed nodegroup."`
 	UpClusterHeaders            []string      `flag:"up-cluster-header" desc:"Additional header to add to eks:CreateCluster requests. Specified in the same format as curl's -H flag."`
+	UserDataFormat              string        `flag:"user-data-format" desc:"Format of the node instance user data"`
 }
 
 // NewDeployer implements deployer.New for EKS using the EKS (and other AWS) API(s) directly (no cloudformation)
@@ -219,6 +220,13 @@ func (d *deployer) verifyUpFlags() error {
 			"m4.large",
 		}
 		klog.V(2).Infof("Using default instance types: %v", d.InstanceTypes)
+	}
+	if d.UnmanagedNodes && d.AMI == "" {
+		return fmt.Errorf("--ami must be specified for --unmanaged-nodes")
+	}
+	if d.UnmanagedNodes && d.UserDataFormat == "" {
+		d.UserDataFormat = "bootstrap.sh"
+		klog.V(2).Infof("Using default user data format: %s", d.UserDataFormat)
 	}
 	if d.NodeReadyTimeout == 0 {
 		d.NodeReadyTimeout = time.Minute * 5

--- a/kubetest2/internal/deployers/eksapi/k8s.go
+++ b/kubetest2/internal/deployers/eksapi/k8s.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -25,6 +26,7 @@ func newKubernetesClient(kubeconfigPath string) (*kubernetes.Clientset, error) {
 }
 
 func waitForReadyNodes(client *kubernetes.Clientset, nodeCount int, timeout time.Duration) error {
+	klog.Infof("waiting up to %v for %d node(s) to be ready...", timeout, nodeCount)
 	readyNodes := sets.NewString()
 	watcher, err := client.CoreV1().Nodes().Watch(context.TODO(), metav1.ListOptions{})
 	if err != nil {
@@ -64,6 +66,7 @@ func waitForReadyNodes(client *kubernetes.Clientset, nodeCount int, timeout time
 			break
 		}
 	}
+	klog.Infof("%d node(s) are ready: %v", readyNodes.Len(), readyNodes)
 	return nil
 }
 

--- a/kubetest2/internal/deployers/eksapi/templates/templates.go
+++ b/kubetest2/internal/deployers/eksapi/templates/templates.go
@@ -8,15 +8,30 @@ import (
 //go:embed infra.yaml
 var Infrastructure string
 
-//go:embed unmanaged-nodegroup.yaml.template
-var unmanagedNodegroupTemplate string
+var (
+	//go:embed unmanaged-nodegroup.yaml.template
+	unmanagedNodegroupTemplate string
+	UnmanagedNodegroup         = template.Must(template.New("unmanagedNodegroup").Parse(unmanagedNodegroupTemplate))
+)
 
-var UnmanagedNodegroup *template.Template
+type UnmanagedNodegroupTemplateData struct {
+	KubernetesVersion string
+	InstanceTypes     []string
+}
 
-func init() {
-	t, err := template.New("unmanaged-nodegroup").Parse(unmanagedNodegroupTemplate)
-	if err != nil {
-		panic(err)
-	}
-	UnmanagedNodegroup = t
+var (
+	//go:embed userdata_bootstrap.sh.mimepart.template
+	userDataBootstrapShTemplate string
+	UserDataBootstrapSh         = template.Must(template.New("userDataBootstrapSh").Parse(userDataBootstrapShTemplate))
+
+	//go:embed userdata_nodeadm.yaml.mimepart.template
+	userDataNodeadmTemplate string
+	UserDataNodeadm         = template.Must(template.New("userDataNodeadm").Parse(userDataNodeadmTemplate))
+)
+
+type UserDataTemplateData struct {
+	Name                 string
+	CertificateAuthority string
+	CIDR                 string
+	APIServerEndpoint    string
 }

--- a/kubetest2/internal/deployers/eksapi/templates/templates_test.go
+++ b/kubetest2/internal/deployers/eksapi/templates/templates_test.go
@@ -7,10 +7,7 @@ import (
 
 func Test_UnmanagedNodegroup(t *testing.T) {
 	buf := bytes.Buffer{}
-	err := UnmanagedNodegroup.Execute(&buf, struct {
-		KubernetesVersion string
-		InstanceTypes     []string
-	}{
+	err := UnmanagedNodegroup.Execute(&buf, UnmanagedNodegroupTemplateData{
 		KubernetesVersion: "1.28",
 		InstanceTypes: []string{
 			"t2.medium",

--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup.yaml.template
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup.yaml.template
@@ -29,38 +29,20 @@ Parameters:
   NodeCount:
     Type: Number
 
-  ClusterCA:
-    Type: String
-
-  ClusterEndpoint:
-    Type: String
-
   ClusterName:
-    Type: String
-
-  ExtraBootstrapArguments:
-    Description: Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami
-    Type: String
-    Default: ""
-
-  BootstrapArgumentsForSpotFleet:
-    Description: Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami
-    Default: "--kubelet-extra-args '--node-labels=lifecycle=Ec2Spot,$ExtraNodeLabels --register-with-taints=spotInstance=true:PreferNoSchedule'"
     Type: String
 
   NodeRoleName:
     Description: The IAM role name  of worker nodes.
     Type: String
-    
-  PauseTime:
-    Description: Pause Time
-    Type: String
-    Default: PT5M
 
   SSHKeyPair:
     Type: String
 
   SSHSecurityGroup:
+    Type: String
+
+  UserData:
     Type: String
 
 Resources:
@@ -76,19 +58,19 @@ Resources:
     UpdatePolicy:
       AutoScalingRollingUpdate:
         WaitOnResourceSignals: true
-        PauseTime: !Ref PauseTime
+        PauseTime: PT15M
     Properties:
       AutoScalingGroupName: !Ref ResourceId
       DesiredCapacity: !Ref NodeCount
       MinSize: !Ref NodeCount
-      MaxSize: !Ref NodeCount      
+      MaxSize: !Ref NodeCount
       MixedInstancesPolicy:
         InstancesDistribution:
           OnDemandAllocationStrategy: prioritized
           OnDemandBaseCapacity: !Ref NodeCount
           OnDemandPercentageAboveBaseCapacity: 0
         LaunchTemplate:
-          LaunchTemplateSpecification: 
+          LaunchTemplateSpecification:
             LaunchTemplateId: !Ref NodeLaunchTemplate
             # LaunchTemplateName: String
             Version: !GetAtt NodeLaunchTemplate.LatestVersionNumber
@@ -117,23 +99,32 @@ Resources:
     Type: AWS::EC2::LaunchTemplate
     Properties:
       LaunchTemplateName: !Ref ResourceId
-      LaunchTemplateData: 
+      LaunchTemplateData:
         SecurityGroupIds:
           - !Ref SecurityGroup
           - !Ref SSHSecurityGroup
         KeyName: !Ref SSHKeyPair
         UserData:
           Fn::Base64:
-            !Sub |
-            #!/bin/bash
-            /etc/eks/bootstrap.sh ${ClusterName} ${ExtraBootstrapArguments} \
-              --b64-cluster-ca ${ClusterCA} \
-              --apiserver-endpoint ${ClusterEndpoint}
-            /opt/aws/bin/cfn-signal --exit-code $? \
-                     --stack  ${AWS::StackName} \
-                     --resource NodeGroup  \
-                     --region ${AWS::Region}
-        IamInstanceProfile: 
+            Fn::Sub: |
+              Content-Type: multipart/mixed; boundary="BOUNDARY"
+              MIME-Version: 1.0
+
+              --BOUNDARY
+              ${UserData}
+
+              --BOUNDARY
+              Content-Type: text/x-shellscript; charset="us-ascii"
+              MIME-Version: 1.0
+
+              #!/usr/bin/env bash
+              /opt/aws/bin/cfn-signal \
+                --stack  ${AWS::StackName} \
+                --resource NodeGroup \
+                --region ${AWS::Region}
+
+              --BOUNDARY--
+        IamInstanceProfile:
           Arn: !GetAtt NodeInstanceProfile.Arn
         ImageId: !Ref AMIId
         InstanceType: "{{index .InstanceTypes 0}}"

--- a/kubetest2/internal/deployers/eksapi/templates/userdata_bootstrap.sh.mimepart.template
+++ b/kubetest2/internal/deployers/eksapi/templates/userdata_bootstrap.sh.mimepart.template
@@ -1,0 +1,7 @@
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+
+#!/usr/bin/env bash
+/etc/eks/bootstrap.sh {{.Name}} \
+  --b64-cluster-ca {{.CertificateAuthority}} \
+  --apiserver-endpoint {{.APIServerEndpoint}}

--- a/kubetest2/internal/deployers/eksapi/templates/userdata_nodeadm.yaml.mimepart.template
+++ b/kubetest2/internal/deployers/eksapi/templates/userdata_nodeadm.yaml.mimepart.template
@@ -1,0 +1,12 @@
+Content-Type: application/node.eks.aws
+MIME-Version: 1.0
+
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: {{.Name}}
+    apiServerEndpoint: {{.APIServerEndpoint}}
+    certificateAuthority: {{.CertificateAuthority}}
+    cidr: {{.CIDR}}

--- a/kubetest2/internal/deployers/eksapi/userdata.go
+++ b/kubetest2/internal/deployers/eksapi/userdata.go
@@ -1,0 +1,32 @@
+package eksapi
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/aws/aws-k8s-tester/kubetest2/internal/deployers/eksapi/templates"
+)
+
+func generateUserData(format string, cluster *Cluster) (string, error) {
+	var t *template.Template
+	switch format {
+	case "bootstrap.sh":
+		t = templates.UserDataBootstrapSh
+	case "nodeadm":
+		// TODO: replace the YAML template with proper usage of the nodeadm API go types
+		t = templates.UserDataNodeadm
+	default:
+		return "", fmt.Errorf("uknown user data format: '%s'", format)
+	}
+	buf := bytes.Buffer{}
+	if err := t.Execute(&buf, templates.UserDataTemplateData{
+		APIServerEndpoint:    cluster.endpoint,
+		CertificateAuthority: cluster.certificateAuthorityData,
+		CIDR:                 cluster.cidr,
+		Name:                 cluster.name,
+	}); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/kubetest2/internal/deployers/eksapi/userdata_test.go
+++ b/kubetest2/internal/deployers/eksapi/userdata_test.go
@@ -1,0 +1,63 @@
+package eksapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var cluster = Cluster{
+	name:                     "cluster",
+	endpoint:                 "https://example.com",
+	certificateAuthorityData: "certificateAuthority",
+	cidr:                     "10.100.0.0/16",
+}
+
+const bootstrapShUserData = `Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+
+#!/usr/bin/env bash
+/etc/eks/bootstrap.sh cluster \
+  --b64-cluster-ca certificateAuthority \
+  --apiserver-endpoint https://example.com
+`
+
+const nodeadmUserData = `Content-Type: application/node.eks.aws
+MIME-Version: 1.0
+
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: certificateAuthority
+	cidr: 10.100.0.0/16
+`
+
+func Test_generateUserData(t *testing.T) {
+	cases := []struct {
+		format   string
+		expected string
+	}{
+		{
+			format:   "bootstrap.sh",
+			expected: bootstrapShUserData,
+		},
+		{
+			format:   "nodeadm",
+			expected: nodeadmUserData,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.format, func(t *testing.T) {
+			actual, err := generateUserData(c.format, &cluster)
+			if err != nil {
+				t.Log(err)
+				t.Error(err)
+			}
+			assert.Equal(t, c.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*

Parameterizes the node user data, with support for the legacy `bootstrap.sh` and the new `nodeadm` formats.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
