### PR TITLE
Update aws-efa-nccl-tests docker file to the latest cuda and nccl version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,3 +16,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: docker build --build-arg=KUBERNETES_MINOR_VERSION=latest --file Dockerfile.kubetest2 .
+  build-nccl:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: docker build --file e2e2/test/images/Dockerfile.aws-efa-nccl-tests .

--- a/e2e2/test/images/Dockerfile.aws-efa-nccl-tests
+++ b/e2e2/test/images/Dockerfile.aws-efa-nccl-tests
@@ -1,8 +1,9 @@
-FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
+# Start with the NVIDIA CUDA base image
+FROM nvidia/cuda:12.5.0-devel-ubuntu22.04
 
 ARG EFA_INSTALLER_VERSION=latest
 # 1.7.4+ is required, to enforce proper EFA function with OFI_NCCL_DISABLE_GDR_REQUIRED_CHECK=0
-ARG AWS_OFI_NCCL_VERSION=1.7.4
+ARG AWS_OFI_NCCL_VERSION=1.9.1
 ARG NCCL_TESTS_VERSION=master
 
 # Install necessary dependencies


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update aws-efa-nccl-tests docker file to the latest cuda and nccl version. Tested with EKS cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
