### PR TITLE
Integrate multi-node nccl testing into the tester package

### DIFF
--- a/e2e2/internal/framework_extensions/client.go
+++ b/e2e2/internal/framework_extensions/client.go
@@ -3,6 +3,7 @@ package frameworkext
 import (
 	"bytes"
 	"context"
+	"html/template"
 	"io"
 	"os"
 
@@ -100,6 +101,17 @@ func deleteManifests(restConfig *rest.Config, manifests ...io.Reader) error {
 		}
 	}
 	return nil
+}
+
+// RenderManifests renders manifests with the supplied data
+func RenderManifests(file []byte, templateData interface{}) ([]byte, error) {
+	tpl, err := template.New("Manifest").Parse(string(file))
+	if err != nil {
+		return nil, err
+	}
+	buf := bytes.Buffer{}
+	err = tpl.Execute(&buf, templateData)
+	return buf.Bytes(), err
 }
 
 func bytesSlicesToReaders(byteSlices ...[]byte) []io.Reader {

--- a/e2e2/test/cases/nvidia/main_test.go
+++ b/e2e2/test/cases/nvidia/main_test.go
@@ -22,13 +22,13 @@ import (
 )
 
 var (
-	testenv    env.Environment
-	nodeType   *string
-	efaEnabled *bool
-	efaImage   *string
-	nodeCount  int
-	gpuCount   int
-	efaCount   int
+	testenv       env.Environment
+	nodeType      *string
+	efaEnabled    *bool
+	ncclTestImage *string
+	nodeCount     int
+	gpuPerNode    int
+	efaPerNode    int
 )
 
 var (
@@ -42,7 +42,7 @@ var (
 
 func TestMain(m *testing.M) {
 	nodeType = flag.String("nodeType", "", "node type for the tests")
-	efaImage = flag.String("efaImage", "", "efa image for nccl tests")
+	ncclTestImage = flag.String("ncclTestImage", "", "nccl test image for nccl tests")
 	efaEnabled = flag.Bool("efaEnabled", false, "enable efa tests")
 	cfg, err := envconf.NewFromFlags()
 	if err != nil {
@@ -114,18 +114,18 @@ func TestMain(m *testing.M) {
 					if v.Labels["node.kubernetes.io/instance-type"] == *nodeType {
 						nodeCount++
 						gpu := v.Status.Capacity["nvidia.com/gpu"]
-						gpuCount = int(gpu.Value())
+						gpuPerNode = int(gpu.Value())
 						efa := v.Status.Capacity["vpc.amazonaws.com/efa"]
-						efaCount = int(efa.Value())
+						efaPerNode = int(efa.Value())
 					}
 				}
 			} else {
 				log.Printf("No node type specified. Using the node type %s in the node groups.", nodes.Items[0].Labels["node.kubernetes.io/instance-type"])
 				nodeCount = len(nodes.Items)
 				gpu := nodes.Items[0].Status.Capacity["nvidia.com/gpu"]
-				gpuCount = int(gpu.Value())
+				gpuPerNode = int(gpu.Value())
 				efa := nodes.Items[0].Status.Capacity["vpc.amazonaws.com/efa"]
-				efaCount = int(efa.Value())
+				efaPerNode = int(efa.Value())
 			}
 			return ctx, nil
 		},

--- a/e2e2/test/cases/nvidia/main_test.go
+++ b/e2e2/test/cases/nvidia/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"slices"
@@ -108,6 +109,16 @@ func TestMain(m *testing.M) {
 				if err != nil {
 					return ctx, err
 				}
+			}
+
+			singleNodeType := true
+			for i := 1; i < len(nodes.Items)-1; i++ {
+				if nodes.Items[i].Labels["node.kubernetes.io/instance-type"] != nodes.Items[i-1].Labels["node.kubernetes.io/instance-type"] {
+					singleNodeType = false
+				}
+			}
+			if !singleNodeType {
+				return ctx, fmt.Errorf("Node types are not the same, all node types must be the same in the cluster")
 			}
 			if *nodeType != "" {
 				for _, v := range nodes.Items {

--- a/e2e2/test/cases/nvidia/manifests/mpi-job-nccl-test-multi-node.yaml
+++ b/e2e2/test/cases/nvidia/manifests/mpi-job-nccl-test-multi-node.yaml
@@ -13,17 +13,17 @@ spec:
     Launcher:
       replicas: 1
       template:
-         spec:
+        spec:
           restartPolicy: OnFailure
           containers:
           - image: {{.NcclTestImage}}
             imagePullPolicy: Always
             name: nccl-test-launcher
             env:
-             - name: XLA_FLAGS
-               value: "--xla_gpu_cuda_data_dir=/usr/local/cuda"
-             - name: TF_XLA_FLAGS
-               value: "--tf_xla_cpu_global_jit"
+            - name: XLA_FLAGS
+              value: "--xla_gpu_cuda_data_dir=/usr/local/cuda"
+            - name: TF_XLA_FLAGS
+              value: "--tf_xla_cpu_global_jit"
             command:
             - /opt/amazon/openmpi/bin/mpirun
             - --allow-run-as-root

--- a/e2e2/test/cases/nvidia/manifests/mpi-job-nccl-test-multi-node.yaml
+++ b/e2e2/test/cases/nvidia/manifests/mpi-job-nccl-test-multi-node.yaml
@@ -3,7 +3,7 @@ kind: MPIJob
 metadata:
   name: multi-node-nccl-test
 spec:
-  slotsPerWorker: {{.GpuCount}}
+  slotsPerWorker: {{.GpuPerNode}}
   runPolicy:
     # it may take a bit for the workers to get ready (the container image is heavy)
     # and we don't want the launcher to reach it's CrashLoopBackoff limit in the meantime
@@ -16,7 +16,7 @@ spec:
          spec:
           restartPolicy: OnFailure
           containers:
-          - image: {{.EfaImage}}
+          - image: {{.NcclTestImage}}
             imagePullPolicy: Always
             name: nccl-test-launcher
             env:
@@ -29,7 +29,7 @@ spec:
             - --allow-run-as-root
             - --tag-output
             - -np
-            - "{{.GpuCount}}"
+            - "{{.WorkerNodeGpuCount}}"
             - -bind-to
             - none
             - -map-by
@@ -82,7 +82,7 @@ spec:
             emptyDir:
               medium: Memory
           containers:
-          - image: {{.EfaImage}}
+          - image: {{.NcclTestImage}}
             imagePullPolicy: Always
             name: nccl-test-worker
             volumeMounts:
@@ -90,12 +90,12 @@ spec:
               name: dshm
             resources:
               requests:
-                nvidia.com/gpu: {{.GpuCount}}
+                nvidia.com/gpu: {{.GpuPerNode}}
                 hugepages-2Mi: 5120Mi
-                vpc.amazonaws.com/efa: {{.EfaInterfaceCount}}
+                vpc.amazonaws.com/efa: {{.EfaInterfacePerNode}}
                 memory: 8000Mi
               limits:
-                nvidia.com/gpu: {{.GpuCount}}
+                nvidia.com/gpu: {{.GpuPerNode}}
                 hugepages-2Mi: 5120Mi
-                vpc.amazonaws.com/efa: {{.EfaInterfaceCount}}
+                vpc.amazonaws.com/efa: {{.EfaInterfacePerNode}}
                 memory: 8000Mi

--- a/e2e2/test/cases/nvidia/manifests/mpi-job-nccl-test-multi-node.yaml
+++ b/e2e2/test/cases/nvidia/manifests/mpi-job-nccl-test-multi-node.yaml
@@ -1,9 +1,9 @@
 apiVersion: kubeflow.org/v2beta1
 kind: MPIJob
 metadata:
-  name: pytorch-training-multi-node
+  name: multi-node-nccl-test
 spec:
-  slotsPerWorker: 8
+  slotsPerWorker: {{.GpuCount}}
   runPolicy:
     # it may take a bit for the workers to get ready (the container image is heavy)
     # and we don't want the launcher to reach it's CrashLoopBackoff limit in the meantime
@@ -16,7 +16,7 @@ spec:
          spec:
           restartPolicy: OnFailure
           containers:
-          - image: TODO
+          - image: {{.EfaImage}}
             imagePullPolicy: Always
             name: nccl-test-launcher
             env:
@@ -29,7 +29,7 @@ spec:
             - --allow-run-as-root
             - --tag-output
             - -np
-            - "16"
+            - "{{.GpuCount}}"
             - -bind-to
             - none
             - -map-by
@@ -53,7 +53,7 @@ spec:
             - -x
             - FI_LOG_LEVEL=warn
             - -x
-            - FI_EFA_USE_DEVICE_RDMA=1
+            - FI_EFA_USE_DEVICE_RDMA={{.EfaUseDeviceRdma}}
             - -x
             - OFI_NCCL_DISABLE_GDR_REQUIRED_CHECK=0
             - -x
@@ -69,16 +69,12 @@ spec:
             - 2G
             - -f
             - "2"
-            - -t
-            - "1"
-            - -g
-            - "1"
             - -c
             - "1"
             - -n
             - "100"
     Worker:
-      replicas: 2
+      replicas: {{.WorkerNodeCount}}
       template:
         spec:
           volumes:
@@ -86,20 +82,20 @@ spec:
             emptyDir:
               medium: Memory
           containers:
-          - image: TODO
+          - image: {{.EfaImage}}
             imagePullPolicy: Always
-            name: nccl-worker
+            name: nccl-test-worker
             volumeMounts:
             - mountPath: /dev/shm
               name: dshm
             resources:
-              limits:
-                nvidia.com/gpu: 8
-                hugepages-2Mi: 5120Mi
-                vpc.amazonaws.com/efa: 4
-                memory: 8000Mi
               requests:
-                nvidia.com/gpu: 8
+                nvidia.com/gpu: {{.GpuCount}}
                 hugepages-2Mi: 5120Mi
-                vpc.amazonaws.com/efa: 4
+                vpc.amazonaws.com/efa: {{.EfaInterfaceCount}}
+                memory: 8000Mi
+              limits:
+                nvidia.com/gpu: {{.GpuCount}}
+                hugepages-2Mi: 5120Mi
+                vpc.amazonaws.com/efa: {{.EfaInterfaceCount}}
                 memory: 8000Mi

--- a/e2e2/test/cases/nvidia/mpi_test.go
+++ b/e2e2/test/cases/nvidia/mpi_test.go
@@ -3,7 +3,7 @@ package nvidia
 import (
 	"context"
 	_ "embed"
-	"slices"
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -23,11 +22,18 @@ import (
 var (
 	//go:embed manifests/mpi-job-pytorch-training-single-node.yaml
 	mpiJobPytorchTrainingSingleNodeManifest []byte
-	//go:embed manifests/mpi-job-pytorch-training-multi-node.yaml
-	mpiJobPytorchTrainingMultiNodeManifest []byte
-	//go:embed manifests/efa-device-plugin.yaml
-	efaDevicePluginManifest []byte
+	//go:embed manifests/mpi-job-nccl-test-multi-node.yaml
+	mpiJobNcclTestMultiNodeManifest         []byte
+	renderedMpiJobNcclTestMultiNodeManifest []byte
 )
+
+type ncclTestManifestTplVars struct {
+	WorkerNodeCount   int
+	GpuCount          int
+	EfaImage          string
+	EfaInterfaceCount int
+	EfaUseDeviceRdma  int
+}
 
 func TestMPIJobPytorchTraining(t *testing.T) {
 	singleNode := features.New("single-node").
@@ -65,28 +71,31 @@ func TestMPIJobPytorchTraining(t *testing.T) {
 		}).
 		Feature()
 
-	manifestsMultiNode := [][]byte{
-		efaDevicePluginManifest,
-		mpiJobPytorchTrainingMultiNodeManifest,
-	}
-
 	multiNode := features.New("multi-node").
 		WithLabel("suite", "nvidia").
 		WithLabel("hardware", "gpu").
 		WithLabel("hardware", "efa").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			err := fwext.ApplyManifests(cfg.Client().RESTConfig(), manifestsMultiNode...)
+			if *efaImage == "" {
+				t.Fatal(fmt.Errorf("efaImage must be set to run nccl test, use https://github.com/aws/aws-k8s-tester/blob/main/e2e2/test/images/Dockerfile.aws-efa-nccl-tests to build the image and -efaImage to set the image url"))
+			}
+			// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl-base.html#nccl-start-base-test
+			var EfaUseDeviceRdma int
+			if *nodeType == "p4d.24xlarge" {
+				EfaUseDeviceRdma = 1
+			}
+			renderedMpiJobNcclTestMultiNodeManifest, err := fwext.RenderManifests(mpiJobNcclTestMultiNodeManifest, ncclTestManifestTplVars{
+				// one of the nodes will be used for the master pod
+				WorkerNodeCount:   nodeCount - 1,
+				GpuCount:          gpuCount,
+				EfaImage:          *efaImage,
+				EfaInterfaceCount: efaCount,
+				EfaUseDeviceRdma:  EfaUseDeviceRdma,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}
-			return ctx
-		}).
-		Assess("EFA device plugin daemonset ready", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			ds := appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "efa-device-plugin-daemonset", Namespace: "kube-system"},
-			}
-			err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).DaemonSetReady(&ds),
-				wait.WithTimeout(time.Minute*5))
+			err = fwext.ApplyManifests(cfg.Client().RESTConfig(), renderedMpiJobNcclTestMultiNodeManifest)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -98,7 +107,7 @@ func TestMPIJobPytorchTraining(t *testing.T) {
 				t.Fatal(err)
 			}
 			j := kubeflowv2beta1.MPIJob{
-				ObjectMeta: metav1.ObjectMeta{Name: "pytorch-training-multi-node", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "multi-node-nccl-test", Namespace: "default"},
 			}
 			timeout := time.Minute * 10
 			err := wait.For(conditions.New(rsrc).ResourceMatch(&j, mpiJobSucceeded),
@@ -109,8 +118,7 @@ func TestMPIJobPytorchTraining(t *testing.T) {
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			slices.Reverse(manifestsMultiNode)
-			err := fwext.DeleteManifests(cfg.Client().RESTConfig(), manifestsMultiNode...)
+			err := fwext.DeleteManifests(cfg.Client().RESTConfig(), renderedMpiJobNcclTestMultiNodeManifest)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR integrates multi-node NCCL testing into the tester package. The tester now accepts the following flags to configure the test:
- ncclTestImage: Specifies the base image to run the multi-node nccl test.
- efaEnabled: Determines whether to use the EFA in the cluster.
- nodeType: Specifies what type of nodes in the node groups will be used to run the multi-node NCCL test.

The tester can retrieve the hardware specifications from the nodes and render the nccl test manifest based on these specifications.

Testing
```
go test -v . -args -efaImage 665181186642.dkr.ecr.us-west-2.amazonaws.com/aws-k8s-tester/nccl-test:latest -skip-features single-node -efaEnabled=true
W0610 22:55:51.199584   28686 warnings.go:70] spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key: beta.kubernetes.io/instance-type is deprecated since v1.17; use "node.kubernetes.io/instance-type" instead
W0610 22:55:51.199630   28686 warnings.go:70] spec.template.metadata.annotations[scheduler.alpha.kubernetes.io/critical-pod]: non-functional in v1.16+; use the "priorityClassName" field instead
2024/06/10 22:55:56 No node type specified. Using the node type p3dn.24xlarge in the node groups.
=== RUN   TestMPIJobPytorchTraining
=== RUN   TestMPIJobPytorchTraining/single-node
    env.go:438: Skipping feature: "single-node": name matched
=== RUN   TestMPIJobPytorchTraining/multi-node
=== RUN   TestMPIJobPytorchTraining/multi-node/MPIJob_succeeds
--- PASS: TestMPIJobPytorchTraining (40.05s)
    --- SKIP: TestMPIJobPytorchTraining/single-node (0.00s)
    --- PASS: TestMPIJobPytorchTraining/multi-node (40.05s)
        --- PASS: TestMPIJobPytorchTraining/multi-node/MPIJob_succeeds (40.01s)
PASS
ok      github.com/aws/aws-k8s-tester/e2e2/test/cases/nvidia    57.324s
```
Testing pod logs
```
...
[1,0]<stdout>:#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
[1,0]<stdout>:#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
[1,0]<stdout>:           8             2     float     sum      -1    52.23    0.00    0.00      0    51.88    0.00    0.00      0
[1,0]<stdout>:          16             4     float     sum      -1    51.30    0.00    0.00      0    51.15    0.00    0.00      0
[1,0]<stdout>:          32             8     float     sum      -1    51.54    0.00    0.00      0    51.09    0.00    0.00      0
[1,0]<stdout>:          64            16     float     sum      -1    51.29    0.00    0.00      0    50.73    0.00    0.00      0
[1,0]<stdout>:         128            32     float     sum      -1    51.35    0.00    0.00      0    50.61    0.00    0.00      0
[1,0]<stdout>:         256            64     float     sum      -1    51.20    0.01    0.01      0    50.47    0.01    0.01      0
[1,0]<stdout>:         512           128     float     sum      -1    50.65    0.01    0.02      0    49.16    0.01    0.02      0
[1,0]<stdout>:        1024           256     float     sum      -1    52.06    0.02    0.03      0    51.37    0.02    0.03      0
[1,0]<stdout>:        2048           512     float     sum      -1    55.56    0.04    0.06      0    54.80    0.04    0.07      0
[1,0]<stdout>:        4096          1024     float     sum      -1    60.02    0.07    0.12      0    59.12    0.07    0.12      0
[1,0]<stdout>:        8192          2048     float     sum      -1    61.74    0.13    0.23      0    60.72    0.13    0.24      0
[1,0]<stdout>:       16384          4096     float     sum      -1    64.68    0.25    0.44      0    63.69    0.26    0.45      0
[1,0]<stdout>:       32768          8192     float     sum      -1    71.38    0.46    0.80      0    70.84    0.46    0.81      0
[1,0]<stdout>:       65536         16384     float     sum      -1    74.78    0.88    1.53      0    74.54    0.88    1.54      0
[1,0]<stdout>:      131072         32768     float     sum      -1    80.97    1.62    2.83      0    79.26    1.65    2.89      0
[1,0]<stdout>:      262144         65536     float     sum      -1    80.99    3.24    5.66      0    78.00    3.36    5.88      0
[1,0]<stdout>:      524288        131072     float     sum      -1    84.01    6.24   10.92      0    83.20    6.30   11.03      0
[1,0]<stdout>:     1048576        262144     float     sum      -1    92.30   11.36   19.88      0    91.67   11.44   20.02      0
[1,0]<stdout>:     2097152        524288     float     sum      -1    114.6   18.29   32.01      0    112.5   18.64   32.62      0
[1,0]<stdout>:     4194304       1048576     float     sum      -1    147.6   28.42   49.74      0    145.3   28.86   50.51      0
[1,0]<stdout>:     8388608       2097152     float     sum      -1    196.9   42.59   74.54      0    197.1   42.55   74.47      0
[1,0]<stdout>:    16777216       4194304     float     sum      -1    288.9   58.07  101.62      0    288.0   58.25  101.95      0
[1,0]<stdout>:    33554432       8388608     float     sum      -1    508.5   65.98  115.47      0    508.6   65.97  115.45      0
[1,0]<stdout>:    67108864      16777216     float     sum      -1    953.6   70.38  123.16      0    954.6   70.30  123.02      0
[1,0]<stdout>:   134217728      33554432     float     sum      -1   1857.3   72.26  126.46      0   1860.8   72.13  126.22      0
[1,0]<stdout>:   268435456      67108864     float     sum      -1   3666.6   73.21  128.12      0   3673.1   73.08  127.89      0
[1,0]<stdout>:   536870912     134217728     float     sum      -1   7286.3   73.68  128.94      0   7299.7   73.55  128.71      0
[1,0]<stdout>:  1073741824     268435456     float     sum      -1    14494   74.08  129.65      0    14515   73.98  129.46      0
[1,0]<stdout>:  2147483648     536870912     float     sum      -1    28866   74.40  130.19      0    28892   74.33  130.08      0
[1,0]<stdout>:multi-node-nccl-test-worker-0:21:21 [0] NCCL INFO comm 0x55f94529a0b0 rank 0 nranks 8 cudaDev 0 busId 160 - Destroy COMPLETE
[1,0]<stdout>:# Out of bounds values : 0 OK
[1,0]<stdout>:# Avg bus bandwidth    : 40.7925 
[1,0]<stdout>:#
[1,1]<stdout>:multi-node-nccl-test-worker-0:22:22 [1] NCCL INFO comm 0x56151cbd4340 rank 1 nranks 8 cudaDev 1 busId 170 - Destroy COMPLETE
[1,2]<stdout>:multi-node-nccl-test-worker-0:23:23 [2] NCCL INFO comm 0x5556c80d7a40 rank 2 nranks 8 cudaDev 2 busId 180 - Destroy COMPLETE
[1,3]<stdout>:multi-node-nccl-test-worker-0:24:24 [3] NCCL INFO comm 0x55ddec7c3630 rank 3 nranks 8 cudaDev 3 busId 190 - Destroy COMPLETE
[1,7]<stdout>:multi-node-nccl-test-worker-0:31:31 [7] NCCL INFO comm 0x55df10ef2500 rank 7 nranks 8 cudaDev 7 busId 1d0 - Destroy COMPLETE
[1,5]<stdout>:multi-node-nccl-test-worker-0:26:26 [5] NCCL INFO comm 0x561b7c28f430 rank 5 nranks 8 cudaDev 5 busId 1b0 - Destroy COMPLETE
[1,6]<stdout>:multi-node-nccl-test-worker-0:29:29 [6] NCCL INFO comm 0x5648feb716d0 rank 6 nranks 8 cudaDev 6 busId 1c0 - Destroy COMPLETE
[1,4]<stdout>:multi-node-nccl-test-worker-0:25:25 [4] NCCL INFO comm 0x5569eef06e40 rank 4 nranks 8 cudaDev 4 busId 1a0 - Destroy COMPLETE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
