### PR TITLE
Add trn2.48xlarge, set workdir to /home/ubuntu in neuron container image

### DIFF
--- a/e2e2/test/cases/neuron/manifests/efa-device-plugin.yaml
+++ b/e2e2/test/cases/neuron/manifests/efa-device-plugin.yaml
@@ -145,6 +145,7 @@ spec:
                     - p5e.48xlarge
                     - trn1.32xlarge
                     - trn1n.32xlarge
+                    - trn2.48xlarge
                     - vt1.24xlarge
                     - hpc6a.48xlarge
                     - hpc6id.32xlarge

--- a/e2e2/test/cases/neuron/manifests/k8s-neuron-device-plugin.yml
+++ b/e2e2/test/cases/neuron/manifests/k8s-neuron-device-plugin.yml
@@ -50,6 +50,7 @@ spec:
               #        - trn1.2xlarge
               #        - trn1.32xlarge
               #        - trn1n.32xlarge
+              #        - trn2.48xlarge
               - matchExpressions:
                   - key: "node.kubernetes.io/instance-type"
                     operator: In
@@ -65,6 +66,7 @@ spec:
                       - trn1.2xlarge
                       - trn1.32xlarge
                       - trn1n.32xlarge
+                      - trn2.48xlarge
       containers:
         # Find all neuron-device-plugin images at https://gallery.ecr.aws/neuron/neuron-device-plugin
       - image: public.ecr.aws/neuron/neuron-device-plugin:2.19.16.0

--- a/e2e2/test/cases/nvidia/manifests/efa-device-plugin.yaml
+++ b/e2e2/test/cases/nvidia/manifests/efa-device-plugin.yaml
@@ -146,6 +146,7 @@ spec:
                     - p5en.48xlarge
                     - trn1.32xlarge
                     - trn1n.32xlarge
+                    - trn2.48xlarge
                     - vt1.24xlarge
                     - hpc6a.48xlarge
                     - hpc6id.32xlarge

--- a/e2e2/test/images/neuron/Dockerfile
+++ b/e2e2/test/images/neuron/Dockerfile
@@ -189,6 +189,8 @@ RUN curl -o /license.txt  https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.1/
 # Allow ssh to work without password/prompt so mpirun does not get stuck
 RUN sed -i -e 's/#   StrictHostKeyChecking ask/    StrictHostKeyChecking accept-new/g' /etc/ssh/ssh_config
 
+WORKDIR /home/ubuntu
+
 USER ubuntu
 RUN mkdir /home/ubuntu/.ssh
 RUN ssh-keygen -t rsa -f /home/ubuntu/.ssh/id_rsa -N ''

--- a/eks/neuron/neuron.go
+++ b/eks/neuron/neuron.go
@@ -157,6 +157,7 @@ spec:
                       - inf1.24xlarge
                       - trn1.2xlarge
                       - trn1.32xlarge
+                      - trn2.48xlarge
               - matchExpressions:
                   - key: "node.kubernetes.io/instance-type"
                     operator: In
@@ -167,6 +168,7 @@ spec:
                       - inf1.24xlarge
                       - trn1.2xlarge
                       - trn1.32xlarge
+                      - trn2.48xlarge
       containers:
         - image: public.ecr.aws/neuron/neuron-device-plugin:1.9.3.0
           imagePullPolicy: IfNotPresent

--- a/eks/trainium/trainium.go
+++ b/eks/trainium/trainium.go
@@ -156,6 +156,7 @@ spec:
                       - inf1.24xlarge
                       - trn1.2xlarge
                       - trn1.32xlarge
+                      - trn2.48xlarge
               - matchExpressions:
                   - key: "node.kubernetes.io/instance-type"
                     operator: In
@@ -166,6 +167,7 @@ spec:
                       - inf1.24xlarge
                       - trn1.2xlarge
                       - trn1.32xlarge
+                      - trn2.48xlarge
       containers:
         - image: public.ecr.aws/neuron/neuron-device-plugin:1.9.3.0
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
*Issue #, if available:*

* Add `trn2.48xlarge`
* Set workdir to /home/ubuntu in container image for neuron. Alleviates in issue where programs that try to write to the working directory are hit with irreconcilable permission denied errors due to the attempt to write to the root directory.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
