### PR TITLE
Add --node-creation-timeout flag

### DIFF
--- a/kubetest2/internal/deployers/eksapi/deployer.go
+++ b/kubetest2/internal/deployers/eksapi/deployer.go
@@ -64,6 +64,7 @@ type deployerOptions struct {
 	IPFamily                    string        `flag:"ip-family" desc:"IP family for the cluster (ipv4 or ipv6)"`
 	KubeconfigPath              string        `flag:"kubeconfig" desc:"Path to kubeconfig"`
 	KubernetesVersion           string        `flag:"kubernetes-version" desc:"cluster Kubernetes version"`
+	NodeCreationTimeout         time.Duration `flag:"node-creation-timeout" desc:"Time to wait for nodes to be created/launched. This should consider instance availability."`
 	NodeReadyTimeout            time.Duration `flag:"node-ready-timeout" desc:"Time to wait for all nodes to become ready"`
 	Nodes                       int           `flag:"nodes" desc:"number of nodes to launch in cluster"`
 	NodeNameStrategy            string        `flag:"node-name-strategy" desc:"Specifies the naming strategy for node. Allowed values: ['SessionName', 'EC2PrivateDNSName'], default to EC2PrivateDNSName"`
@@ -249,6 +250,9 @@ func (d *deployer) verifyUpFlags() error {
 	}
 	if d.UnmanagedNodes && d.AMIType != "" {
 		return fmt.Errorf("--ami-type should not be provided with --unmanaged-nodes")
+	}
+	if d.NodeCreationTimeout == 0 {
+		d.NodeCreationTimeout = time.Minute * 20
 	}
 	if d.NodeReadyTimeout == 0 {
 		d.NodeReadyTimeout = time.Minute * 5

--- a/kubetest2/internal/deployers/eksapi/nodegroup.go
+++ b/kubetest2/internal/deployers/eksapi/nodegroup.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	nodegroupCreationTimeout = time.Minute * 20
 	nodegroupDeletionTimeout = time.Minute * 20
 )
 
@@ -119,7 +118,7 @@ func (m *NodegroupManager) createManagedNodegroup(infra *Infrastructure, cluster
 		Wait(context.TODO(), &eks.DescribeNodegroupInput{
 			ClusterName:   input.ClusterName,
 			NodegroupName: input.NodegroupName,
-		}, nodegroupCreationTimeout)
+		}, opts.NodeCreationTimeout)
 	if err != nil {
 		return err
 	}
@@ -228,7 +227,7 @@ func (m *NodegroupManager) createUnmanagedNodegroup(infra *Infrastructure, clust
 			&cloudformation.DescribeStacksInput{
 				StackName: out.StackId,
 			},
-			infraStackCreationTimeout)
+			opts.NodeCreationTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to wait for unmanaged nodegroup stack creation: %w", err)
 	}


### PR DESCRIPTION
*Description of changes:*

Adds a flag to control how long we wait for nodes to be launched. Some instance types are scarce and we may need to wait longer than the default (20 minutes).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
