### PR TITLE
fix: Expose all 32 EFA interfaces on p5 launch template

### DIFF
--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
@@ -239,7 +239,43 @@ Resources:
               Groups:
                 - !Ref EFASecurityGroup
             - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 1
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 2
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 3
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
               NetworkCardIndex: 4
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 5
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 6
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 7
               DeviceIndex: 1
               InterfaceType: efa
               Groups:
@@ -251,7 +287,43 @@ Resources:
               Groups:
                 - !Ref EFASecurityGroup
             - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 9
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 10
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 11
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
               NetworkCardIndex: 12
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 13
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 14
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 15
               DeviceIndex: 1
               InterfaceType: efa
               Groups:
@@ -263,7 +335,43 @@ Resources:
               Groups:
                 - !Ref EFASecurityGroup
             - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 17
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 18
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 19
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
               NetworkCardIndex: 20
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 21
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 22
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 23
               DeviceIndex: 1
               InterfaceType: efa
               Groups:
@@ -275,7 +383,43 @@ Resources:
               Groups:
                 - !Ref EFASecurityGroup
             - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 25
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 26
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 27
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
               NetworkCardIndex: 28
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 29
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 30
+              DeviceIndex: 1
+              InterfaceType: efa
+              Groups:
+                - !Ref EFASecurityGroup
+            - Description: NetworkInterfaces Configuration For EFA and EKS
+              NetworkCardIndex: 31
               DeviceIndex: 1
               InterfaceType: efa
               Groups:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Expose all 32 EFA interfaces on p5 launch template

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
