### PR TITLE
Fix unit test

### DIFF
--- a/e2e2/test/cases/nvidia/manifests/job-unit-test-single-node.yaml
+++ b/e2e2/test/cases/nvidia/manifests/job-unit-test-single-node.yaml
@@ -21,6 +21,7 @@ spec:
           limits:
             cpu: "4"
             memory: 4Gi
+            nvidia.com/gpu: {{.GpuPerNode}}
           requests:
             cpu: "1"
             memory: 1Gi

--- a/e2e2/test/images/nvidia/Dockerfile
+++ b/e2e2/test/images/nvidia/Dockerfile
@@ -41,7 +41,8 @@ RUN apt install -y \
   cmake \
   apt-utils \
   libhwloc-dev \
-  cuda-demo-suite-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION}
+  cuda-demo-suite-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
+  datacenter-gpu-manager
 
 RUN mkdir -p /var/run/sshd \
   && sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config \

--- a/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_sysinfo.sh.data/g5.8xlarge/gpu_count.txt
+++ b/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_sysinfo.sh.data/g5.8xlarge/gpu_count.txt
@@ -1,0 +1,2 @@
+name, index, pci.bus_id
+NVIDIA A10G, 0, 00000000:00:1E.0

--- a/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_sysinfo.sh.data/g5.8xlarge/numa_topo.txt
+++ b/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_sysinfo.sh.data/g5.8xlarge/numa_topo.txt
@@ -1,0 +1,2 @@
+/sys/devices/system/node/node0/cpulist:0-31
+/sys/devices/system/node/node0/distance:10

--- a/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_sysinfo.sh.data/g5.8xlarge/nvidia_persistence_status.txt
+++ b/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_sysinfo.sh.data/g5.8xlarge/nvidia_persistence_status.txt
@@ -1,0 +1,2 @@
+name, pci.bus_id, persistence_mode
+NVIDIA A10G, 00000000:00:1E.0, Enabled

--- a/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_sysinfo.sh.data/g5.8xlarge/nvidia_smi_topo.txt
+++ b/e2e2/test/images/nvidia/gpu_unit_tests/tests/test_sysinfo.sh.data/g5.8xlarge/nvidia_smi_topo.txt
@@ -1,0 +1,2 @@
+	[4mGPU0	CPU Affinity	NUMA Affinity	GPU NUMA ID[0m
+GPU0	 X 	0-31	0		N/A


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
encountered several issue when execute unit test for bottlerocket 
1. 
```
# Running tests in gpu_unit_tests/tests/test_basic.sh
common.sh: line 14: nvidia-smi: command not found
```
fix by adding resource limit
2.
dgcmi not found
fix by installing `datacenter-gpu-manager`
3. missing file for test-sysinfo, followed the readme to add expected files


### testing
```
k logs unit-test-job-nb6gn
# Running tests in gpu_unit_tests/tests/test_basic.sh
ok - test_01_device_query
ok - test_02_vector_add
ok - test_03_bandwidth
ok - test_04_bus_grind
ok - test_05_dcgm_diagnostics
# Running tests in gpu_unit_tests/tests/test_sysinfo.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:02:03 --:--:--     0
curl: (56) Recv failure: Connection reset by peer
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    10  100    10    0     0  12787      0 --:--:-- --:--:-- --:--:-- 10000
ok - test_numa_topo_topo
ok - test_nvidia_gpu_count
ok - test_nvidia_gpu_throttled
ok - test_nvidia_gpu_unused
not ok - test_nvidia_persistence_status
# Unexpected perfistance status, likely system configuration issue
#  test data value diff:
# --- test_sysinfo.sh.data/g5.8xlarge/nvidia_persistence_status.txt	2024-10-07 22:15:11.000000000 +0000
# +++ /tmp/test_sysinfo.sh.actual-data.tgP/nvidia_persistence_status.txt	2024-10-08 07:37:30.716879902 +0000
# @@ -1,2 +1,2 @@
#  name, pci.bus_id, persistence_mode
# -NVIDIA A10G, 00000000:00:1E.0, Enabled
# +NVIDIA A10G, 00000000:00:1E.0, Disabled
# common.sh:32:_assert_data()
# common.sh:37:assert_data()
# test_sysinfo.sh:52:test_nvidia_persistence_status()
ok - test_nvidia_smi_topo
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
