### PR TITLE
fix ami-type flag

### DIFF
--- a/kubetest2/internal/deployers/eksapi/deployer.go
+++ b/kubetest2/internal/deployers/eksapi/deployer.go
@@ -61,27 +61,27 @@ type deployer struct {
 }
 
 type deployerOptions struct {
-	Addons                      []string          `flag:"addons" desc:"Managed addons (name:version pairs) to create in the cluster. Use 'latest' for the most recent version, or 'default' for the default version."`
-	AMI                         string            `flag:"ami" desc:"AMI for unmanaged nodes"`
-	AMIType                     ekstypes.AMITypes `flag:"ami-type" desc:"AMI type for managed nodes"`
-	ClusterRoleServicePrincipal string            `flag:"cluster-role-service-principal" desc:"Additional service principal that can assume the cluster role"`
-	EFA                         bool              `flag:"efa" desc:"Create EFA interfaces on the node of an unmanaged nodegroup. Requires --unmanaged-nodes."`
-	EKSEndpointURL              string            `flag:"endpoint-url" desc:"Endpoint URL for the EKS API"`
-	EmitMetrics                 bool              `flag:"emit-metrics" desc:"Record and emit metrics to CloudWatch"`
-	ExpectedAMI                 string            `flag:"expected-ami" desc:"Expected AMI of nodes. Up will fail if the actual nodes are not utilizing the expected AMI. Defaults to --ami if defined."`
-	GenerateSSHKey              bool              `flag:"generate-ssh-key" desc:"Generate an SSH key to use for tests. The generated key should not be used in production, as it will not have a passphrase."`
-	InstanceTypes               []string          `flag:"instance-types" desc:"Node instance types"`
-	IPFamily                    string            `flag:"ip-family" desc:"IP family for the cluster (ipv4 or ipv6)"`
-	KubeconfigPath              string            `flag:"kubeconfig" desc:"Path to kubeconfig"`
-	KubernetesVersion           string            `flag:"kubernetes-version" desc:"cluster Kubernetes version"`
-	NodeReadyTimeout            time.Duration     `flag:"node-ready-timeout" desc:"Time to wait for all nodes to become ready"`
-	Nodes                       int               `flag:"nodes" desc:"number of nodes to launch in cluster"`
-	NodeNameStrategy            string            `flag:"node-name-strategy" desc:"Specifies the naming strategy for node. Allowed values: ['SessionName', 'EC2PrivateDNSName'], default to EC2PrivateDNSName"`
-	Region                      string            `flag:"region" desc:"AWS region for EKS cluster"`
-	TuneVPCCNI                  bool              `flag:"tune-vpc-cni" desc:"Apply tuning parameters to the VPC CNI DaemonSet"`
-	UnmanagedNodes              bool              `flag:"unmanaged-nodes" desc:"Use an AutoScalingGroup instead of an EKS-managed nodegroup. Requires --ami"`
-	UpClusterHeaders            []string          `flag:"up-cluster-header" desc:"Additional header to add to eks:CreateCluster requests. Specified in the same format as curl's -H flag."`
-	UserDataFormat              string            `flag:"user-data-format" desc:"Format of the node instance user data"`
+	Addons                      []string      `flag:"addons" desc:"Managed addons (name:version pairs) to create in the cluster. Use 'latest' for the most recent version, or 'default' for the default version."`
+	AMI                         string        `flag:"ami" desc:"AMI for unmanaged nodes"`
+	AMIType                     string        `flag:"ami-type" desc:"AMI type for managed nodes"`
+	ClusterRoleServicePrincipal string        `flag:"cluster-role-service-principal" desc:"Additional service principal that can assume the cluster role"`
+	EFA                         bool          `flag:"efa" desc:"Create EFA interfaces on the node of an unmanaged nodegroup. Requires --unmanaged-nodes."`
+	EKSEndpointURL              string        `flag:"endpoint-url" desc:"Endpoint URL for the EKS API"`
+	EmitMetrics                 bool          `flag:"emit-metrics" desc:"Record and emit metrics to CloudWatch"`
+	ExpectedAMI                 string        `flag:"expected-ami" desc:"Expected AMI of nodes. Up will fail if the actual nodes are not utilizing the expected AMI. Defaults to --ami if defined."`
+	GenerateSSHKey              bool          `flag:"generate-ssh-key" desc:"Generate an SSH key to use for tests. The generated key should not be used in production, as it will not have a passphrase."`
+	InstanceTypes               []string      `flag:"instance-types" desc:"Node instance types"`
+	IPFamily                    string        `flag:"ip-family" desc:"IP family for the cluster (ipv4 or ipv6)"`
+	KubeconfigPath              string        `flag:"kubeconfig" desc:"Path to kubeconfig"`
+	KubernetesVersion           string        `flag:"kubernetes-version" desc:"cluster Kubernetes version"`
+	NodeReadyTimeout            time.Duration `flag:"node-ready-timeout" desc:"Time to wait for all nodes to become ready"`
+	Nodes                       int           `flag:"nodes" desc:"number of nodes to launch in cluster"`
+	NodeNameStrategy            string        `flag:"node-name-strategy" desc:"Specifies the naming strategy for node. Allowed values: ['SessionName', 'EC2PrivateDNSName'], default to EC2PrivateDNSName"`
+	Region                      string        `flag:"region" desc:"AWS region for EKS cluster"`
+	TuneVPCCNI                  bool          `flag:"tune-vpc-cni" desc:"Apply tuning parameters to the VPC CNI DaemonSet"`
+	UnmanagedNodes              bool          `flag:"unmanaged-nodes" desc:"Use an AutoScalingGroup instead of an EKS-managed nodegroup. Requires --ami"`
+	UpClusterHeaders            []string      `flag:"up-cluster-header" desc:"Additional header to add to eks:CreateCluster requests. Specified in the same format as curl's -H flag."`
+	UserDataFormat              string        `flag:"user-data-format" desc:"Format of the node instance user data"`
 }
 
 // NewDeployer implements deployer.New for EKS using the EKS (and other AWS) API(s) directly (no cloudformation)

