### PR TITLE
Fix Nvidia Image build

### DIFF
--- a/e2e2/test/cases/nvidia/main_test.go
+++ b/e2e2/test/cases/nvidia/main_test.go
@@ -24,14 +24,15 @@ import (
 )
 
 var (
-	testenv             env.Environment
-	nodeType            *string
-	installDevicePlugin *bool
-	efaEnabled          *bool
-	nvidiaTestImage     *string
-	nodeCount           int
-	gpuPerNode          int
-	efaPerNode          int
+	testenv                env.Environment
+	nodeType               *string
+	installDevicePlugin    *bool
+	efaEnabled             *bool
+	nvidiaTestImage        *string
+	skipUnitTestSubcommand *string
+	nodeCount              int
+	gpuPerNode             int
+	efaPerNode             int
 )
 
 var (
@@ -134,6 +135,7 @@ func TestMain(m *testing.M) {
 	nvidiaTestImage = flag.String("nvidiaTestImage", "", "nccl test image for nccl tests")
 	efaEnabled = flag.Bool("efaEnabled", false, "enable efa tests")
 	installDevicePlugin = flag.Bool("installDevicePlugin", true, "install nvidia device plugin")
+	skipUnitTestSubcommand = flag.String("skipUnitTestSubcommand", "", "optional command to skip specified unit test, `-s test1|test2|...`")
 	cfg, err := envconf.NewFromFlags()
 	if err != nil {
 		log.Fatalf("failed to initialize test environment: %v", err)

--- a/e2e2/test/cases/nvidia/manifests/job-unit-test-single-node.yaml
+++ b/e2e2/test/cases/nvidia/manifests/job-unit-test-single-node.yaml
@@ -16,6 +16,9 @@ spec:
         command: 
         - /bin/bash
         - ./gpu_unit_tests/unit_test
+        env:
+            - name: SKIP_TESTS_SUBCOMMAND
+              value: {{.SkipTestCommand}}
         imagePullPolicy: Always
         resources:
           limits:

--- a/e2e2/test/cases/nvidia/unit_test.go
+++ b/e2e2/test/cases/nvidia/unit_test.go
@@ -25,7 +25,9 @@ var (
 )
 
 type unitTestManifestTplVars struct {
-	NvidiaTestImage string
+	NvidiaTestImage    string
+	SkipTestSubcommand string
+	GpuPerNode         int
 }
 
 type hpcTestManifestTplVars struct {
@@ -42,7 +44,9 @@ func TestSingleNodeUnitTest(t *testing.T) {
 			}
 			var err error
 			renderedJobUnitTestSingleNodeManifest, err = fwext.RenderManifests(jobUnitTestSingleNodeManifest, unitTestManifestTplVars{
-				NvidiaTestImage: *nvidiaTestImage,
+				NvidiaTestImage:    *nvidiaTestImage,
+				SkipTestSubcommand: *skipUnitTestSubcommand,
+				GpuPerNode:         gpuPerNode,
 			})
 			if err != nil {
 				t.Fatal(err)

--- a/e2e2/test/images/nvidia/Dockerfile
+++ b/e2e2/test/images/nvidia/Dockerfile
@@ -4,7 +4,7 @@ ARG CUDA_MAJOR_VERSION=12
 ARG CUDA_MINOR_VERSION=5
 
 # Start with the NVIDIA CUDA base image
-FROM nvidia/cuda:${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}.1-devel-ubuntu${UBUNTU_MAJOR_VERSION}.04
+FROM nvidia/cuda:$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION.1-devel-ubuntu$UBUNTU_MAJOR_VERSION.04
 
 ARG UBUNTU_MAJOR_VERSION
 ARG CUDA_MAJOR_VERSION
@@ -41,7 +41,7 @@ RUN apt install -y \
   cmake \
   apt-utils \
   libhwloc-dev \
-  cuda-demo-suite-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
+  cuda-demo-suite-$CUDA_MAJOR_VERSION-$CUDA_MINOR_VERSION \
   datacenter-gpu-manager
 
 RUN mkdir -p /var/run/sshd \
@@ -55,24 +55,24 @@ ENV PATH /usr/local/cuda/bin:/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:/usr/sb
 # Install EFA
 ARG EFA_INSTALLER_VERSION=latest
 RUN cd /tmp \
-  && curl -sL https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz | tar xvz \
+  && curl -sL https://efa-installer.amazonaws.com/aws-efa-installer-$EFA_INSTALLER_VERSION.tar.gz | tar xvz \
   && cd aws-efa-installer \
   && ./efa_installer.sh --yes --enable-gdr --skip-kmod --skip-limit-conf --no-verify --mpi openmpi5 \
   && rm -rf /tmp/* \
     /var/lib/apt/lists/*
 
 # Install NCCL
-ARG NCCL_VERSION=2.22.3-1+cuda${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}
+ARG NCCL_VERSION=2.22.3-1+cuda12.5
 RUN apt update \
   && apt install -y \
-    libnccl2=${NCCL_VERSION}  \
-    libnccl-dev=${NCCL_VERSION}
+    libnccl2=$NCCL_VERSION  \
+    libnccl-dev=$NCCL_VERSION
 
 # Install AWS-OFI-NCCL plugin
 ARG AWS_OFI_NCCL_VERSION=1.11.0-aws
 RUN cd tmp \
-  && curl -sL https://github.com/aws/aws-ofi-nccl/releases/download/v${AWS_OFI_NCCL_VERSION}/aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}.tar.gz | tar xvz \
-  && cd aws-ofi-nccl-${AWS_OFI_NCCL_VERSION} \
+  && curl -sL https://github.com/aws/aws-ofi-nccl/releases/download/v$AWS_OFI_NCCL_VERSION/aws-ofi-nccl-$AWS_OFI_NCCL_VERSION.tar.gz | tar xvz \
+  && cd aws-ofi-nccl-$AWS_OFI_NCCL_VERSION \
   && ./configure --prefix=/opt/aws-ofi-nccl/install \
     --with-mpi=/opt/amazon/openmpi \
     --with-libfabric=/opt/amazon/efa \
@@ -85,8 +85,8 @@ RUN cd tmp \
 # Install NCCL Tests
 ARG NCCL_TESTS_VERSION=2.13.10
 RUN cd /tmp \
-  && curl -sL https://github.com/NVIDIA/nccl-tests/archive/refs/tags/v${NCCL_TESTS_VERSION}.tar.gz | tar xvz \
-  && cd nccl-tests-${NCCL_TESTS_VERSION} \
+  && curl -sL https://github.com/NVIDIA/nccl-tests/archive/refs/tags/v$NCCL_TESTS_VERSION.tar.gz | tar xvz \
+  && cd nccl-tests-$NCCL_TESTS_VERSION \
   && make MPI=1 \
     MPI_HOME=/opt/amazon/openmpi5/ \
     CUDA_HOME=/usr/local/cuda \

--- a/e2e2/test/images/nvidia/gpu_unit_tests/bash_unit
+++ b/e2e2/test/images/nvidia/gpu_unit_tests/bash_unit
@@ -286,6 +286,9 @@ run_tests() {
       declare -F | "$GREP" ' setup$' >/dev/null && setup
       __bash_unit_test_skipped__=$(mktemp)
       trap "$RM  -f \"$stdout\" \"$stderr\"" EXIT
+      if [[ -n "$skip_pattern" && ("$test" =~ $skip_pattern) ]]; then
+        skip "$test as specified in skip pattern: $skip_pattern"
+      fi
       (__bash_unit_current_test__="$test" run_test) || status=$?
       test -s $__bash_unit_test_skipped__ && status=0
       declare -F | "$GREP" ' teardown$' >/dev/null && teardown
@@ -311,9 +314,10 @@ run_teardown_suite() {
 
 usage() {
   echo "$1" >&2
-  echo "$0 [-f <output format>] [-p <pattern1>] [-p <pattern2>] [-r] ... <test_file1> <test_file2> ..." >&2
+  echo "$0 [-f <output format>] [-p <pattern1>] [-p <pattern2>] [-s <skip_pattern>] [-r] ... <test_file1> <test_file2> ..." >&2
   echo >&2
   echo "Runs tests in test files that match <pattern>s" >&2
+  echo "Skip tests in test files that match <skip_pattern>s" >&2
   echo "<output format> is optional only supported value is tap" >&2
   echo "-r to execute test cases in random order" >&2
   echo "-v to get current version information" >&2
@@ -533,14 +537,19 @@ tap_format() {
 
 output_format=text
 test_pattern=""
+skip_pattern=""
 trace_file=""
 separator=""
 randomise=0
-while getopts "vp:t:f:r" option
+while getopts "vp:t:f:r:s" option
 do
   case "$option" in
     p)
       test_pattern="${test_pattern}${separator}${OPTARG}"
+      separator="|"
+      ;;
+    s)
+      skip_pattern="${skip_pattern}${separator}${OPTARG}"
       separator="|"
       ;;
     t)

--- a/e2e2/test/images/nvidia/gpu_unit_tests/unit_test
+++ b/e2e2/test/images/nvidia/gpu_unit_tests/unit_test
@@ -4,5 +4,6 @@ TRACE_LOG=trace.log
 TEST_TIMEOUT=1800
 BASH="/usr/bin/bash"
 CURRENT_DIR=$(pwd)
+SKIP_TESTS_SUBCOMMAND=${SKIP_TESTS_SUBCOMMAND:-""}
 
-timeout -k 10 ${TEST_TIMEOUT} ${BASH} gpu_unit_tests/bash_unit -f tap -t gpu_unit_tests/${TRACE_LOG} gpu_unit_tests/tests/*test*.sh
+timeout -k 10 ${TEST_TIMEOUT} ${BASH} gpu_unit_tests/bash_unit -f tap ${SKIP_TESTS_SUBCOMMAND} -t gpu_unit_tests/${TRACE_LOG} gpu_unit_tests/tests/*test*.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Issue 1:
Build failed in CodeBuild 
```
Step 17/26 : ARG NCCL_VERSION=2.22.3-1+cuda${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}
 ---> Running in 1a06f4ac470e
Removing intermediate container 1a06f4ac470e
 ---> 07cde702fb9b
Step 18/26 : RUN apt update   && apt install -y     libnccl2=${NCCL_VERSION}      libnccl-dev=${NCCL_VERSION}
...
E: Version '2.22.3-1' for 'libnccl2' was not found
E: Version '2.22.3-1' for 'libnccl-dev' was not found
The command '/bin/sh -c apt update   && apt install -y     libnccl2=${NCCL_VERSION}      libnccl-dev=${NCCL_VERSION}' returned a non-zero code: 100
```
temp fix by hardcode it

Issue 2:
The unit test `test_nvidia_persistence_status` is failing on Bottlerocket as it is not enabled, there are an incoming release will fix it. But extending a flag to skip tests for flexibility 

Testing with below
```
---
kind: Job
apiVersion: batch/v1
metadata:
  name: unit-test-job
  labels:
    app: unit-test-job
spec:
  template:
    metadata:
      labels:
        app: unit-test-job
    spec:
      containers:
        - name: unit-test-container
          image: "171391670848.dkr.ecr.us-west-2.amazonaws.com/test-images:nvtest-withSkip"
          command:
            - /bin/bash
            - ./gpu_unit_tests/unit_test
          env:
            - name: SKIP_TESTS_SUBCOMMAND
              value: "-s test_05_dcgm_diagnostics|test_nvidia_persistence_status"
          imagePullPolicy: Always
          resources:
            limits:
              cpu: "4"
              memory: 4Gi
              nvidia.com/gpu: "1"
            requests:
              cpu: "1"
              memory: 1Gi
      restartPolicy: Never
  backoffLimit: 4
```

Output
```
k logs unit-test-job-77xkh -f
# Running tests in gpu_unit_tests/tests/test_basic.sh
ok - test_01_device_query
ok - test_02_vector_add
ok - test_03_bandwidth
ok - test_04_bus_grind
ok -  # skip skip pattern: test_05_dcgm_diagnostics|test_nvidia_persistence_status
# Running tests in gpu_unit_tests/tests/test_sysinfo.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:02:02 --:--:--     0
curl: (56) Recv failure: Connection reset by peer
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    10  100    10    0     0  13717      0 --:--:-- --:--:-- --:--:-- 10000
ok - test_numa_topo_topo
ok - test_nvidia_gpu_count
ok - test_nvidia_gpu_throttled
ok - test_nvidia_gpu_unused
ok -  # skip skip pattern: test_05_dcgm_diagnostics|test_nvidia_persistence_status
ok - test_nvidia_smi_topo
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
