### PR TITLE
make the inbound security rule for SSH a no-op

### DIFF
--- a/kubetest2/internal/deployers/eksapi/templates/infra.yaml
+++ b/kubetest2/internal/deployers/eksapi/templates/infra.yaml
@@ -496,7 +496,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          CidrIp: 0.0.0.0/0
+          CidrIp: 127.0.0.1/32
 
   SSHKeyPair:
     Type: AWS::EC2::KeyPair


### PR DESCRIPTION
By default this won't allow access, but can easily be hacked on to enable SSH for testing.

*Issue #, if available:*

*Description of changes:*
make the inbound security rule for SSH a no-op

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
