### PR TITLE
Add support for static cluster

### DIFF
--- a/kubetest2/internal/deployers/eksapi/infra.go
+++ b/kubetest2/internal/deployers/eksapi/infra.go
@@ -168,6 +168,7 @@ func (m *InfrastructureManager) createInfrastructureStack(opts *deployerOptions)
 		return nil, fmt.Errorf("failed to get infrastructure stack resources: %w", err)
 	}
 	klog.Infof("created infrastructure: %+v", infra)
+
 	return infra, nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add support for existing cluster

Testing:

```
kubetest2 eksapi --up --down --static-cluster-name=static-kubetest2-cluster --node-role-arn arn:aws:iam::xxx:role/NodeRole \
 --endpoint-url https://api.beta.us-west-2.wesley.amazonaws.com \
 --user-data-format=bottlerocket --generate-ssh-key \
 --emit-metrics --unmanaged-nodes --node-name-strategy=SessionName \
 --ami=ami-0f788954ca6a52fba --kubernetes-version=1.29 --nodes=2 --instance-types=inf2.xlarge 
```

```
I1021 04:06:44.667431      14 app.go:61] The files in RunDir shall not be part of Artifacts
I1021 04:06:44.667520      14 app.go:62] pass rundir-in-artifacts flag True for RunDir to be part of Artifacts
I1021 04:06:44.667545      14 app.go:64] RunDir for this run: "/workdir/_rundir/48d0e01a-c50c-4834-9937-fa1a667d5065"
I1021 04:06:44.670597      14 app.go:136] ID for this run: "48d0e01a-c50c-4834-9937-fa1a667d5065"
I1021 04:06:44.670809      14 ssh.go:56] Generating SSH key: /root/.ssh/id_rsa
I1021 04:06:44.773271      14 infra.go:92] getting infrastructure resource for static cluster: static-kubetest2-cluster
I1021 04:06:45.175135      14 cluster.go:72] reusing existing static cluster static-kubetest2-cluster
I1021 04:06:45.175166      14 cluster.go:85] waiting for cluster to be active: static-kubetest2-cluster
I1021 04:06:45.474045      14 cluster.go:91] cluster details after creation: &{AccessConfig:0xc0008120c0 Arn:0xc000816210 CertificateAuthority:0xc0008162b0 ClientRequestToken:<nil> ConnectorConfig:<nil> CreatedAt:2024-10-18 23:00:46.75 +0000 UTC EncryptionConfig:[] Endpoint:0xc000816220 Health:0xc0008120e0 Id:<nil> Identity:0xc0008162e0 KubernetesNetworkConfig:0xc00080c420 Logging:0xc000812080 Name:0xc0008162d0 OutpostConfig:<nil> PlatformVersion:0xc000816200 ResourcesVpcConfig:0xc000406000 RoleArn:0xc000816230 Status:ACTIVE Tags:map[] Version:0xc000816290 noSmithyDocumentSerde:{}}
I1021 04:06:45.474131      14 cluster.go:95] cluster is active: arn:aws:eks:us-west-2:xxx:cluster/static-kubetest2-cluster
I1021 04:06:45.474190      14 kubeconfig.go:49] writing kubeconfig to /workdir/_rundir/48d0e01a-c50c-4834-9937-fa1a667d5065/kubeconfig for cluster: arn:aws:eks:us-west-2:xxx:cluster/static-kubetest2-cluster
I1021 04:06:45.474460      14 kubeconfig.go:73] wrote kubeconfig: /workdir/_rundir/48d0e01a-c50c-4834-9937-fa1a667d5065/kubeconfig
---
apiVersion: v1
kind: Config
clusters:
- cluster:
    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lJVDZHV21GUEgyaDR3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TkRFd01UZ3lNalU1TkRkYUZ3MHpOREV3TVRZeU16QTBORGRhTUJVeApFekFSQmdOVkJBTVRDbXQxWW1WeWJtVjBaWE13Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURvVlZHaVcvK0dyd3U0SkVrNllHYmlVQ1ZWVlZISDN0Mjd3bkllUnpzUG1QQzZaR0M4TjNPSUZSVVEKbmNVWlcydXRLOFZvNkFWYzRWbk9wazIwM0pyTkVUZGp0Q1F1emR4YjE2OWVoNFAwQnpSaXMrME9FM1hXalRveQpDMGg0WXNJQXdTSnUrY2dZUG14emdOWDJxRXNrYVVTY3F2MjhnQzNpYllIT09sREtkREh2WGFVT29DSWZ0dm9SCmR1bmNucGpWT0d4TWVZZkt2ZjF5c3U4YUg0VEpPdlRQS3lWQSt5NWkzVXBwRDJVenNDRU1XQ0YzbVphYytGdi8KbTZLb1VibDVXZWlDUHk4QXNjOHpXZFAxcGQ4TmJuUnlhb2tHVEU5d1ozWjFSanU2anZiT0J4MTYzc2hSaVZiNQpKb2ZaRkJHV0tENjBVZWtPd2ZQWGtwdDFSMk96QWdNQkFBR2pXVEJYTUE0R0ExVWREd0VCL3dRRUF3SUNwREFQCkJnTlZIUk1CQWY4RUJUQURBUUgvTUIwR0ExVWREZ1FXQkJTazhzTWJJZFJSMEFxWG8xNHdOdVc2OHllWXpqQVYKQmdOVkhSRUVEakFNZ2dwcmRXSmxjbTVsZEdWek1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ3ZZV3dQd291NgoycEFkUGoxSVJvaGdxVXVXUCtwSkNpcFo3TE1VdlVyZ3JDYjF0d051OURReGdUM2N4d1puTUFNWWwzSEt2MGZoCk5tU3VpZHJudlpaTjc1UFVVenByd1BqcTdLVVNuTURoeGR2aXJub2dSTlFTUnowdnRQdE50TE9uYkcvd0IvMVAKaGF5NDEvK1ZOc2RKd2JsQTdqaVZWODB2a3ZuS3dwQnorUEZOemVEdWx4ZFBiTmYwbDFLdXViRGlvK1ZVcHFRMgpISkI4Z2FianZmeUVsbksrRURxaTB3aG91RW9vVy82YWlhYVRvb0t4UU5QSDFkL1lXa0lwNGdkc1dqamNRYnFmCmMzeUdXdDZtRHBlcUgxR0c4UENYa29ZWElNdzZSNHIzdDVld3ZPWDRRaHZta3FiSm93RlZZTUh0MzNCa01aNXMKd2Zwck95cEtXMjhiCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    server: https://8D6D8816FBACCF255903080EE5A9F34F.sk1.beta.us-west-2.clusters.wesley.amazonaws.com
  name: arn:aws:eks:us-west-2:xxx:cluster/static-kubetest2-cluster
contexts:
- context:
    cluster: arn:aws:eks:us-west-2:xxx:cluster/static-kubetest2-cluster
    user: arn:aws:eks:us-west-2:xxx:cluster/static-kubetest2-cluster
  name: arn:aws:eks:us-west-2:xxx:cluster/static-kubetest2-cluster
current-context: arn:aws:eks:us-west-2:xxx:cluster/static-kubetest2-cluster
preferences: {}
users:
- name: arn:aws:eks:us-west-2:xxx:cluster/static-kubetest2-cluster
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1beta1
      command: aws
      args:
      - eks
      - get-token
      - --cluster-name
      - static-kubetest2-cluster
I1021 04:06:45.476239      14 nodegroup.go:159] creating unmanaged nodegroup stack...
I1021 04:06:45.687325      14 nodegroup.go:237] waiting for unmanaged nodegroup to be created: arn:aws:cloudformation:us-west-2:xxx:stack/static-kubetest2-cluster-48d0e01a-c50c-4834-9937-fa1a667d5065-unmanaged-nodegroup/e3072270-8f61-11ef-be1c-06d15b760715
I1021 04:10:51.051365      14 nodegroup.go:247] created unmanaged nodegroup stack: arn:aws:cloudformation:us-west-2:xxx:stack/static-kubetest2-cluster-48d0e01a-c50c-4834-9937-fa1a667d5065-unmanaged-nodegroup/e3072270-8f61-11ef-be1c-06d15b760715
I1021 04:10:51.051394      14 nodegroup.go:440] verifying AMI is ami-0f788954ca6a52fba for ASG: static-kubetest2-cluster-48d0e01a-c50c-4834-9937-fa1a667d5065
I1021 04:10:51.178986      14 nodegroup.go:454] verifying AMI for instances: [i-0bcc594ce1ad637c8 i-0d3e8ebf524272d45]
I1021 04:10:51.282233      14 nodegroup.go:472] ASG instances are using expected AMI: ami-0f788954ca6a52fba
I1021 04:10:51.282254      14 k8s.go:33] waiting up to 5m0s for 2 node(s) to be ready...
I1021 04:10:52.777403      14 k8s.go:74] 2 node(s) are ready: map[i-0bcc594ce1ad637c8:{} i-0d3e8ebf524272d45:{}]
I1021 04:10:53.004309      14 nodegroup.go:411] deleting unmanaged nodegroup stack: static-kubetest2-cluster-48d0e01a-c50c-4834-9937-fa1a667d5065-unmanaged-nodegroup
I1021 04:10:53.180843      14 nodegroup.go:421] waiting for unmanaged nodegroup stack to be deleted: static-kubetest2-cluster-48d0e01a-c50c-4834-9937-fa1a667d5065-unmanaged-nodegroup
I1021 04:23:13.886211      14 nodegroup.go:431] deleted unmanaged nodegroup stack: static-kubetest2-cluster-48d0e01a-c50c-4834-9937-fa1a667d5065-unmanaged-nodegroup
I1021 04:23:13.886258      14 nodegroup.go:383] deleting nodegroup...
I1021 04:23:13.973044      14 nodegroup.go:388] nodegroup does not exist: static-kubetest2-cluster-48d0e01a-c50c-4834-9937-fa1a667d5065
I1021 04:23:13.996880      14 cloudwatch.go:79] emitted 5 metrics to namespace: kubetest2/eksapi
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