--- a/kubetest2/internal/deployers/eksapi/nodegroup.go
+++ b/kubetest2/internal/deployers/eksapi/nodegroup.go
@@ -66,7 +66,7 @@ func (m *NodegroupManager) createManagedNodegroup(infra *Infrastructure, cluster
 		},
 	}
 	if opts.AMIType != "" {
-		input.AmiType = opts.AMIType
+		input.AmiType = ekstypes.AMITypes(opts.AMIType)
 	}
 	if len(opts.InstanceTypes) > 0 {
 		input.InstanceTypes = opts.InstanceTypes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

missed a test to validate this flag, and looks like it can only parse under the `string` primitive and not the `ekstypes.AMITypes` wrapper type

Before:
```bash
$ kubetest2 eksapi --ami-type=FOO
Error: unknown flag: --ami-type

Usage:
  kubetest2 eksapi [Flags] [DeployerFlags] -- [TesterArgs]

Flags:
      --artifacts string         top-level directory to put artifacts under for each kubetest2 run, defaulting to "${ARTIFACTS:-./_artifacts}". If using the ginkgo tester, this must be an absolute path. (default "/home/nbakerd/workspace/aws-k8s-tester/kubetest2/_artifacts")
      --build                    build kubernetes
      --down                     tear down the test cluster
  -h, --help                     display help
      --run-id string            unique identifier for a kubetest2 run (default "60358132-dc7f-467f-8d03-69da7996ed21")
      --rundir string            directory to put run related test binaries like e2e.test, ginkgo, kubectl for each kubetest2 run, defaulting to "${KUBETEST2_RUN_DIR:-./_rundir}". If using the ginkgo tester, this must be an absolute path.
      --rundir-in-artifacts      if true, the test binaries and run specific metadata will be in the ARTIFACTS
      --skip-test-junit-report   skip reporting the test step as a JUnit test case, should be set to true when solely relying on the tester binary to generate it's own junit.
      --test string              test type to run, if unset no tests will run
      --up                       provision the test cluster

DeployerFlags(eksapi):
      --add_dir_header                          If true, adds the file directory to the header
      --addons strings                          Managed addons (name:version pairs) to create in the cluster. Use 'latest' for the most recent version, or 'default' for the default version. (default [])
      --alsologtostderr                         log to standard error as well as files
      --ami string                              AMI for unmanaged nodes
      --cluster-role-service-principal string   Additional service principal that can assume the cluster role
      --efa                                     Create EFA interfaces on the node of an unmanaged nodegroup. Requires --unmanaged-nodes.
      --emit-metrics                            Record and emit metrics to CloudWatch
      --endpoint-url string                     Endpoint URL for the EKS API
      --expected-ami string                     Expected AMI of nodes. Up will fail if the actual nodes are not utilizing the expected AMI. Defaults to --ami if defined.
      --generate-ssh-key                        Generate an SSH key to use for tests. The generated key should not be used in production, as it will not have a passphrase.
      --instance-types strings                  Node instance types (default [])
      --ip-family string                        IP family for the cluster (ipv4 or ipv6)
      --kubeconfig string                       Path to kubeconfig
      --kubernetes-version string               cluster Kubernetes version
      --log_backtrace_at traceLocation          when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                          If non-empty, write log files in this directory
      --log_file string                         If non-empty, use this log file
      --log_file_max_size uint                  Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                             log to standard error instead of files (default true)
      --node-name-strategy string               Specifies the naming strategy for node. Allowed values: ['SessionName', 'EC2PrivateDNSName'], default to EC2PrivateDNSName
      --node-ready-timeout duration             Time to wait for all nodes to become ready (default 0s)
      --nodes int                               number of nodes to launch in cluster
      --region string                           AWS region for EKS cluster
      --skip_headers                            If true, avoid header prefixes in the log messages
      --skip_log_headers                        If true, avoid headers when opening log files
      --stderrthreshold severity                logs at or above this threshold go to stderr (default 2)
      --tune-vpc-cni                            Apply tuning parameters to the VPC CNI DaemonSet
      --unmanaged-nodes                         Use an AutoScalingGroup instead of an EKS-managed nodegroup. Requires --ami
      --up-cluster-header strings               Additional header to add to eks:CreateCluster requests. Specified in the same format as curl's -H flag. (default [])
      --user-data-format string                 Format of the node instance user data
  -v, --v Level                                 number for the log level verbosity
      --vmodule moduleSpec                      comma-separated list of pattern=N settings for file-filtered logging

```

After:
```bash
$ kubetest2 eksapi --ami-type=FOO
I0412 01:48:48.357699 1412239 app.go:61] The files in RunDir shall not be part of Artifacts
I0412 01:48:48.357738 1412239 app.go:62] pass rundir-in-artifacts flag True for RunDir to be part of Artifacts
I0412 01:48:48.357752 1412239 app.go:64] RunDir for this run: "/home/nbakerd/workspace/aws-k8s-tester/kubetest2/_rundir/a4371ae8-02d9-4947-8c33-ebb4170e5684"
I0412 01:48:48.360867 1412239 app.go:136] ID for this run: "a4371ae8-02d9-4947-8c33-ebb4170e5684"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
