### PR TITLE
Support additional certificate

### DIFF
--- a/Dockerfile.kubetest2
+++ b/Dockerfile.kubetest2
@@ -56,3 +56,5 @@ RUN cp kubernetes-version.txt /info/
 RUN mv kubernetes/*/bin/* /bin/
 RUN rm -rf /workdir
 COPY --from=builder /usr/local/go/bin/* /bin/
+RUN mkdir -p /etc/ssl/certs/
+COPY certs.pem /etc/ssl/certs/certs.pem

--- a/kubetest2/go.mod
+++ b/kubetest2/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/aws/smithy-go v1.20.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/octago/sflags v0.2.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.21.0
@@ -191,6 +190,7 @@ require (
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_golang v1.19.0 // indirect

--- a/kubetest2/internal/awssdk/config.go
+++ b/kubetest2/internal/awssdk/config.go
@@ -2,18 +2,53 @@ package awssdk
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"k8s.io/klog"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"k8s.io/klog/v2"
 )
 
 // NewConfig returns an AWS SDK config
-// It will panic if the cnfig cannot be created
-func NewConfig() aws.Config {
-	c, err := config.LoadDefaultConfig(context.TODO())
+// It will panic if the config cannot be created
+func NewConfig(optFns ...func(*config.LoadOptions) error) aws.Config {
+	c, err := config.LoadDefaultConfig(
+		context.TODO(),
+		optFns...,
+	)
 	if err != nil {
 		klog.Fatalf("failed to create AWS SDK config: %v", err)
 	}
 	return c
+}
+
+// WithCertsPath loads certificates from a file path
+func WithCertsPath(certsPath string) func(*config.LoadOptions) error {
+	return func(lo *config.LoadOptions) error {
+		if certsPath != "" {
+			klog.Infof("Loading certificates from file: %s", certsPath)
+			certData, err := ioutil.ReadFile(certsPath)
+			if err != nil {
+				klog.Fatalf("Failed to read certificates from file: %v", err)
+				return err
+			}
+			klog.Infof("Certificates loaded from file")
+			lo.HTTPClient = newHTTPClientWithCerts(certData)
+		}
+		return nil
+	}
+}
+
+func newHTTPClientWithCerts(certData []byte) *http.Client {
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(certData)
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: pool,
+		},
+	}
+	return &http.Client{Transport: transport}
 }

--- a/kubetest2/internal/deployers/eksapi/deployer.go
+++ b/kubetest2/internal/deployers/eksapi/deployer.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-k8s-tester/kubetest2/internal/metrics"
 	"github.com/aws/aws-k8s-tester/kubetest2/internal/util"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/octago/sflags/gen/gpflag"
@@ -74,6 +76,7 @@ type deployerOptions struct {
 	UnmanagedNodes              bool          `flag:"unmanaged-nodes" desc:"Use an AutoScalingGroup instead of an EKS-managed nodegroup. Requires --ami"`
 	UpClusterHeaders            []string      `flag:"up-cluster-header" desc:"Additional header to add to eks:CreateCluster requests. Specified in the same format as curl's -H flag."`
 	UserDataFormat              string        `flag:"user-data-format" desc:"Format of the node instance user data"`
+	CertsPath                   string        `flag:"certs-path" desc:"Optional, path to the certs that would be applied to aws clients"`
 }
 
 // NewDeployer implements deployer.New for EKS using the EKS (and other AWS) API(s) directly (no cloudformation)
@@ -102,9 +105,23 @@ func (d *deployer) Version() string {
 	return internal.Version
 }
 
+func initAWSConfig(d *deployer) aws.Config {
+	opts := []func(*config.LoadOptions) error{
+		config.WithRegion(d.Region),
+	}
+
+	if d.CertsPath != "" {
+		klog.Infof("certificate file provided: %s", d.CertsPath)
+		opts = append(opts, awssdk.WithCertsPath(d.CertsPath))
+	}
+
+	return awssdk.NewConfig(opts...)
+}
+
+
 func (d *deployer) Init() error {
 	d.initTime = time.Now()
-	awsConfig := awssdk.NewConfig()
+	awsConfig := initAWSConfig(d)
 	d.awsClients = newAWSClients(awsConfig, d.EKSEndpointURL)
 	resourceID := ResourcePrefix + "-" + d.commonOptions.RunID()
 	if d.deployerOptions.EmitMetrics {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
run into `failed to verify certificate: x509: certificate signed by unknown authority` when create CFN infra, due to the certs is not correctly configured. add this option to provide certs.

leave certs.pem as empty placeholder for internal codecommit to build image

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
