### PR TITLE
Add bottlerocket user data format

### DIFF
--- a/kubetest2/internal/deployers/eksapi/nodegroup.go
+++ b/kubetest2/internal/deployers/eksapi/nodegroup.go
@@ -106,7 +106,7 @@ func (m *NodegroupManager) createManagedNodegroup(infra *Infrastructure, cluster
 func (m *NodegroupManager) createUnmanagedNodegroup(infra *Infrastructure, cluster *Cluster, opts *deployerOptions) error {
 	stackName := m.getUnmanagedNodegroupStackName()
 	klog.Infof("creating unmanaged nodegroup stack...")
-	userData, err := generateUserData(opts.UserDataFormat, cluster)
+	userData, userDataIsMimePart, err := generateUserData(opts.UserDataFormat, cluster)
 	if err != nil {
 		return err
 	}
@@ -144,6 +144,10 @@ func (m *NodegroupManager) createUnmanagedNodegroup(infra *Infrastructure, clust
 			{
 				ParameterKey:   aws.String("UserData"),
 				ParameterValue: aws.String(userData),
+			},
+			{
+				ParameterKey:   aws.String("UserDataIsMIMEPart"),
+				ParameterValue: aws.String(strconv.FormatBool(userDataIsMimePart)),
 			},
 			{
 				ParameterKey:   aws.String("ClusterName"),
@@ -203,7 +207,7 @@ func (m *NodegroupManager) createUnmanagedNodegroup(infra *Infrastructure, clust
 func (m *NodegroupManager) createUnmanagedNodegroupWithEFA(infra *Infrastructure, cluster *Cluster, opts *deployerOptions) error {
 	stackName := m.getUnmanagedNodegroupStackName()
 	klog.Infof("creating unmanaged nodegroup with EFA stack...")
-	userData, err := generateUserData(opts.UserDataFormat, cluster)
+	userData, _, err := generateUserData(opts.UserDataFormat, cluster)
 	if err != nil {
 		return err
 	}

--- a/kubetest2/internal/deployers/eksapi/templates/templates.go
+++ b/kubetest2/internal/deployers/eksapi/templates/templates.go
@@ -30,6 +30,10 @@ var (
 	//go:embed userdata_nodeadm.yaml.mimepart.template
 	userDataNodeadmTemplate string
 	UserDataNodeadm         = template.Must(template.New("userDataNodeadm").Parse(userDataNodeadmTemplate))
+
+	//go:embed userdata_bottlerocket.toml.template
+	userDataBottlerocketTemplate string
+	UserDataBottlerocket         = template.Must(template.New("userDataBottlerocket").Parse(userDataBottlerocketTemplate))
 )
 
 type UserDataTemplateData struct {

--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup.yaml.template
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup.yaml.template
@@ -45,6 +45,16 @@ Parameters:
   UserData:
     Type: String
 
+  UserDataIsMIMEPart:
+    Description: "User data should be embedded as a part of a multi-part MIME document"
+    Default: true
+    Type: String
+    AllowedValues: [true, false]
+
+Conditions:
+  IsUserDataMIMEPart:
+    !Equals [true, !Ref UserDataIsMIMEPart]
+
 Resources:
   NodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -97,24 +107,28 @@ Resources:
         KeyName: !Ref SSHKeyPair
         UserData:
           Fn::Base64:
-            Fn::Sub: |
-              Content-Type: multipart/mixed; boundary="BOUNDARY"
-              MIME-Version: 1.0
+            Fn::If:
+              - IsUserDataMIMEPart
+              - Fn::Sub: |
+                  Content-Type: multipart/mixed; boundary="BOUNDARY"
+                  MIME-Version: 1.0
 
-              --BOUNDARY
-              ${UserData}
+                  --BOUNDARY
+                  ${UserData}
 
-              --BOUNDARY
-              Content-Type: text/x-shellscript; charset="us-ascii"
-              MIME-Version: 1.0
+                  --BOUNDARY
+                  Content-Type: text/x-shellscript; charset="us-ascii"
+                  MIME-Version: 1.0
 
-              #!/usr/bin/env bash
-              /opt/aws/bin/cfn-signal \
-                --stack  ${AWS::StackName} \
-                --resource NodeGroup \
-                --region ${AWS::Region}
+                  #!/usr/bin/env bash
+                  /opt/aws/bin/cfn-signal \
+                    --stack  ${AWS::StackName} \
+                    --resource NodeGroup \
+                    --region ${AWS::Region}
 
-              --BOUNDARY--
+                  --BOUNDARY--
+              - Fn::Sub: |
+                  ${UserData}
         IamInstanceProfile:
           Arn: !GetAtt NodeInstanceProfile.Arn
         ImageId: !Ref AMIId

--- a/kubetest2/internal/deployers/eksapi/templates/userdata_bottlerocket.toml.template
+++ b/kubetest2/internal/deployers/eksapi/templates/userdata_bottlerocket.toml.template
@@ -1,0 +1,7 @@
+[settings.kubernetes]
+"cluster-name" = "{{.Name}}"
+"api-server" = "{{.APIServerEndpoint}}"
+"cluster-certificate" = "{{.CertificateAuthority}}"
+
+[settings.host-containers.admin]
+"enabled" = true

--- a/kubetest2/internal/deployers/eksapi/userdata_test.go
+++ b/kubetest2/internal/deployers/eksapi/userdata_test.go
@@ -38,26 +38,30 @@ spec:
 
 func Test_generateUserData(t *testing.T) {
 	cases := []struct {
-		format   string
-		expected string
+		format             string
+		expected           string
+		expectedIsMimePart bool
 	}{
 		{
-			format:   "bootstrap.sh",
-			expected: bootstrapShUserData,
+			format:             "bootstrap.sh",
+			expected:           bootstrapShUserData,
+			expectedIsMimePart: true,
 		},
 		{
-			format:   "nodeadm",
-			expected: nodeadmUserData,
+			format:             "nodeadm",
+			expected:           nodeadmUserData,
+			expectedIsMimePart: true,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.format, func(t *testing.T) {
-			actual, err := generateUserData(c.format, &cluster)
+			actual, isMimePart, err := generateUserData(c.format, &cluster)
 			if err != nil {
 				t.Log(err)
 				t.Error(err)
 			}
 			assert.Equal(t, c.expected, actual)
+			assert.Equal(t, c.expectedIsMimePart, isMimePart)
 		})
 	}
 }


### PR DESCRIPTION
*Description of changes:*

Adds a new `--user-data-format` option, `bottlerocket`, which writes a TOML document (not in a MIME multi-part) containing Bottlerocket settings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
