### PR TITLE
replace `wait.WithTimeout(timeout)` with `wait.WithContext(ctx))`

### DIFF
--- a/e2e2/test/cases/neuron/main_test.go
+++ b/e2e2/test/cases/neuron/main_test.go
@@ -37,6 +37,9 @@ func TestMain(m *testing.M) {
 		log.Fatalf("failed to initialize test environment: %v", err)
 	}
 	testenv = env.NewWithConfig(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
+	defer cancel()
+	testenv = testenv.WithContext(ctx)
 
 	manifests := [][]byte{
 		neuronDevicePluginManifest,
@@ -56,7 +59,7 @@ func TestMain(m *testing.M) {
 				ObjectMeta: metav1.ObjectMeta{Name: "neuron-device-plugin-daemonset", Namespace: "kube-system"},
 			}
 			err := wait.For(fwext.NewConditionExtension(config.Client().Resources()).DaemonSetReady(&ds),
-				wait.WithTimeout(time.Minute*5))
+				wait.WithContext(ctx))
 			if err != nil {
 				return ctx, err
 			}

--- a/e2e2/test/cases/neuron/neuron_test.go
+++ b/e2e2/test/cases/neuron/neuron_test.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"fmt"
 	"testing"
-	"time"
 
 	fwext "github.com/aws/aws-k8s-tester/e2e2/internal/framework_extensions"
 	"sigs.k8s.io/e2e-framework/klient/wait"
@@ -52,7 +51,7 @@ func TestMPIJobPytorchTraining(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "neuronx-single-node", Namespace: "default"},
 			}
 			err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
-				wait.WithTimeout(time.Minute*20))
+				wait.WithContext(ctx))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/e2e2/test/cases/nvidia/main_test.go
+++ b/e2e2/test/cases/nvidia/main_test.go
@@ -50,6 +50,9 @@ func TestMain(m *testing.M) {
 		log.Fatalf("failed to initialize test environment: %v", err)
 	}
 	testenv = env.NewWithConfig(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
+	defer cancel()
+	testenv = testenv.WithContext(ctx)
 
 	// all NVIDIA tests require the device plugin and MPI operator
 	manifests := [][]byte{
@@ -70,7 +73,7 @@ func TestMain(m *testing.M) {
 				ObjectMeta: metav1.ObjectMeta{Name: "mpi-operator", Namespace: "mpi-operator"},
 			}
 			err := wait.For(conditions.New(config.Client().Resources()).DeploymentConditionMatch(&dep, appsv1.DeploymentAvailable, v1.ConditionTrue),
-				wait.WithTimeout(time.Minute*5))
+				wait.WithContext(ctx))
 			if err != nil {
 				return ctx, err
 			}
@@ -81,7 +84,7 @@ func TestMain(m *testing.M) {
 				ObjectMeta: metav1.ObjectMeta{Name: "nvidia-device-plugin-daemonset", Namespace: "kube-system"},
 			}
 			err := wait.For(fwext.NewConditionExtension(config.Client().Resources()).DaemonSetReady(&ds),
-				wait.WithTimeout(time.Minute*5))
+				wait.WithContext(ctx))
 			if err != nil {
 				return ctx, err
 			}
@@ -105,7 +108,7 @@ func TestMain(m *testing.M) {
 					ObjectMeta: metav1.ObjectMeta{Name: "efa-device-plugin-daemonset", Namespace: "kube-system"},
 				}
 				err = wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).DaemonSetReady(&ds),
-					wait.WithTimeout(time.Minute*5))
+					wait.WithContext(ctx))
 				if err != nil {
 					return ctx, err
 				}

--- a/e2e2/test/cases/nvidia/mpi_test.go
+++ b/e2e2/test/cases/nvidia/mpi_test.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"fmt"
 	"testing"
-	"time"
 
 	fwext "github.com/aws/aws-k8s-tester/e2e2/internal/framework_extensions"
 	kubeflowv2beta1 "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
@@ -55,9 +54,8 @@ func TestMPIJobPytorchTraining(t *testing.T) {
 			j := kubeflowv2beta1.MPIJob{
 				ObjectMeta: metav1.ObjectMeta{Name: "pytorch-training-single-node", Namespace: "default"},
 			}
-			timeout := time.Minute * 20
 			err := wait.For(fwext.NewConditionExtension(rsrc).ResourceMatch(&j, mpiJobSucceeded),
-				wait.WithTimeout(timeout))
+				wait.WithContext(ctx))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -111,9 +109,8 @@ func TestMPIJobPytorchTraining(t *testing.T) {
 			j := kubeflowv2beta1.MPIJob{
 				ObjectMeta: metav1.ObjectMeta{Name: "multi-node-nccl-test", Namespace: "default"},
 			}
-			timeout := time.Minute * 10
 			err := wait.For(conditions.New(rsrc).ResourceMatch(&j, mpiJobSucceeded),
-				wait.WithTimeout(timeout))
+				wait.WithContext(ctx))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/e2e2/test/cases/nvidia/unit_test.go
+++ b/e2e2/test/cases/nvidia/unit_test.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"fmt"
 	"testing"
-	"time"
 
 	fwext "github.com/aws/aws-k8s-tester/e2e2/internal/framework_extensions"
 	"sigs.k8s.io/e2e-framework/klient/wait"
@@ -52,7 +51,7 @@ func TestSingleNodeUnitTest(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "unit-test-job", Namespace: "default"},
 			}
 			err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
-				wait.WithTimeout(time.Minute*20))
+				wait.WithContext(ctx))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

replace `wait.WithTimeout(timeout)` with `wait.WithContext(ctx))`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
