### PR TITLE
handle the nil pointer exception in writeKubeconfig when no cluster r…

### DIFF
--- a/kubetest2/internal/deployers/eksapi/kubeconfig.go
+++ b/kubetest2/internal/deployers/eksapi/kubeconfig.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"text/template"
+	"fmt"
 
 	"k8s.io/klog"
 )
@@ -46,6 +47,9 @@ type kubeconfigTemplateParameters struct {
 }
 
 func writeKubeconfig(cluster *Cluster, kubeconfigPath string) error {
+	if cluster == nil {
+		return fmt.Errorf("Cluster is nil, you might need set --static-cluster-name or set --up to initial cluster resrouces")
+	}
 	klog.Infof("writing kubeconfig to %s for cluster: %s", kubeconfigPath, cluster.arn)
 	templateParams := kubeconfigTemplateParameters{
 		ClusterCertificateAuthority: cluster.certificateAuthorityData,


### PR DESCRIPTION
*Issue #, if available:*
* Handle the nil pointer exception in writeKubeconfig method when we didn't set --up flag and --static-cluster-name in kubetest2 command and the cluster pass to writeKubeconfig will be nil.