### PR TITLE
fix(kubetest2): Fix YAML syntax issue in unmanaged-nodegroup-efa.yaml for !If conditional block

### DIFF
--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
@@ -460,7 +460,7 @@ Resources:
                 InterfaceType: efa
                 Groups:
                   - !Ref EFASecurityGroup
-          !If
+          - !If
             - IsTRN1Node
             - 
               - Description: NetworkInterfaces Configuration For EFA and EKS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes a YAML syntax issue in the unmanaged-nodegroup-efa.yaml file. The issue was caused by an incorrect indentation and missing list marker for the !If conditional block. 

**Changes made:**
- Added the missing `-` to properly denote the start of the !If block list.
- Ensured proper alignment of the nested block under the !If condition for `IsTRN1Node`.

This fix resolves the "YAML not well-formed" CloudFormation validation error (line 464, column 13) encountered during stack creation with EFA-enabled unmanaged nodegroups.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
