### PR TITLE
Create placeholder deployment for Auto clusters if --nodes > 0

### DIFF
--- a/kubetest2/internal/deployers/eksapi/janitor.go
+++ b/kubetest2/internal/deployers/eksapi/janitor.go
@@ -66,9 +66,9 @@ func (j *janitor) Sweep(ctx context.Context) error {
 			clients := j.awsClientsForStack(stack)
 			infraManager := NewInfrastructureManager(clients, resourceID, j.metrics)
 			clusterManager := NewClusterManager(clients, resourceID)
-			nodegroupManager := NewNodegroupManager(clients, resourceID)
+			nodeManager := NewNodeManager(clients, resourceID)
 			klog.Infof("deleting resources (%v old): %s", resourceAge, resourceID)
-			if err := deleteResources(infraManager, clusterManager, nodegroupManager); err != nil {
+			if err := deleteResources(infraManager, clusterManager, nodeManager); err != nil {
 				errs = append(errs, fmt.Errorf("failed to delete resources: %s: %v", resourceID, err))
 			}
 		}

--- a/kubetest2/internal/deployers/eksapi/logs.go
+++ b/kubetest2/internal/deployers/eksapi/logs.go
@@ -39,6 +39,11 @@ func (m *logManager) gatherLogsFromNodes(k8sClient *kubernetes.Clientset, opts *
 		klog.Info("--log-bucket is empty, no logs will be gathered!")
 		return nil
 	}
+	// TODO: gather logs from Auto nodes
+	if opts.AutoMode {
+		klog.Info("--auto-mode was used, no logs will be gathered!")
+		return nil
+	}
 	switch opts.UserDataFormat {
 	case "bootstrap.sh", "nodeadm", "": // if no --user-data-format was passed, we must be using managed nodes, which default to AL-based AMIs
 		return m.gatherLogsUsingScript(k8sClient, opts, phase)


### PR DESCRIPTION
*Description of changes:*

This refactors the `NodegroupManager` into a more general `NodeManager` that supports EKS Auto. A "placeholder" deployment will be created that makes the `--nodes` flag effective when `--auto-mode` is used.

There's a similar thing being done for `--static-cluster-name`. That will be removed in later PR's; I haven't touched that behavior so that CI jobs can be migrated without breakage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
