### PR TITLE
Add osDistro metric dimension

### DIFF
--- a/kubetest2/internal/deployers/eksapi/k8s.go
+++ b/kubetest2/internal/deployers/eksapi/k8s.go
@@ -172,6 +172,19 @@ func emitNodeMetrics(metricRegistry metrics.MetricRegistry, k8sClient *kubernete
 			"arch":         node.Status.NodeInfo.Architecture,
 		}
 
+		var osDistro string
+		if strings.HasPrefix(node.Status.NodeInfo.OSImage, "Amazon Linux") {
+			// on al2: "Amazon Linux 2"
+			// on al2023: "Amazon Linux 2023.6.20241010"
+			parts := strings.Split(node.Status.NodeInfo.OSImage, ".")
+			amazonLinuxMajorVersion := parts[0]
+			osDistro = amazonLinuxMajorVersion
+		}
+
+		if osDistro != "" {
+			nodeDimensions["osDistro"] = osDistro
+		}
+
 		metricRegistry.Record(nodeTimeToRegistrationSeconds, timeToRegistration.Seconds(), nodeDimensions)
 		metricRegistry.Record(nodeTimeToReadySeconds, timeToReady.Seconds(), nodeDimensions)
 	}


### PR DESCRIPTION
*Description of changes:*

This adds an `osDistro` dimension to the Node metrics, for `osImage` values that start with `Amazon Linux`.

For AL2, `osImage` is always `Amazon Linux 2`. But for AL2023, it's the release-specific `Amazon Linux 2023.6.20241010`. This PR adds an `osDistro` dimension that will be `Amazon Linux 2`, `Amazon Linux 2023`, `Amazon Linux 2025`, etc. to make aggregate cloudwatch queries easier.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
