### PR TITLE
Determine default instance types based on AMI architecture

### DIFF
--- a/kubetest2/internal/deployers/eksapi/deployer.go
+++ b/kubetest2/internal/deployers/eksapi/deployer.go
@@ -229,17 +229,6 @@ func (d *deployer) verifyUpFlags() error {
 		d.IPFamily = string(ekstypes.IpFamilyIpv4)
 		klog.V(2).Infof("Using default IP family: %s", d.IPFamily)
 	}
-	if len(d.InstanceTypes) == 0 && d.UnmanagedNodes {
-		d.InstanceTypes = []string{
-			"m6i.xlarge",
-			"m6i.large",
-			"m6a.large",
-			"m5.large",
-			"m5a.large",
-			"m4.large",
-		}
-		klog.V(2).Infof("Using default instance types: %v", d.InstanceTypes)
-	}
 	if d.UnmanagedNodes && d.AMI == "" {
 		return fmt.Errorf("--ami must be specified for --unmanaged-nodes")
 	}


### PR DESCRIPTION
*Description of changes:*

When `--instance-types` is not specified, we set a default list of x86_64 instance types. This adds an `ec2:DescribeImages` call to determine the AMI's architecture, so that arm64 AMI's don't always require an `--instance-types` override.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
