### PR TITLE
Add node metrics for time to register, ready

### DIFF
--- a/kubetest2/internal/deployers/eksapi/metrics.go
+++ b/kubetest2/internal/deployers/eksapi/metrics.go
@@ -1,0 +1,30 @@
+package eksapi
+
+import (
+	"path"
+
+	"github.com/aws/aws-k8s-tester/kubetest2/internal/metrics"
+	cloudwatchtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+var DeployerMetricNamespace = path.Join("kubetest2", DeployerName)
+
+var (
+	totalRuntimeSeconds = &metrics.MetricSpec{
+		Namespace: DeployerMetricNamespace,
+		Metric:    "TotalRuntimeSeconds",
+		Unit:      cloudwatchtypes.StandardUnitSeconds,
+	}
+
+	nodeTimeToRegistrationSeconds = &metrics.MetricSpec{
+		Namespace: DeployerMetricNamespace,
+		Metric:    "NodeTimeToRegistrationSeconds",
+		Unit:      cloudwatchtypes.StandardUnitSeconds,
+	}
+
+	nodeTimeToReadySeconds = &metrics.MetricSpec{
+		Namespace: DeployerMetricNamespace,
+		Metric:    "NodeTimeToReadySeconds",
+		Unit:      cloudwatchtypes.StandardUnitSeconds,
+	}
+)


### PR DESCRIPTION
*Description of changes:*

This adds 2 new metrics for `Node` objects:
1. The number of seconds from EC2 instance launch time and the creation of the `Node` object.
2. The number of seconds from EC2 instance launch time and the `Node`'s `Ready` condition becoming true.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
