### PR TITLE
Fix volume capacity issue

### DIFF
--- a/kubetest2/internal/deployers/eksapi/nodegroup.go
+++ b/kubetest2/internal/deployers/eksapi/nodegroup.go
@@ -259,6 +259,11 @@ func (m *NodegroupManager) createUnmanagedNodegroupWithEFA(infra *Infrastructure
 		subnetId = infra.subnetsPrivate[0]
 	}
 
+	volumeMountPath := "/dev/xvda"
+	if opts.UserDataFormat == "bottlerocket" {
+		volumeMountPath = "/dev/xvdb"
+	}
+
 	// pull the role name out of the ARN
 	nodeRoleArnParts := strings.Split(infra.nodeRole, "/")
 	nodeRoleName := nodeRoleArnParts[len(nodeRoleArnParts)-1]
@@ -286,6 +291,10 @@ func (m *NodegroupManager) createUnmanagedNodegroupWithEFA(infra *Infrastructure
 			{
 				ParameterKey:   aws.String("UserDataIsMIMEPart"),
 				ParameterValue: aws.String(strconv.FormatBool(userDataIsMimePart)),
+			},
+			{
+				ParameterKey:   aws.String("VolumeMountPath"),
+				ParameterValue: aws.String(volumeMountPath),
 			},
 			{
 				ParameterKey:   aws.String("ClusterName"),

--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
@@ -41,6 +41,9 @@ Parameters:
   UserData:
     Type: String
   
+  VolumeMountPath:
+    Type: String
+  
   CapacityReservationId:
     Type: String
     Description: Capacity reservation id for the unmanaged nodegroup
@@ -210,7 +213,7 @@ Resources:
       LaunchTemplateName: !Ref ResourceId
       LaunchTemplateData:
         BlockDeviceMappings:
-          - DeviceName: /dev/xvda
+          - DeviceName: !Ref VolumeMountPath
             Ebs:
               DeleteOnTermination: true
               VolumeSize: !Ref NodeDiskSize


### PR DESCRIPTION
*Issue #, if available:*
When testing EFA for bottlerocket, run into 
```
 Warning  Evicted              29s   kubelet            The node was low on resource: ephemeral-storage. Threshold quantity: 2867269745, available: 1396568Ki.
 ```

*Description of changes:*
As bottlerocket has 2 volume, we should use `/dev/xvdb` for data volume

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
