### PR TITLE
add(kubetest2/eksapi): Add EFA Support for trn1.32xlarge Instances

### DIFF
--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
@@ -64,6 +64,8 @@ Conditions:
     !Equals [Ref: InstanceType, p4d.24xlarge]
   IsP5Node:
     !Equals [Ref: InstanceType, p5.48xlarge]
+  IsTRN1Node:
+    !Equals [Ref: InstanceType, trn1.32xlarge]
   IsCapacityReservationIdSet: 
     !Not [!Equals [!Ref CapacityReservationId, ""]]
   IsUserDataMIMEPart:
@@ -455,6 +457,57 @@ Resources:
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 0
                 DeviceIndex: 0
+                InterfaceType: efa
+                Groups:
+                  - !Ref EFASecurityGroup
+          !If
+            - IsTRN1Node
+            - 
+              - Description: NetworkInterfaces Configuration For EFA and EKS
+                NetworkCardIndex: 0
+                DeviceIndex: 0
+                InterfaceType: efa
+                Groups:
+                  - !Ref EFASecurityGroup
+              - Description: NetworkInterfaces Configuration For EFA and EKS
+                NetworkCardIndex: 1
+                DeviceIndex: 1
+                InterfaceType: efa
+                Groups:
+                  - !Ref EFASecurityGroup
+              - Description: NetworkInterfaces Configuration For EFA and EKS
+                NetworkCardIndex: 2
+                DeviceIndex: 2
+                InterfaceType: efa
+                Groups:
+                  - !Ref EFASecurityGroup
+              - Description: NetworkInterfaces Configuration For EFA and EKS
+                NetworkCardIndex: 3
+                DeviceIndex: 3
+                InterfaceType: efa
+                Groups:
+                  - !Ref EFASecurityGroup
+              - Description: NetworkInterfaces Configuration For EFA and EKS
+                NetworkCardIndex: 4
+                DeviceIndex: 4
+                InterfaceType: efa
+                Groups:
+                  - !Ref EFASecurityGroup
+              - Description: NetworkInterfaces Configuration For EFA and EKS
+                NetworkCardIndex: 5
+                DeviceIndex: 5
+                InterfaceType: efa
+                Groups:
+                  - !Ref EFASecurityGroup
+              - Description: NetworkInterfaces Configuration For EFA and EKS
+                NetworkCardIndex: 6
+                DeviceIndex: 6
+                InterfaceType: efa
+                Groups:
+                  - !Ref EFASecurityGroup
+              - Description: NetworkInterfaces Configuration For EFA and EKS
+                NetworkCardIndex: 7
+                DeviceIndex: 7
                 InterfaceType: efa
                 Groups:
                   - !Ref EFASecurityGroup


### PR DESCRIPTION
*Description of changes:*
This PR enhances the unmanaged-nodegroup-efa.yaml CloudFormation template to support trn1.32xlarge instances with 8 EFA-enabled network interfaces. Key changes include:

 * New Condition: Added IsTRN1Node to detect when InstanceType is trn1.32xlarge.
 *  EFA Configuration: Configured 8 EFA interfaces for trn1.32xlarge under NodeLaunchTemplate.
 * Backward Compatibility: Ensured P4 and P5 instance logic remains unchanged.

These changes enable EKS unmanaged node groups to leverage the full EFA capacity of trn1.32xlarge instances

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
