### PR TITLE
Add `--tune-vpc-cni` option to eksapi deployer

### DIFF
--- a/kubetest2/internal/deployers/eksapi/auth_map_role_test.go
+++ b/kubetest2/internal/deployers/eksapi/auth_map_role_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-rolearn := "mock-role-arn"
+const rolearn = "mock-role-arn"
 
 const sessionNamedAuthMapRole = `
 - username: system:node:{{SessionName}} 
@@ -25,7 +25,7 @@ const privateDNSNamedAuthMapRole = `
 func Test_generateAuthRoleMap(t *testing.T) {
 	cases := []struct {
 		nodeNameStrategy string
-		expected string
+		expected         string
 	}{
 		{
 			nodeNameStrategy: "SessionName",

--- a/kubetest2/internal/deployers/eksapi/deployer.go
+++ b/kubetest2/internal/deployers/eksapi/deployer.go
@@ -76,6 +76,7 @@ type deployerOptions struct {
 	Nodes                       int           `flag:"nodes" desc:"number of nodes to launch in cluster"`
 	NodeNameStrategy            string        `flag:"node-name-strategy" desc:"Specifies the naming strategy for node. Allowed values: ['SessionName', 'EC2PrivateDNSName'], default to EC2PrivateDNSName"`
 	Region                      string        `flag:"region" desc:"AWS region for EKS cluster"`
+	TuneVPCCNI                  bool          `flag:"tune-vpc-cni" desc:"Apply tuning parameters to the VPC CNI DaemonSet"`
 	UnmanagedNodes              bool          `flag:"unmanaged-nodes" desc:"Use an AutoScalingGroup instead of an EKS-managed nodegroup."`
 	UpClusterHeaders            []string      `flag:"up-cluster-header" desc:"Additional header to add to eks:CreateCluster requests. Specified in the same format as curl's -H flag."`
 	UserDataFormat              string        `flag:"user-data-format" desc:"Format of the node instance user data"`
@@ -190,6 +191,11 @@ func (d *deployer) Up() error {
 	}
 	if err := d.addonManager.createAddons(d.infra, d.cluster, &d.deployerOptions); err != nil {
 		return err
+	}
+	if d.deployerOptions.TuneVPCCNI {
+		if err := tuneVPCCNI(k8sClient); err != nil {
+			return err
+		}
 	}
 	if err := d.nodegroupManager.createNodegroup(d.infra, d.cluster, &d.deployerOptions); err != nil {
 		return err

--- a/kubetest2/internal/deployers/eksapi/vpccni.go
+++ b/kubetest2/internal/deployers/eksapi/vpccni.go
@@ -1,0 +1,49 @@
+package eksapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+const vpcCNIDaemonSetPatch = `{
+	"spec": {
+		"template": {
+			"spec": {
+				"containers": [
+					{
+						"name": "aws-node",
+						"env": [
+							{
+								"name": "ENABLE_PREFIX_DELEGATION",
+								"value": "true"
+							},
+							{
+								"name": "MINIMUM_IP_TARGET",
+								"value": "80"
+							},
+							{
+								"name": "WARM_IP_TARGET",
+								"value": "10"
+							}
+						]
+					}
+				]
+			}
+		}
+	}
+}`
+
+// tuneVPCCNI applies configuration to the VPC CNI DaemonSet that helps prevent test flakiness
+func tuneVPCCNI(client *kubernetes.Clientset) error {
+	var patch bytes.Buffer
+	if err := json.Compact(&patch, []byte(vpcCNIDaemonSetPatch)); err != nil {
+		return err
+	}
+	_, err := client.AppsV1().DaemonSets("kube-system").Patch(context.TODO(), "aws-node", types.StrategicMergePatchType, patch.Bytes(), metav1.PatchOptions{})
+	return err
+}

--- a/kubetest2/internal/deployers/eksapi/vpccni_test.go
+++ b/kubetest2/internal/deployers/eksapi/vpccni_test.go
@@ -1,0 +1,13 @@
+package eksapi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func Test_validVPCCNIDaemonSetPatch(t *testing.T) {
+	var j json.RawMessage
+	if err := json.Unmarshal([]byte(vpcCNIDaemonSetPatch), &j); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
*Description of changes:*

This adds an option to increase the number of warm ENIs + IPs for the VPC CNI, which prevents flakiness when conformance testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
