### PR TITLE
Ensure node for static cluster

### DIFF
--- a/kubetest2/internal/deployers/eksapi/templates/busybox_deployment.yaml.template
+++ b/kubetest2/internal/deployers/eksapi/templates/busybox_deployment.yaml.template
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox-deployment
+spec:
+  replicas: {{.Nodes}}
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - busybox
+            topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: busybox
+        image: busybox
+        command: ["sleep", "infinity"]

--- a/kubetest2/internal/deployers/eksapi/templates/templates.go
+++ b/kubetest2/internal/deployers/eksapi/templates/templates.go
@@ -22,6 +22,10 @@ type UnmanagedNodegroupTemplateData struct {
 	InstanceTypes     []string
 }
 
+type BusyboxDeploymentTemplateData struct {
+	Nodes int
+}
+
 var (
 	//go:embed userdata_bootstrap.sh.mimepart.template
 	userDataBootstrapShTemplate string
@@ -34,6 +38,10 @@ var (
 	//go:embed userdata_bottlerocket.toml.template
 	userDataBottlerocketTemplate string
 	UserDataBottlerocket         = template.Must(template.New("userDataBottlerocket").Parse(userDataBottlerocketTemplate))
+
+	//go:embed busybox_deployment.yaml.template
+	busyboxDeploymentTemplate string
+	BusyboxDeployment         = template.Must(template.New("busyboxDeployment").Parse(busyboxDeploymentTemplate))
 )
 
 type UserDataTemplateData struct {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For static cluster, use dummy busybox to ensure the node to be ready before e2e test and teardown them after test

## Testing 
```
kubetest2 eksapi --up --down --static-cluster-name=129-static-cluster --test=multi -- --fail-fast=false -- ginkgo --use-binaries-from-path --parallel=6 --ginkgo-args='--no-color' --focus-regex='\[Conformance\]' --skip-regex='\[Serial\]|\[Disruptive\]|\[Slow\]|Garbage.collector'
...
Ran 347 of 7407 Specs in 792.495 seconds
SUCCESS! -- 347 Passed | 0 Failed | 0 Pending | 7060 Skipped

I1101 18:13:18.967304      76 deployer.go:392] Waiting for nodes to be removed: Current node count: 0
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
