### PR TITLE
Enable EFA set up for bottlerocket

### DIFF
--- a/kubetest2/internal/deployers/eksapi/nodegroup.go
+++ b/kubetest2/internal/deployers/eksapi/nodegroup.go
@@ -144,7 +144,7 @@ func (m *NodegroupManager) createManagedNodegroup(infra *Infrastructure, cluster
 func (m *NodegroupManager) createUnmanagedNodegroup(infra *Infrastructure, cluster *Cluster, opts *deployerOptions) error {
 	stackName := m.getUnmanagedNodegroupStackName()
 	klog.Infof("creating unmanaged nodegroup stack...")
-	userData, userDataIsMimePart, err := generateUserData(opts.UserDataFormat, cluster)
+	userData, userDataIsMimePart, err := generateUserData(opts.UserDataFormat, opts.EFA, cluster)
 	if err != nil {
 		return err
 	}
@@ -245,7 +245,7 @@ func (m *NodegroupManager) createUnmanagedNodegroup(infra *Infrastructure, clust
 func (m *NodegroupManager) createUnmanagedNodegroupWithEFA(infra *Infrastructure, cluster *Cluster, opts *deployerOptions) error {
 	stackName := m.getUnmanagedNodegroupStackName()
 	klog.Infof("creating unmanaged nodegroup with EFA stack...")
-	userData, _, err := generateUserData(opts.UserDataFormat, cluster)
+	userData, userDataIsMimePart, err := generateUserData(opts.UserDataFormat, opts.EFA, cluster)
 	if err != nil {
 		return err
 	}
@@ -272,6 +272,10 @@ func (m *NodegroupManager) createUnmanagedNodegroupWithEFA(infra *Infrastructure
 			{
 				ParameterKey:   aws.String("UserData"),
 				ParameterValue: aws.String(userData),
+			},
+			{
+				ParameterKey:   aws.String("UserDataIsMIMEPart"),
+				ParameterValue: aws.String(strconv.FormatBool(userDataIsMimePart)),
 			},
 			{
 				ParameterKey:   aws.String("ClusterName"),

--- a/kubetest2/internal/deployers/eksapi/templates/templates.go
+++ b/kubetest2/internal/deployers/eksapi/templates/templates.go
@@ -41,6 +41,7 @@ type UserDataTemplateData struct {
 	CertificateAuthority string
 	CIDR                 string
 	APIServerEndpoint    string
+	EFAEnabled           bool
 }
 
 var (

--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
@@ -41,6 +41,12 @@ Parameters:
   UserData:
     Type: String
 
+  UserDataIsMIMEPart:
+    Description: "User data should be embedded as a part of a multi-part MIME document"
+    Default: true
+    Type: String
+    AllowedValues: [true, false]
+
   InstanceType:
     Type: String
     Description: Efa supports only one instance type in the cluster. eg. p3dn.24xlarge, p4d.24xlarge or p5.48xlarge
@@ -51,6 +57,8 @@ Conditions:
     !Equals [Ref: InstanceType, p4d.24xlarge]
   IsP5Node:
     !Equals [Ref: InstanceType, p5.48xlarge]
+  IsUserDataMIMEPart:
+    !Equals [true, !Ref UserDataIsMIMEPart]
 
 Resources:
   EFASecurityGroup:
@@ -293,24 +301,28 @@ Resources:
                   - !Ref EFASecurityGroup
         UserData:
           Fn::Base64:
-            Fn::Sub: |
-              Content-Type: multipart/mixed; boundary="BOUNDARY"
-              MIME-Version: 1.0
+            Fn::If:
+            - IsUserDataMIMEPart
+            - Fn::Sub: |
+                Content-Type: multipart/mixed; boundary="BOUNDARY"
+                MIME-Version: 1.0
 
-              --BOUNDARY
-              ${UserData}
+                --BOUNDARY
+                ${UserData}
 
-              --BOUNDARY
-              Content-Type: text/x-shellscript; charset="us-ascii"
-              MIME-Version: 1.0
+                --BOUNDARY
+                Content-Type: text/x-shellscript; charset="us-ascii"
+                MIME-Version: 1.0
 
-              #!/usr/bin/env bash
-              /opt/aws/bin/cfn-signal \
-                --stack  ${AWS::StackName} \
-                --resource NodeGroup \
-                --region ${AWS::Region}
+                #!/usr/bin/env bash
+                /opt/aws/bin/cfn-signal \
+                  --stack  ${AWS::StackName} \
+                  --resource NodeGroup \
+                  --region ${AWS::Region}
 
-              --BOUNDARY--
+                --BOUNDARY--
+            - Fn::Sub: |
+                ${UserData}
 
   NodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/kubetest2/internal/deployers/eksapi/templates/userdata_bottlerocket.toml.template
+++ b/kubetest2/internal/deployers/eksapi/templates/userdata_bottlerocket.toml.template
@@ -5,3 +5,6 @@
 
 [settings.host-containers.admin]
 "enabled" = true
+
+[settings.efa]
+"enabled" = {{.EFAEnabled}}

--- a/kubetest2/internal/deployers/eksapi/userdata.go
+++ b/kubetest2/internal/deployers/eksapi/userdata.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-k8s-tester/kubetest2/internal/deployers/eksapi/templates"
 )
 
-func generateUserData(format string, cluster *Cluster) (string, bool, error) {
+func generateUserData(format string, efaEnabled bool, cluster *Cluster) (string, bool, error) {
 	userDataIsMimePart := true
 	var t *template.Template
 	switch format {
@@ -29,6 +29,7 @@ func generateUserData(format string, cluster *Cluster) (string, bool, error) {
 		CertificateAuthority: cluster.certificateAuthorityData,
 		CIDR:                 cluster.cidr,
 		Name:                 cluster.name,
+		EFAEnabled:           efaEnabled,
 	}); err != nil {
 		return "", false, err
 	}

--- a/kubetest2/internal/deployers/eksapi/userdata_test.go
+++ b/kubetest2/internal/deployers/eksapi/userdata_test.go
@@ -33,29 +33,49 @@ spec:
     name: cluster
     apiServerEndpoint: https://example.com
     certificateAuthority: certificateAuthority
-	cidr: 10.100.0.0/16
+    cidr: 10.100.0.0/16
+`
+const bottlerocketUserData = `[settings.kubernetes]
+"cluster-name" = "cluster"
+"api-server" = "https://example.com"
+"cluster-certificate" = "certificateAuthority"
+
+[settings.host-containers.admin]
+"enabled" = true
+
+[settings.efa]
+"enabled" = true
 `
 
 func Test_generateUserData(t *testing.T) {
 	cases := []struct {
 		format             string
+		efa                bool
 		expected           string
 		expectedIsMimePart bool
 	}{
 		{
 			format:             "bootstrap.sh",
+			efa:                false,
 			expected:           bootstrapShUserData,
 			expectedIsMimePart: true,
 		},
 		{
 			format:             "nodeadm",
+			efa:                false,
 			expected:           nodeadmUserData,
 			expectedIsMimePart: true,
+		},
+		{
+			format:             "bottlerocket",
+			efa:                true,
+			expected:           bottlerocketUserData,
+			expectedIsMimePart: false,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.format, func(t *testing.T) {
-			actual, isMimePart, err := generateUserData(c.format, &cluster)
+			actual, isMimePart, err := generateUserData(c.format, c.efa, &cluster)
 			if err != nil {
 				t.Log(err)
 				t.Error(err)


### PR DESCRIPTION
*Description of changes:*
title

*Testing*
```
kubetest2 eksapi --up --user-data-format=bottlerocket --generate-ssh-key --unmanaged-nodes --nodes=1 --ami=ami-0126512b7310b5013 --kubernetes-version=1.29 --efa --instance-types=g5.8xlarge
```

```
Capacity:
  cpu:                    32
  ephemeral-storage:      18667120Ki
  hugepages-1Gi:          0
  hugepages-2Mi:          0
  memory:                 130461372Ki
  nvidia.com/gpu:         1
  pods:                   234
  vpc.amazonaws.com/efa:  1
Allocatable:
  cpu:                    31850m
  ephemeral-storage:      16129875940
  hugepages-1Gi:          0
  hugepages-2Mi:          0
  memory:                 127462076Ki
  nvidia.com/gpu:         1
  pods:                   234
  vpc.amazonaws.com/efa:  1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
