### PR TITLE
Add debug logging for e2e-nvidia setup

### DIFF
--- a/e2e2/test/cases/nvidia/main_test.go
+++ b/e2e2/test/cases/nvidia/main_test.go
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 			err := wait.For(conditions.New(config.Client().Resources()).DeploymentConditionMatch(&dep, appsv1.DeploymentAvailable, v1.ConditionTrue),
 				wait.WithContext(ctx))
 			if err != nil {
-				return ctx, err
+				return ctx, fmt.Errorf("failed to deploy mpi-operator: %v", err)
 			}
 			return ctx, nil
 		},
@@ -86,7 +86,7 @@ func TestMain(m *testing.M) {
 			err := wait.For(fwext.NewConditionExtension(config.Client().Resources()).DaemonSetReady(&ds),
 				wait.WithContext(ctx))
 			if err != nil {
-				return ctx, err
+				return ctx, fmt.Errorf("failed to deploy nvidia-device-plugin: %v", err)
 			}
 			return ctx, nil
 		},
@@ -110,7 +110,7 @@ func TestMain(m *testing.M) {
 				err = wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).DaemonSetReady(&ds),
 					wait.WithContext(ctx))
 				if err != nil {
-					return ctx, err
+					return ctx, fmt.Errorf("failed to deploy efa-device-plugin: %v", err)
 				}
 			}
 


### PR DESCRIPTION
*Description of changes:*

Timeouts during `Setup` can be caused by a failure in one of:
1. mpi-operator
2. nvidia-device-plugin
3. efa-device-plugin

This adds some logging to narrow things down.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
