### PR TITLE
Remove unsupported instance types in isolated regions

### DIFF
--- a/kubetest2/internal/deployers/eksapi/nodegroup.go
+++ b/kubetest2/internal/deployers/eksapi/nodegroup.go
@@ -31,9 +31,7 @@ var (
 	defaultInstanceTypes_x86_64 = []string{
 		"m6i.xlarge",
 		"m6i.large",
-		"m6a.large",
 		"m5.large",
-		"m5a.large",
 		"m4.large",
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

remove `A` type ec2 instances from default list due to lack of support in isolated regions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
