### PR TITLE
Pull the logs when test finished and remove unnecessary resources requests and limits in the nccl test manifest

### DIFF
--- a/e2e2/internal/framework_extensions/client.go
+++ b/e2e2/internal/framework_extensions/client.go
@@ -3,11 +3,16 @@ package frameworkext
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"html/template"
 	"io"
 	"os"
 
+	kubeflowv2beta1 "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -94,7 +99,10 @@ func deleteManifests(restConfig *rest.Config, manifests ...io.Reader) error {
 			if namespace == "" {
 				namespace = "default"
 			}
-			_, err = client.Delete(namespace, name)
+			deletePolicy := metav1.DeletePropagationBackground
+			_, err = client.DeleteWithOptions(namespace, name, &metav1.DeleteOptions{
+				PropagationPolicy: &deletePolicy,
+			})
 			return err
 		}); err != nil {
 			return err
@@ -112,6 +120,43 @@ func RenderManifests(file []byte, templateData interface{}) ([]byte, error) {
 	buf := bytes.Buffer{}
 	err = tpl.Execute(&buf, templateData)
 	return buf.Bytes(), err
+}
+
+// GetJobLogs get logs from MPIJob
+func GetJobLogs(ctx context.Context, restConfig *rest.Config, job k8s.Object) (string, error) {
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return "", err
+	}
+	var jobLabel string
+	switch job.(type) {
+	case *kubeflowv2beta1.MPIJob:
+		jobLabel = fmt.Sprintf("job-name=%s-launcher", job.GetName())
+	case *batchv1.Job:
+		jobLabel = fmt.Sprintf("job-name=%s", job.GetName())
+	default:
+		return "", fmt.Errorf("unsupported job type %T", job)
+	}
+	pods, err := clientset.CoreV1().Pods(job.GetNamespace()).List(ctx, metav1.ListOptions{LabelSelector: jobLabel})
+	if err != nil {
+		return "", err
+	}
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("no pods found for job %s", job.GetName())
+	}
+	log := clientset.CoreV1().Pods(job.GetNamespace()).GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{})
+	podLogs, err := log.Stream(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer podLogs.Close()
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return "", err
+	}
+	str := buf.String()
+	return str, nil
 }
 
 func bytesSlicesToReaders(byteSlices ...[]byte) []io.Reader {

--- a/e2e2/test/cases/neuron/neuron_test.go
+++ b/e2e2/test/cases/neuron/neuron_test.go
@@ -58,7 +58,15 @@ func TestMPIJobPytorchTraining(t *testing.T) {
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			err := fwext.DeleteManifests(cfg.Client().RESTConfig(), renderedNeuronSingleNodeManifest)
+			log, err := fwext.GetJobLogs(ctx, cfg.Client().RESTConfig(), &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "neuronx-single-node", Namespace: "default"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Log("Test log for neuronx-single-node:")
+			t.Log(log)
+			err = fwext.DeleteManifests(cfg.Client().RESTConfig(), renderedNeuronSingleNodeManifest)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/e2e2/test/cases/nvidia/manifests/mpi-job-nccl-test-multi-node.yaml
+++ b/e2e2/test/cases/nvidia/manifests/mpi-job-nccl-test-multi-node.yaml
@@ -91,11 +91,7 @@ spec:
             resources:
               requests:
                 nvidia.com/gpu: {{.GpuPerNode}}
-                hugepages-2Mi: 5120Mi
                 vpc.amazonaws.com/efa: {{.EfaInterfacePerNode}}
-                memory: 8000Mi
               limits:
                 nvidia.com/gpu: {{.GpuPerNode}}
-                hugepages-2Mi: 5120Mi
                 vpc.amazonaws.com/efa: {{.EfaInterfacePerNode}}
-                memory: 8000Mi

--- a/e2e2/test/cases/nvidia/mpi_test.go
+++ b/e2e2/test/cases/nvidia/mpi_test.go
@@ -62,7 +62,15 @@ func TestMPIJobPytorchTraining(t *testing.T) {
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			err := fwext.DeleteManifests(cfg.Client().RESTConfig(), mpiJobPytorchTrainingSingleNodeManifest)
+			log, err := fwext.GetJobLogs(ctx, cfg.Client().RESTConfig(), &kubeflowv2beta1.MPIJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "pytorch-training-single-node", Namespace: "default"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Log("Test log for pytorch-training-single-node:")
+			t.Log(log)
+			err = fwext.DeleteManifests(cfg.Client().RESTConfig(), mpiJobPytorchTrainingSingleNodeManifest)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -117,7 +125,15 @@ func TestMPIJobPytorchTraining(t *testing.T) {
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			err := fwext.DeleteManifests(cfg.Client().RESTConfig(), renderedMpiJobNcclTestMultiNodeManifest)
+			log, err := fwext.GetJobLogs(ctx, cfg.Client().RESTConfig(), &kubeflowv2beta1.MPIJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "multi-node-nccl-test", Namespace: "default"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Log("Test log for multi-node-nccl-test:")
+			t.Log(log)
+			err = fwext.DeleteManifests(cfg.Client().RESTConfig(), renderedMpiJobNcclTestMultiNodeManifest)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/e2e2/test/cases/nvidia/unit_test.go
+++ b/e2e2/test/cases/nvidia/unit_test.go
@@ -58,7 +58,15 @@ func TestSingleNodeUnitTest(t *testing.T) {
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			err := fwext.DeleteManifests(cfg.Client().RESTConfig(), renderedJobUnitTestSingleNodeManifest)
+			log, err := fwext.GetJobLogs(ctx, cfg.Client().RESTConfig(), &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "unit-test-job", Namespace: "default"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Log("Test log for unit-test-job:")
+			t.Log(log)
+			err = fwext.DeleteManifests(cfg.Client().RESTConfig(), renderedJobUnitTestSingleNodeManifest)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_basic.sh
+++ b/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_basic.sh
@@ -37,5 +37,10 @@ test_04_bus_grind()
 test_05_dcgm_diagnostics()
 {
     # https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/dcgm-diagnostics.html#run-levels-and-tests
-    assert_status_code 0 "dcgmi diag -r 2"
+    if [[ $EC2_INSTANCE_TYPE == g* ]]; then
+        # The G series instance don't have nvlink and GPU p2p communication
+        assert_status_code 0 'dcgmi diag -r "software,memory,memory_bandwidth"'
+    else
+        assert_status_code 0 "dcgmi diag -r 2"
+    fi
 }

--- a/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_sysinfo.sh
+++ b/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_sysinfo.sh
@@ -43,7 +43,7 @@ test_nvidia_gpu_count()
 test_nvidia_smi_topo()
 {
     assert_data $data/nvidia_smi_topo.txt "nvidia-smi topo -m | grep GPU | cut -f 1-11" \
-		  "Unexpected gpu topology, likely broken nvlinks"
+		"Unexpected gpu topology, likely broken nvlinks"
 }
 
 
@@ -63,7 +63,7 @@ test_nvidia_gpu_throttled()
 
     # https://docs.nvidia.com/deploy/nvml-api/group__nvmlClocksEventReasons.html#group__nvmlClocksEventReasons
     # The only  bit allowed is nvmlClocksEventReasonGpuIdle 0x0000000000000001LL
-    filter="egrep -v -e '(0x0000000000000000|0x0000000000000001)'"
+    filter="egrep -v -e '(0x0000000000000000|0x0000000000000001|0x0000000000000004)'"
     cmd="nvidia-smi --query-gpu index,gpu_bus_id,gpu_uuid,clocks_throttle_reasons.active --format=csv,noheader"
-    assert_status_code 1 "$cmd | $filter" "Throttled gpu detected, possible reason https://tt.amazon.com/P115211285"
+    assert_status_code 1 "$cmd | $filter" "Throttled gpu detected"
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Pull the logs when test finished
- Remove unnecessary resources requests and limits in the nccl test manifest. And some instance type doesn't have `hugepages-2Mi`

Test:
```
go test -timeout 60m -v . -args -nvidiaTestImage public.ecr.aws/o5d5x8n6/weicongw:nvidia
2024/07/31 17:37:39 No node type specified. Using the node type p3.2xlarge in the node groups.
=== RUN   TestMPIJobPytorchTraining
=== RUN   TestMPIJobPytorchTraining/single-node
=== RUN   TestMPIJobPytorchTraining/single-node/MPIJob_succeeds
=== NAME  TestMPIJobPytorchTraining/single-node
    mpi_test.go:71: Test log for pytorch-training-single-node:
    mpi_test.go:72: Cloning into '/pytorch-examples'...
        Note: switching to '0f0c9131ca5c79d1332dce1f4c06fe942fbdc665'.
        
        You are in 'detached HEAD' state. You can look around, make experimental
        changes and commit them, and you can discard any commits you make in this
        state without impacting any branches by switching back to a branch.
        
        If you want to create a new branch to retain commits you create, you may
        do so (now or later) by using -c with the switch command. Example:
        
          git switch -c <new-branch-name>
        
        Or undo this operation with:
        
          git switch -
        
        Turn off this advice by setting config variable advice.detachedHead to false
        
        HEAD is now at 0f0c913 Use regular dropout rather than dropout2d
        Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz
        Failed to download (trying next):
        HTTP Error 403: Forbidden
        
        Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz
        Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz to ../data/MNIST/raw/train-images-idx3-ubyte.gz
100%|██████████| 9912422/9912422 [00:00<00:00, 129914354.06it/s]
        Extracting ../data/MNIST/raw/train-images-idx3-ubyte.gz to ../data/MNIST/raw
        
        Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz
        Failed to download (trying next):
        HTTP Error 403: Forbidden
        
        Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz
        Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz to ../data/MNIST/raw/train-labels-idx1-ubyte.gz
100%|██████████| 28881/28881 [00:00<00:00, 16958657.96it/s]
        Extracting ../data/MNIST/raw/train-labels-idx1-ubyte.gz to ../data/MNIST/raw
        
        Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz
        Failed to download (trying next):
        HTTP Error 403: Forbidden
        
        Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz
        Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz to ../data/MNIST/raw/t10k-images-idx3-ubyte.gz
100%|██████████| 1648877/1648877 [00:00<00:00, 140709896.17it/s]
        Extracting ../data/MNIST/raw/t10k-images-idx3-ubyte.gz to ../data/MNIST/raw
        
        Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
        Failed to download (trying next):
        HTTP Error 403: Forbidden
        
        Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz
        Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz to ../data/MNIST/raw/t10k-labels-idx1-ubyte.gz
100%|██████████| 4542/4542 [00:00<00:00, 4635165.15it/s]
        Extracting ../data/MNIST/raw/t10k-labels-idx1-ubyte.gz to ../data/MNIST/raw
        
        Train Epoch: 1 [0/60000 (0%)]   Loss: 2.305400
        Train Epoch: 1 [640/60000 (1%)] Loss: 1.359780
        Train Epoch: 1 [1280/60000 (2%)]        Loss: 0.830670
        Train Epoch: 1 [1920/60000 (3%)]        Loss: 0.605961
        Train Epoch: 1 [2560/60000 (4%)]        Loss: 0.345934
        Train Epoch: 1 [3200/60000 (5%)]        Loss: 0.446331
        Train Epoch: 1 [3840/60000 (6%)]        Loss: 0.306768
        Train Epoch: 1 [4480/60000 (7%)]        Loss: 0.279325
        Train Epoch: 1 [5120/60000 (9%)]        Loss: 0.555025
        Train Epoch: 1 [5760/60000 (10%)]       Loss: 0.208878
        Train Epoch: 1 [6400/60000 (11%)]       Loss: 0.279527
        Train Epoch: 1 [7040/60000 (12%)]       Loss: 0.327207
        Train Epoch: 1 [7680/60000 (13%)]       Loss: 0.204888
        Train Epoch: 1 [8320/60000 (14%)]       Loss: 0.220855
        Train Epoch: 1 [8960/60000 (15%)]       Loss: 0.273643
        Train Epoch: 1 [9600/60000 (16%)]       Loss: 0.097318
        Train Epoch: 1 [10240/60000 (17%)]      Loss: 0.248318
        Train Epoch: 1 [10880/60000 (18%)]      Loss: 0.112893
        Train Epoch: 1 [11520/60000 (19%)]      Loss: 0.439383
        Train Epoch: 1 [12160/60000 (20%)]      Loss: 0.244582
        Train Epoch: 1 [12800/60000 (21%)]      Loss: 0.245529
        Train Epoch: 1 [13440/60000 (22%)]      Loss: 0.221483
        Train Epoch: 1 [14080/60000 (23%)]      Loss: 0.157298
        Train Epoch: 1 [14720/60000 (25%)]      Loss: 0.418896
        Train Epoch: 1 [15360/60000 (26%)]      Loss: 0.168725
        Train Epoch: 1 [16000/60000 (27%)]      Loss: 0.110782
        Train Epoch: 1 [16640/60000 (28%)]      Loss: 0.185906
        Train Epoch: 1 [17280/60000 (29%)]      Loss: 0.054832
        Train Epoch: 1 [17920/60000 (30%)]      Loss: 0.167925
        Train Epoch: 1 [18560/60000 (31%)]      Loss: 0.195231
        Train Epoch: 1 [19200/60000 (32%)]      Loss: 0.282548
        Train Epoch: 1 [19840/60000 (33%)]      Loss: 0.076006
        Train Epoch: 1 [20480/60000 (34%)]      Loss: 0.042161
        Train Epoch: 1 [21120/60000 (35%)]      Loss: 0.217422
        Train Epoch: 1 [21760/60000 (36%)]      Loss: 0.004375
        Train Epoch: 1 [22400/60000 (37%)]      Loss: 0.066934
        Train Epoch: 1 [23040/60000 (38%)]      Loss: 0.208920
        Train Epoch: 1 [23680/60000 (39%)]      Loss: 0.229430
        Train Epoch: 1 [24320/60000 (41%)]      Loss: 0.014528
        Train Epoch: 1 [24960/60000 (42%)]      Loss: 0.130294
        Train Epoch: 1 [25600/60000 (43%)]      Loss: 0.071659
        Train Epoch: 1 [26240/60000 (44%)]      Loss: 0.098376
        Train Epoch: 1 [26880/60000 (45%)]      Loss: 0.383814
        Train Epoch: 1 [27520/60000 (46%)]      Loss: 0.263688
        Train Epoch: 1 [28160/60000 (47%)]      Loss: 0.123490
        Train Epoch: 1 [28800/60000 (48%)]      Loss: 0.099680
        Train Epoch: 1 [29440/60000 (49%)]      Loss: 0.037860
        Train Epoch: 1 [30080/60000 (50%)]      Loss: 0.149224
        Train Epoch: 1 [30720/60000 (51%)]      Loss: 0.042093
        Train Epoch: 1 [31360/60000 (52%)]      Loss: 0.105343
        Train Epoch: 1 [32000/60000 (53%)]      Loss: 0.232382
        Train Epoch: 1 [32640/60000 (54%)]      Loss: 0.135167
        Train Epoch: 1 [33280/60000 (55%)]      Loss: 0.067577
        Train Epoch: 1 [33920/60000 (57%)]      Loss: 0.021159
        Train Epoch: 1 [34560/60000 (58%)]      Loss: 0.023109
        Train Epoch: 1 [35200/60000 (59%)]      Loss: 0.225845
        Train Epoch: 1 [35840/60000 (60%)]      Loss: 0.185864
        Train Epoch: 1 [36480/60000 (61%)]      Loss: 0.061325
        Train Epoch: 1 [37120/60000 (62%)]      Loss: 0.071801
        Train Epoch: 1 [37760/60000 (63%)]      Loss: 0.162966
        Train Epoch: 1 [38400/60000 (64%)]      Loss: 0.135675
        Train Epoch: 1 [39040/60000 (65%)]      Loss: 0.072343
        Train Epoch: 1 [39680/60000 (66%)]      Loss: 0.026730
        Train Epoch: 1 [40320/60000 (67%)]      Loss: 0.076386
        Train Epoch: 1 [40960/60000 (68%)]      Loss: 0.120102
        Train Epoch: 1 [41600/60000 (69%)]      Loss: 0.126077
        Train Epoch: 1 [42240/60000 (70%)]      Loss: 0.101517
        Train Epoch: 1 [42880/60000 (71%)]      Loss: 0.091000
        Train Epoch: 1 [43520/60000 (72%)]      Loss: 0.209517
        Train Epoch: 1 [44160/60000 (74%)]      Loss: 0.058008
        Train Epoch: 1 [44800/60000 (75%)]      Loss: 0.128887
        Train Epoch: 1 [45440/60000 (76%)]      Loss: 0.179389
        Train Epoch: 1 [46080/60000 (77%)]      Loss: 0.121748
        Train Epoch: 1 [46720/60000 (78%)]      Loss: 0.151364
        Train Epoch: 1 [47360/60000 (79%)]      Loss: 0.129901
        Train Epoch: 1 [48000/60000 (80%)]      Loss: 0.058679
        Train Epoch: 1 [48640/60000 (81%)]      Loss: 0.019105
        Train Epoch: 1 [49280/60000 (82%)]      Loss: 0.041951
        Train Epoch: 1 [49920/60000 (83%)]      Loss: 0.080363
        Train Epoch: 1 [50560/60000 (84%)]      Loss: 0.075957
        Train Epoch: 1 [51200/60000 (85%)]      Loss: 0.307334
        Train Epoch: 1 [51840/60000 (86%)]      Loss: 0.015220
        Train Epoch: 1 [52480/60000 (87%)]      Loss: 0.024241
        Train Epoch: 1 [53120/60000 (88%)]      Loss: 0.126394
        Train Epoch: 1 [53760/60000 (90%)]      Loss: 0.077792
        Train Epoch: 1 [54400/60000 (91%)]      Loss: 0.090643
        Train Epoch: 1 [55040/60000 (92%)]      Loss: 0.022916
        Train Epoch: 1 [55680/60000 (93%)]      Loss: 0.121202
        Train Epoch: 1 [56320/60000 (94%)]      Loss: 0.089443
        Train Epoch: 1 [56960/60000 (95%)]      Loss: 0.079569
        Train Epoch: 1 [57600/60000 (96%)]      Loss: 0.139670
        Train Epoch: 1 [58240/60000 (97%)]      Loss: 0.021290
        Train Epoch: 1 [58880/60000 (98%)]      Loss: 0.027833
        Train Epoch: 1 [59520/60000 (99%)]      Loss: 0.001188
        
        Test set: Average loss: 0.0466, Accuracy: 9844/10000 (98%)
        
        Train Epoch: 2 [0/60000 (0%)]   Loss: 0.116403
        Train Epoch: 2 [640/60000 (1%)] Loss: 0.050264
        Train Epoch: 2 [1280/60000 (2%)]        Loss: 0.092467
        Train Epoch: 2 [1920/60000 (3%)]        Loss: 0.119749
        Train Epoch: 2 [2560/60000 (4%)]        Loss: 0.057013
        Train Epoch: 2 [3200/60000 (5%)]        Loss: 0.063743
        Train Epoch: 2 [3840/60000 (6%)]        Loss: 0.008541
        Train Epoch: 2 [4480/60000 (7%)]        Loss: 0.064263
        Train Epoch: 2 [5120/60000 (9%)]        Loss: 0.155038
        Train Epoch: 2 [5760/60000 (10%)]       Loss: 0.116473
        Train Epoch: 2 [6400/60000 (11%)]       Loss: 0.255886
        Train Epoch: 2 [7040/60000 (12%)]       Loss: 0.184631
        Train Epoch: 2 [7680/60000 (13%)]       Loss: 0.073841
        Train Epoch: 2 [8320/60000 (14%)]       Loss: 0.020532
        Train Epoch: 2 [8960/60000 (15%)]       Loss: 0.120054
        Train Epoch: 2 [9600/60000 (16%)]       Loss: 0.053557
        Train Epoch: 2 [10240/60000 (17%)]      Loss: 0.110744
        Train Epoch: 2 [10880/60000 (18%)]      Loss: 0.023491
        Train Epoch: 2 [11520/60000 (19%)]      Loss: 0.118071
        Train Epoch: 2 [12160/60000 (20%)]      Loss: 0.057553
        Train Epoch: 2 [12800/60000 (21%)]      Loss: 0.070433
        Train Epoch: 2 [13440/60000 (22%)]      Loss: 0.008699
        Train Epoch: 2 [14080/60000 (23%)]      Loss: 0.032483
        Train Epoch: 2 [14720/60000 (25%)]      Loss: 0.100742
        Train Epoch: 2 [15360/60000 (26%)]      Loss: 0.086969
        Train Epoch: 2 [16000/60000 (27%)]      Loss: 0.084643
        Train Epoch: 2 [16640/60000 (28%)]      Loss: 0.127885
        Train Epoch: 2 [17280/60000 (29%)]      Loss: 0.013055
        Train Epoch: 2 [17920/60000 (30%)]      Loss: 0.052431
        Train Epoch: 2 [18560/60000 (31%)]      Loss: 0.067011
        Train Epoch: 2 [19200/60000 (32%)]      Loss: 0.123953
        Train Epoch: 2 [19840/60000 (33%)]      Loss: 0.142147
        Train Epoch: 2 [20480/60000 (34%)]      Loss: 0.019123
        Train Epoch: 2 [21120/60000 (35%)]      Loss: 0.129621
        Train Epoch: 2 [21760/60000 (36%)]      Loss: 0.006479
        Train Epoch: 2 [22400/60000 (37%)]      Loss: 0.005736
        Train Epoch: 2 [23040/60000 (38%)]      Loss: 0.078761
        Train Epoch: 2 [23680/60000 (39%)]      Loss: 0.036433
        Train Epoch: 2 [24320/60000 (41%)]      Loss: 0.001922
        Train Epoch: 2 [24960/60000 (42%)]      Loss: 0.017966
        Train Epoch: 2 [25600/60000 (43%)]      Loss: 0.049428
        Train Epoch: 2 [26240/60000 (44%)]      Loss: 0.019111
        Train Epoch: 2 [26880/60000 (45%)]      Loss: 0.200730
        Train Epoch: 2 [27520/60000 (46%)]      Loss: 0.040320
        Train Epoch: 2 [28160/60000 (47%)]      Loss: 0.161458
        Train Epoch: 2 [28800/60000 (48%)]      Loss: 0.005862
        Train Epoch: 2 [29440/60000 (49%)]      Loss: 0.042807
        Train Epoch: 2 [30080/60000 (50%)]      Loss: 0.032942
        Train Epoch: 2 [30720/60000 (51%)]      Loss: 0.056029
        Train Epoch: 2 [31360/60000 (52%)]      Loss: 0.090914
        Train Epoch: 2 [32000/60000 (53%)]      Loss: 0.163993
        Train Epoch: 2 [32640/60000 (54%)]      Loss: 0.076990
        Train Epoch: 2 [33280/60000 (55%)]      Loss: 0.040407
        Train Epoch: 2 [33920/60000 (57%)]      Loss: 0.008500
        Train Epoch: 2 [34560/60000 (58%)]      Loss: 0.014407
        Train Epoch: 2 [35200/60000 (59%)]      Loss: 0.070210
        Train Epoch: 2 [35840/60000 (60%)]      Loss: 0.059865
        Train Epoch: 2 [36480/60000 (61%)]      Loss: 0.032789
        Train Epoch: 2 [37120/60000 (62%)]      Loss: 0.031061
        Train Epoch: 2 [37760/60000 (63%)]      Loss: 0.046759
        Train Epoch: 2 [38400/60000 (64%)]      Loss: 0.067897
        Train Epoch: 2 [39040/60000 (65%)]      Loss: 0.001008
        Train Epoch: 2 [39680/60000 (66%)]      Loss: 0.027828
        Train Epoch: 2 [40320/60000 (67%)]      Loss: 0.052259
        Train Epoch: 2 [40960/60000 (68%)]      Loss: 0.048987
        Train Epoch: 2 [41600/60000 (69%)]      Loss: 0.044013
        Train Epoch: 2 [42240/60000 (70%)]      Loss: 0.029858
        Train Epoch: 2 [42880/60000 (71%)]      Loss: 0.094191
        Train Epoch: 2 [43520/60000 (72%)]      Loss: 0.061771
        Train Epoch: 2 [44160/60000 (74%)]      Loss: 0.003768
        Train Epoch: 2 [44800/60000 (75%)]      Loss: 0.065121
        Train Epoch: 2 [45440/60000 (76%)]      Loss: 0.124149
        Train Epoch: 2 [46080/60000 (77%)]      Loss: 0.115549
        Train Epoch: 2 [46720/60000 (78%)]      Loss: 0.099370
        Train Epoch: 2 [47360/60000 (79%)]      Loss: 0.067407
        Train Epoch: 2 [48000/60000 (80%)]      Loss: 0.058504
        Train Epoch: 2 [48640/60000 (81%)]      Loss: 0.017735
        Train Epoch: 2 [49280/60000 (82%)]      Loss: 0.012113
        Train Epoch: 2 [49920/60000 (83%)]      Loss: 0.027846
        Train Epoch: 2 [50560/60000 (84%)]      Loss: 0.068561
        Train Epoch: 2 [51200/60000 (85%)]      Loss: 0.123127
        Train Epoch: 2 [51840/60000 (86%)]      Loss: 0.043849
        Train Epoch: 2 [52480/60000 (87%)]      Loss: 0.011382
        Train Epoch: 2 [53120/60000 (88%)]      Loss: 0.036509
        Train Epoch: 2 [53760/60000 (90%)]      Loss: 0.108129
        Train Epoch: 2 [54400/60000 (91%)]      Loss: 0.068972
        Train Epoch: 2 [55040/60000 (92%)]      Loss: 0.015052
        Train Epoch: 2 [55680/60000 (93%)]      Loss: 0.040589
        Train Epoch: 2 [56320/60000 (94%)]      Loss: 0.022106
        Train Epoch: 2 [56960/60000 (95%)]      Loss: 0.012523
        Train Epoch: 2 [57600/60000 (96%)]      Loss: 0.051880
        Train Epoch: 2 [58240/60000 (97%)]      Loss: 0.018960
        Train Epoch: 2 [58880/60000 (98%)]      Loss: 0.030982
        Train Epoch: 2 [59520/60000 (99%)]      Loss: 0.005444
        
        Test set: Average loss: 0.0361, Accuracy: 9876/10000 (99%)
        
        Train Epoch: 3 [0/60000 (0%)]   Loss: 0.041156
        Train Epoch: 3 [640/60000 (1%)] Loss: 0.036974
        Train Epoch: 3 [1280/60000 (2%)]        Loss: 0.025516
        Train Epoch: 3 [1920/60000 (3%)]        Loss: 0.113873
        Train Epoch: 3 [2560/60000 (4%)]        Loss: 0.054220
        Train Epoch: 3 [3200/60000 (5%)]        Loss: 0.080104
        Train Epoch: 3 [3840/60000 (6%)]        Loss: 0.033227
        Train Epoch: 3 [4480/60000 (7%)]        Loss: 0.028183
        Train Epoch: 3 [5120/60000 (9%)]        Loss: 0.041538
        Train Epoch: 3 [5760/60000 (10%)]       Loss: 0.027408
        Train Epoch: 3 [6400/60000 (11%)]       Loss: 0.068012
        Train Epoch: 3 [7040/60000 (12%)]       Loss: 0.211440
        Train Epoch: 3 [7680/60000 (13%)]       Loss: 0.016665
        Train Epoch: 3 [8320/60000 (14%)]       Loss: 0.035765
        Train Epoch: 3 [8960/60000 (15%)]       Loss: 0.031119
        Train Epoch: 3 [9600/60000 (16%)]       Loss: 0.105142
        Train Epoch: 3 [10240/60000 (17%)]      Loss: 0.204612
        Train Epoch: 3 [10880/60000 (18%)]      Loss: 0.013224
        Train Epoch: 3 [11520/60000 (19%)]      Loss: 0.078332
        Train Epoch: 3 [12160/60000 (20%)]      Loss: 0.023427
        Train Epoch: 3 [12800/60000 (21%)]      Loss: 0.049441
        Train Epoch: 3 [13440/60000 (22%)]      Loss: 0.037459
        Train Epoch: 3 [14080/60000 (23%)]      Loss: 0.023270
        Train Epoch: 3 [14720/60000 (25%)]      Loss: 0.093209
        Train Epoch: 3 [15360/60000 (26%)]      Loss: 0.016384
        Train Epoch: 3 [16000/60000 (27%)]      Loss: 0.043236
        Train Epoch: 3 [16640/60000 (28%)]      Loss: 0.146848
        Train Epoch: 3 [17280/60000 (29%)]      Loss: 0.000858
        Train Epoch: 3 [17920/60000 (30%)]      Loss: 0.020579
        Train Epoch: 3 [18560/60000 (31%)]      Loss: 0.013580
        Train Epoch: 3 [19200/60000 (32%)]      Loss: 0.092271
        Train Epoch: 3 [19840/60000 (33%)]      Loss: 0.059704
        Train Epoch: 3 [20480/60000 (34%)]      Loss: 0.004923
        Train Epoch: 3 [21120/60000 (35%)]      Loss: 0.102181
        Train Epoch: 3 [21760/60000 (36%)]      Loss: 0.013212
        Train Epoch: 3 [22400/60000 (37%)]      Loss: 0.005240
        Train Epoch: 3 [23040/60000 (38%)]      Loss: 0.047212
        Train Epoch: 3 [23680/60000 (39%)]      Loss: 0.022404
        Train Epoch: 3 [24320/60000 (41%)]      Loss: 0.000586
        Train Epoch: 3 [24960/60000 (42%)]      Loss: 0.010347
        Train Epoch: 3 [25600/60000 (43%)]      Loss: 0.077845
        Train Epoch: 3 [26240/60000 (44%)]      Loss: 0.055388
        Train Epoch: 3 [26880/60000 (45%)]      Loss: 0.047565
        Train Epoch: 3 [27520/60000 (46%)]      Loss: 0.108996
        Train Epoch: 3 [28160/60000 (47%)]      Loss: 0.081563
        Train Epoch: 3 [28800/60000 (48%)]      Loss: 0.022834
        Train Epoch: 3 [29440/60000 (49%)]      Loss: 0.012917
        Train Epoch: 3 [30080/60000 (50%)]      Loss: 0.028287
        Train Epoch: 3 [30720/60000 (51%)]      Loss: 0.066707
        Train Epoch: 3 [31360/60000 (52%)]      Loss: 0.050930
        Train Epoch: 3 [32000/60000 (53%)]      Loss: 0.051113
        Train Epoch: 3 [32640/60000 (54%)]      Loss: 0.002648
        Train Epoch: 3 [33280/60000 (55%)]      Loss: 0.032010
        Train Epoch: 3 [33920/60000 (57%)]      Loss: 0.001094
        Train Epoch: 3 [34560/60000 (58%)]      Loss: 0.009095
        Train Epoch: 3 [35200/60000 (59%)]      Loss: 0.070099
        Train Epoch: 3 [35840/60000 (60%)]      Loss: 0.094528
        Train Epoch: 3 [36480/60000 (61%)]      Loss: 0.013394
        Train Epoch: 3 [37120/60000 (62%)]      Loss: 0.070342
        Train Epoch: 3 [37760/60000 (63%)]      Loss: 0.071798
        Train Epoch: 3 [38400/60000 (64%)]      Loss: 0.053334
        Train Epoch: 3 [39040/60000 (65%)]      Loss: 0.002679
        Train Epoch: 3 [39680/60000 (66%)]      Loss: 0.040941
        Train Epoch: 3 [40320/60000 (67%)]      Loss: 0.027158
        Train Epoch: 3 [40960/60000 (68%)]      Loss: 0.040392
        Train Epoch: 3 [41600/60000 (69%)]      Loss: 0.083458
        Train Epoch: 3 [42240/60000 (70%)]      Loss: 0.024119
        Train Epoch: 3 [42880/60000 (71%)]      Loss: 0.033582
        Train Epoch: 3 [43520/60000 (72%)]      Loss: 0.060558
        Train Epoch: 3 [44160/60000 (74%)]      Loss: 0.013897
        Train Epoch: 3 [44800/60000 (75%)]      Loss: 0.020948
        Train Epoch: 3 [45440/60000 (76%)]      Loss: 0.055007
        Train Epoch: 3 [46080/60000 (77%)]      Loss: 0.101892
        Train Epoch: 3 [46720/60000 (78%)]      Loss: 0.048161
        Train Epoch: 3 [47360/60000 (79%)]      Loss: 0.085926
        Train Epoch: 3 [48000/60000 (80%)]      Loss: 0.031943
        Train Epoch: 3 [48640/60000 (81%)]      Loss: 0.013601
        Train Epoch: 3 [49280/60000 (82%)]      Loss: 0.001783
        Train Epoch: 3 [49920/60000 (83%)]      Loss: 0.020416
        Train Epoch: 3 [50560/60000 (84%)]      Loss: 0.018090
        Train Epoch: 3 [51200/60000 (85%)]      Loss: 0.051472
        Train Epoch: 3 [51840/60000 (86%)]      Loss: 0.004347
        Train Epoch: 3 [52480/60000 (87%)]      Loss: 0.002406
        Train Epoch: 3 [53120/60000 (88%)]      Loss: 0.049920
        Train Epoch: 3 [53760/60000 (90%)]      Loss: 0.138956
        Train Epoch: 3 [54400/60000 (91%)]      Loss: 0.007761
        Train Epoch: 3 [55040/60000 (92%)]      Loss: 0.003048
        Train Epoch: 3 [55680/60000 (93%)]      Loss: 0.047181
        Train Epoch: 3 [56320/60000 (94%)]      Loss: 0.029689
        Train Epoch: 3 [56960/60000 (95%)]      Loss: 0.007264
        Train Epoch: 3 [57600/60000 (96%)]      Loss: 0.074576
        Train Epoch: 3 [58240/60000 (97%)]      Loss: 0.012654
        Train Epoch: 3 [58880/60000 (98%)]      Loss: 0.042871
        Train Epoch: 3 [59520/60000 (99%)]      Loss: 0.001480
        
        Test set: Average loss: 0.0338, Accuracy: 9883/10000 (99%)
        
        
=== RUN   TestMPIJobPytorchTraining/multi-node
W0731 17:45:35.642110    7641 warnings.go:70] unknown field "spec.mpiReplicaSpecs.Launcher.template.metadata.creationTimestamp"
W0731 17:45:35.642121    7641 warnings.go:70] unknown field "spec.mpiReplicaSpecs.Worker.template.metadata.creationTimestamp"
=== RUN   TestMPIJobPytorchTraining/multi-node/MPIJob_succeeds
=== NAME  TestMPIJobPytorchTraining/multi-node
    mpi_test.go:134: Test log for multi-node-nccl-test:
    mpi_test.go:135: Warning: Permanently added 'multi-node-nccl-test-worker-0.multi-node-nccl-test.default.svc' (ED25519) to the list of known hosts.
        Warning: Permanently added 'multi-node-nccl-test-worker-1.multi-node-nccl-test.default.svc' (ED25519) to the list of known hosts.
        [1,1]<stderr>:libfabric:21:1722447956::core:core:cuda_hmem_dl_init():499<warn> Failed to dlopen libnvidia-ml.so.  Trying libnvidia-ml.so.1
        [1,0]<stderr>:libfabric:22:1722447956::core:core:cuda_hmem_dl_init():499<warn> Failed to dlopen libnvidia-ml.so.  Trying libnvidia-ml.so.1
        [1,1]<stderr>:libfabric:21:1722447956::core:core:cuda_gdrcopy_hmem_init():192<warn> gdrcopy_dl_hmem_init failed!
        [1,0]<stderr>:libfabric:22:1722447956::core:core:cuda_gdrcopy_hmem_init():192<warn> gdrcopy_dl_hmem_init failed!
        [1,1]<stderr>:libfabric:21:1722447956::core:core:cuda_hmem_dl_init():499<warn> Failed to dlopen libnvidia-ml.so.  Trying libnvidia-ml.so.1
        [1,0]<stderr>:libfabric:22:1722447956::core:core:cuda_hmem_dl_init():499<warn> Failed to dlopen libnvidia-ml.so.  Trying libnvidia-ml.so.1
        [1,1]<stderr>:libfabric:21:1722447956::core:core:cuda_gdrcopy_hmem_init():192<warn> gdrcopy_dl_hmem_init failed!
        [1,0]<stderr>:libfabric:22:1722447956::core:core:cuda_gdrcopy_hmem_init():192<warn> gdrcopy_dl_hmem_init failed!
        [1,0]<stdout>:# nThread 1 nGpus 1 minBytes 8 maxBytes 2147483648 step: 2(factor) warmup iters: 5 iters: 100 agg iters: 1 validation: 1 graph: 0
        [1,0]<stdout>:#
        [1,0]<stdout>:# Using devices
        [1,0]<stdout>:#  Rank  0 Group  0 Pid     22 on multi-node-nccl-test-worker-0 device  0 [0x00] Tesla V100-SXM2-16GB
        [1,0]<stdout>:#  Rank  1 Group  0 Pid     21 on multi-node-nccl-test-worker-1 device  0 [0x00] Tesla V100-SXM2-16GB
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:22 [0] NCCL INFO Bootstrap : Using eth0:192.168.24.153<0>
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:22 [0] NCCL INFO NET/Plugin: Failed to find ncclCollNetPlugin_v6 symbol.
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:22 [0] NCCL INFO NET/Plugin: Failed to find ncclCollNetPlugin symbol (v4 or v5).
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:21 [0] NCCL INFO cudaDriverVersion 12050
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:21 [0] NCCL INFO Bootstrap : Using eth0:192.168.95.231<0>
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:21 [0] NCCL INFO NET/Plugin: Failed to find ncclCollNetPlugin_v6 symbol.
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:21 [0] NCCL INFO NET/Plugin: Failed to find ncclCollNetPlugin symbol (v4 or v5).
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:22 [0] NCCL INFO cudaDriverVersion 12050
        [1,0]<stdout>:NCCL version 2.18.5+cuda12.2
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/OFI Initializing aws-ofi-nccl 1.9.1-aws
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/OFI Initializing aws-ofi-nccl 1.9.1-aws
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/OFI Using Libfabric version 1.21
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/OFI Using CUDA driver version 12050
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/OFI Configuring AWS-specific options
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/OFI Setting provider_filter to efa
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/OFI Setting FI_EFA_FORK_SAFE environment variable to 1
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/OFI Setting NCCL_NVLSTREE_MAX_CHUNKSIZE to 512KiB
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/OFI Setting NCCL_NVLS_CHUNKSIZE to 512KiB
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/OFI Internode latency set at 150.0 us
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/OFI Using transport protocol SENDRECV
        [1,1]<stdout>:
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] nccl_net_ofi_create_plugin:204 NCCL WARN NET/OFI Failed to initialize sendrecv protocol
        [1,1]<stdout>:
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] nccl_net_ofi_create_plugin:257 NCCL WARN NET/OFI aws-ofi-nccl initialization failed
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/IB : No device found.
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NET/Socket : Using [0]eth0:192.168.95.231<0>
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO Using network Socket
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/OFI Initializing aws-ofi-nccl 1.9.1-aws
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/OFI Initializing aws-ofi-nccl 1.9.1-aws
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/OFI Using Libfabric version 1.21
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/OFI Using CUDA driver version 12050
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/OFI Configuring AWS-specific options
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/OFI Setting provider_filter to efa
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/OFI Setting FI_EFA_FORK_SAFE environment variable to 1
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/OFI Setting NCCL_NVLSTREE_MAX_CHUNKSIZE to 512KiB
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/OFI Setting NCCL_NVLS_CHUNKSIZE to 512KiB
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/OFI Internode latency set at 150.0 us
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/OFI Using transport protocol SENDRECV
        [1,0]<stdout>:
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] nccl_net_ofi_create_plugin:204 NCCL WARN NET/OFI Failed to initialize sendrecv protocol
        [1,0]<stdout>:
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] nccl_net_ofi_create_plugin:257 NCCL WARN NET/OFI aws-ofi-nccl initialization failed
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/IB : No device found.
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NET/Socket : Using [0]eth0:192.168.24.153<0>
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO Using network Socket
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO comm 0x55a2c6625c10 rank 1 nranks 2 cudaDev 0 nvmlDev 0 busId 1e0 commId 0xea078395019732fa - Init START
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO comm 0x55fb28c68190 rank 0 nranks 2 cudaDev 0 nvmlDev 0 busId 1e0 commId 0xea078395019732fa - Init START
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO Trees [0] -1/-1/-1->1->0 [1] 0/-1/-1->1->-1
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO P2P Chunksize set to 131072
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO Channel 00/02 :    0   1
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO Channel 01/02 :    0   1
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO Trees [0] 1/-1/-1->0->-1 [1] -1/-1/-1->0->1
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO P2P Chunksize set to 131072
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO Channel 00/0 : 1[0] -> 0[0] [receive] via NET/Socket/0
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO Channel 00/0 : 0[0] -> 1[0] [receive] via NET/Socket/0
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO Channel 01/0 : 1[0] -> 0[0] [receive] via NET/Socket/0
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO Channel 01/0 : 0[0] -> 1[0] [receive] via NET/Socket/0
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO Channel 00/0 : 0[0] -> 1[0] [send] via NET/Socket/0
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO Channel 00/0 : 1[0] -> 0[0] [send] via NET/Socket/0
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO Channel 01/0 : 0[0] -> 1[0] [send] via NET/Socket/0
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO Channel 01/0 : 1[0] -> 0[0] [send] via NET/Socket/0
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO Connected all rings
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO Connected all trees
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NCCL_PROTO set by environment to simple
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO NCCL_ALGO set by environment to RING
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO threadThresholds 8/8/64 | 16/8/64 | 512 | 512
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO 2 coll channels, 0 nvls channels, 2 p2p channels, 2 p2p channels per peer
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO Connected all rings
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO Connected all trees
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NCCL_PROTO set by environment to simple
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO NCCL_ALGO set by environment to RING
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO threadThresholds 8/8/64 | 16/8/64 | 512 | 512
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO 2 coll channels, 0 nvls channels, 2 p2p channels, 2 p2p channels per peer
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:28 [0] NCCL INFO comm 0x55fb28c68190 rank 0 nranks 2 cudaDev 0 nvmlDev 0 busId 1e0 commId 0xea078395019732fa - Init COMPLETE
        [1,0]<stdout>:#
        [1,0]<stdout>:#                                                              out-of-place                       in-place          
        [1,0]<stdout>:#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
        [1,0]<stdout>:#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:26 [0] NCCL INFO comm 0x55a2c6625c10 rank 1 nranks 2 cudaDev 0 nvmlDev 0 busId 1e0 commId 0xea078395019732fa - Init COMPLETE
        [1,0]<stdout>:           8             2     float     sum      -1    328.0    0.00    0.00      0    289.8    0.00    0.00      0
        [1,0]<stdout>:          16             4     float     sum      -1    257.4    0.00    0.00      0    286.4    0.00    0.00      0
        [1,0]<stdout>:          32             8     float     sum      -1    228.0    0.00    0.00      0    209.7    0.00    0.00      0
        [1,0]<stdout>:          64            16     float     sum      -1    216.6    0.00    0.00      0    214.5    0.00    0.00      0
        [1,0]<stdout>:         128            32     float     sum      -1    216.0    0.00    0.00      0    207.9    0.00    0.00      0
        [1,0]<stdout>:         256            64     float     sum      -1    233.5    0.00    0.00      0    215.0    0.00    0.00      0
        [1,0]<stdout>:         512           128     float     sum      -1    263.4    0.00    0.00      0    282.5    0.00    0.00      0
        [1,0]<stdout>:        1024           256     float     sum      -1    344.8    0.00    0.00      0    376.2    0.00    0.00      0
        [1,0]<stdout>:        2048           512     float     sum      -1    362.0    0.01    0.01      0    260.4    0.01    0.01      0
        [1,0]<stdout>:        4096          1024     float     sum      -1    247.5    0.02    0.02      0    265.8    0.02    0.02      0
        [1,0]<stdout>:        8192          2048     float     sum      -1    419.2    0.02    0.02      0    423.8    0.02    0.02      0
        [1,0]<stdout>:       16384          4096     float     sum      -1    341.4    0.05    0.05      0    326.8    0.05    0.05      0
        [1,0]<stdout>:       32768          8192     float     sum      -1    480.7    0.07    0.07      0    431.8    0.08    0.08      0
        [1,0]<stdout>:       65536         16384     float     sum      -1    532.2    0.12    0.12      0    480.7    0.14    0.14      0
        [1,0]<stdout>:      131072         32768     float     sum      -1    558.8    0.23    0.23      0    494.5    0.27    0.27      0
        [1,0]<stdout>:      262144         65536     float     sum      -1    609.0    0.43    0.43      0    630.4    0.42    0.42      0
        [1,0]<stdout>:      524288        131072     float     sum      -1    972.1    0.54    0.54      0    929.5    0.56    0.56      0
        [1,0]<stdout>:     1048576        262144     float     sum      -1   1295.8    0.81    0.81      0   1203.7    0.87    0.87      0
        [1,0]<stdout>:     2097152        524288     float     sum      -1   1873.1    1.12    1.12      0   1910.3    1.10    1.10      0
        [1,0]<stdout>:     4194304       1048576     float     sum      -1   3451.3    1.22    1.22      0   3443.3    1.22    1.22      0
        [1,0]<stdout>:     8388608       2097152     float     sum      -1   7681.8    1.09    1.09      0   7543.4    1.11    1.11      0
        [1,0]<stdout>:    16777216       4194304     float     sum      -1    13963    1.20    1.20      0    14158    1.18    1.18      0
        [1,0]<stdout>:    33554432       8388608     float     sum      -1    27219    1.23    1.23      0    27251    1.23    1.23      0
        [1,0]<stdout>:    67108864      16777216     float     sum      -1    54328    1.24    1.24      0    54546    1.23    1.23      0
        [1,0]<stdout>:   134217728      33554432     float     sum      -1   109211    1.23    1.23      0   108923    1.23    1.23      0
        [1,0]<stdout>:   268435456      67108864     float     sum      -1   217858    1.23    1.23      0   217297    1.24    1.24      0
        [1,0]<stdout>:   536870912     134217728     float     sum      -1   437876    1.23    1.23      0   440610    1.22    1.22      0
        [1,0]<stdout>:  1073741824     268435456     float     sum      -1   867358    1.24    1.24      0   867468    1.24    1.24      0
        [1,0]<stdout>:  2147483648     536870912     float     sum      -1  1741881    1.23    1.23      0  1736354    1.24    1.24      0
        [1,0]<stdout>:multi-node-nccl-test-worker-0:22:22 [0] NCCL INFO comm 0x55fb28c68190 rank 0 nranks 2 cudaDev 0 busId 1e0 - Destroy COMPLETE
        [1,1]<stdout>:multi-node-nccl-test-worker-1:21:21 [0] NCCL INFO comm 0x55a2c6625c10 rank 1 nranks 2 cudaDev 0 busId 1e0 - Destroy COMPLETE
        [1,0]<stdout>:# Out of bounds values : 0 OK
        [1,0]<stdout>:# Avg bus bandwidth    : 0.538265 
        [1,0]<stdout>:#
        [1,0]<stdout>:
        
--- PASS: TestMPIJobPytorchTraining (1226.15s)
    --- PASS: TestMPIJobPytorchTraining/single-node (475.62s)
        --- PASS: TestMPIJobPytorchTraining/single-node/MPIJob_succeeds (475.07s)
    --- PASS: TestMPIJobPytorchTraining/multi-node (750.53s)
        --- PASS: TestMPIJobPytorchTraining/multi-node/MPIJob_succeeds (750.07s)
=== RUN   TestSingleNodeUnitTest
=== RUN   TestSingleNodeUnitTest/unit-test
=== RUN   TestSingleNodeUnitTest/unit-test/Unit_test_Job_succeeds
=== NAME  TestSingleNodeUnitTest/unit-test
    unit_test.go:67: Test log for unit-test-job:
    unit_test.go:68: # Running tests in gpu_unit_tests/tests/test_basic.sh
        ok - test_01_device_query
        ok - test_02_vector_add
        ok - test_03_bandwidth
        ok - test_04_bus_grind
        ok - test_05_dcgm_diagnostics
        # Running tests in gpu_unit_tests/tests/test_sysinfo.sh
          % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                         Dload  Upload   Total   Spent    Left  Speed
100    56  100    56    0     0  37110      0 --:--:-- --:--:-- --:--:-- 56000
          % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                         Dload  Upload   Total   Spent    Left  Speed
100    10  100    10    0     0  10277      0 --:--:-- --:--:-- --:--:-- 10000
        ok - test_numa_topo_topo
        ok - test_nvidia_gpu_count
        ok - test_nvidia_gpu_throttled
        ok - test_nvidia_gpu_unused
        ok - test_nvidia_persistence_status
        ok - test_nvidia_smi_topo
        
--- PASS: TestSingleNodeUnitTest (25.58s)
    --- PASS: TestSingleNodeUnitTest/unit-test (25.58s)
        --- PASS: TestSingleNodeUnitTest/unit-test/Unit_test_Job_succeeds (25.06s)
PASS
ok      github.com/aws/aws-k8s-tester/e2e2/test/cases/nvidia    1266.361s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
