### PR TITLE
Use instance type from EC2 API instead of Node label

### DIFF
--- a/kubetest2/internal/deployers/eksapi/k8s.go
+++ b/kubetest2/internal/deployers/eksapi/k8s.go
@@ -143,12 +143,13 @@ func emitNodeMetrics(metricRegistry metrics.MetricRegistry, k8sClient *kubernete
 			errs = append(errs, err)
 			continue
 		}
-		launchTime := *instanceInfo.Reservations[0].Instances[0].LaunchTime
+		instance := instanceInfo.Reservations[0].Instances[0]
+		launchTime := *instance.LaunchTime
 		timeToRegistration := node.ObjectMeta.CreationTimestamp.Time.Sub(launchTime)
 		timeToReady := getNodeReadyCondition(&node).LastTransitionTime.Time.Sub(launchTime)
 
 		nodeDimensions := map[string]string{
-			"instanceType": node.ObjectMeta.Labels[corev1.LabelInstanceTypeStable],
+			"instanceType": string(instance.InstanceType),
 			"os":           node.Status.NodeInfo.OperatingSystem,
 			"osImage":      node.Status.NodeInfo.OSImage,
 			"arch":         node.Status.NodeInfo.Architecture,


### PR DESCRIPTION
*Description of changes:*

Fixes an issue in which the instance type label may be missing at the time of metric recording.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
