### PR TITLE
Bump go version in kubetest2 image

### DIFF
--- a/Dockerfile.kubetest2
+++ b/Dockerfile.kubetest2
@@ -2,7 +2,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 RUN yum install -y git tar gzip make unzip gcc rsync wget jq
-ARG GO_MINOR_VERSION="1.21"
+ARG GO_MINOR_VERSION="1.23"
 RUN curl https://go.dev/dl/?mode=json | jq -r .[].version | grep "^go${GO_MINOR_VERSION}" | head -n1 > go-version.txt
 RUN  wget -O go.tar.gz https://go.dev/dl/$(cat go-version.txt).${TARGETOS}-${TARGETARCH}.tar.gz && \
     rm -rf /usr/local/go && \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump go version because 1.21 is no longer listed in the download list at https://go.dev/dl/?mode=json

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
