### PR TITLE
handle EFA security group eni leakage

### DIFF
--- a/kubetest2/internal/deployers/eksapi/node.go
+++ b/kubetest2/internal/deployers/eksapi/node.go
@@ -567,6 +567,20 @@ func (m *nodeManager) deleteUnmanagedNodegroup() error {
 		}
 		return fmt.Errorf("failed to delete unmanaged nodegroup stack: %w", err)
 	}
+
+	efaSecurityGroupID, err := m.getEFASecurityGroupIDFromStack(stackName)
+	if err != nil {
+		return fmt.Errorf("failed to get EFASecurityGroup ID from stack: %w", err)
+	}
+	
+	if efaSecurityGroupID != "" {
+		klog.Infof("clean up leakage ENIs in EFA Security Group")
+		err = m.cleanupLeakageENIs(efaSecurityGroupID)
+		if err != nil {
+			return fmt.Errorf("failed to wait for ASG deletion: %w", err)
+		}
+	}
+
 	klog.Infof("waiting for unmanaged nodegroup stack to be deleted: %s", stackName)
 	err = cloudformation.NewStackDeleteCompleteWaiter(m.clients.CFN()).
 		Wait(context.TODO(),
@@ -579,6 +593,100 @@ func (m *nodeManager) deleteUnmanagedNodegroup() error {
 	}
 	klog.Infof("deleted unmanaged nodegroup stack: %s", stackName)
 	return nil
+}
+
+func (m *nodeManager) cleanupLeakageENIs(efaSecurityGroupID string) error {
+	klog.Infof("waiting for ASG in stack to be deleted: %s", m.resourceID)
+	err := m.waitForASGDeletion(m.resourceID)
+	if err != nil {
+		return fmt.Errorf("failed to wait for ASG deletion: %w", err)
+	}
+
+	klog.Infof("cleaning up ENIs attached to EFASecurityGroup: %s", efaSecurityGroupID)
+	err = m.cleanupEFASecurityGroupENIs(efaSecurityGroupID)
+	if err != nil {
+		return fmt.Errorf("failed to clean up EFASecurityGroup ENIs: %w", err)
+	}
+	return nil
+}
+
+func (m *nodeManager) waitForASGDeletion(asgName string) error {
+	for {
+		deleted, err := m.isASGDeleted(m.resourceID)
+		if err != nil {
+			return fmt.Errorf("failed to wait for ASG Deletion: %w", err)
+		} else if deleted {
+			return nil
+		}
+		time.Sleep(10 * time.Second)
+	}
+}
+
+func (m *nodeManager) isASGDeleted(asgName string) (bool, error) {
+	asgOutput, err := m.clients.ASG().DescribeAutoScalingGroups(context.TODO(), &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []string{asgName},
+	})
+	if err != nil  {
+		return false, fmt.Errorf("failed to describe ASG: %w", err)
+	} else if len(asgOutput.AutoScalingGroups) == 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (m *nodeManager) cleanupEFASecurityGroupENIs(efaSecurityGroupID string) error {
+	enis, err := m.getSecurityGroupNetworkInterfaceIds(efaSecurityGroupID)
+	if err != nil {
+		return fmt.Errorf("failed to describe ENIs: %w", err)
+	}
+
+	for _, eni := range enis {
+		klog.Infof("deleting leaked ENI: %s", eni)
+		_, err := m.clients.EC2().DeleteNetworkInterface(context.TODO(), &ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: aws.String(eni),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to delete leaked ENI: %w", err)
+		}
+	}
+	klog.Infof("deleted %d leaked ENI(s) attached to EFA security group!", len(enis))
+	return nil
+}
+
+func (m *nodeManager) getSecurityGroupNetworkInterfaceIds(efaSecurityGroupID string) ([]string, error) {
+	output, err := m.clients.EC2().DescribeNetworkInterfaces(context.TODO(), &ec2.DescribeNetworkInterfacesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   aws.String("group-id"),
+				Values: []string{efaSecurityGroupID},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe ENIs: %w", err)
+	}
+
+	var enis []string
+	for _, eni := range output.NetworkInterfaces {
+		enis = append(enis, *eni.NetworkInterfaceId)
+	}
+	return enis, nil
+}
+
+func (m *nodeManager) getEFASecurityGroupIDFromStack(stackName string) (string, error) {
+	describeInput := cloudformation.DescribeStackResourcesInput{
+		StackName: aws.String(stackName),
+	}
+	output, err := m.clients.CFN().DescribeStackResources(context.TODO(), &describeInput)
+	if err != nil {
+		return "", fmt.Errorf("failed to describe stack resources: %w", err)
+	}
+	for _, resource := range output.StackResources {
+		if *resource.LogicalResourceId == "EFASecurityGroup" {
+			return *resource.PhysicalResourceId, nil
+		}
+	}
+	return "", nil
 }
 
 func (m *nodeManager) getUnmanagedNodegroupStackName() string {

--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
@@ -64,114 +64,6 @@ Conditions:
   IsUserDataMIMEPart: !Equals [true, !Ref UserDataIsMIMEPart]
 
 Resources:
-  EFASecurityGroup:
-    Type: "AWS::EC2::SecurityGroup"
-    Properties:
-      GroupDescription: Security group for all nodes in the cluster
-      Tags:
-        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
-          Value: owned
-      VpcId: !Ref VpcId
-
-  EFASecurityGroupIngress:
-    Type: "AWS::EC2::SecurityGroupIngress"
-    DependsOn: EFASecurityGroup
-    Properties:
-      Description: Allow node to communicate with each other
-      FromPort: 0
-      ToPort: 65535
-      GroupId: !Ref EFASecurityGroup
-      IpProtocol: "-1"
-      SourceSecurityGroupId: !Ref EFASecurityGroup
-
-  EFASecurityGroupEgress:
-    Type: "AWS::EC2::SecurityGroupEgress"
-    DependsOn: EFASecurityGroup
-    Properties:
-      Description: Allow the efa worker nodes outbound communication
-      DestinationSecurityGroupId: !Ref EFASecurityGroup
-      FromPort: 0
-      ToPort: 65536
-      GroupId: !Ref EFASecurityGroup
-      IpProtocol: "-1"
-
-  EFASecurityGroupEgressAllIpv4:
-    Type: "AWS::EC2::SecurityGroupEgress"
-    DependsOn: EFASecurityGroup
-    Properties:
-      Description: Allow the efa worker nodes outbound communication
-      FromPort: 0
-      ToPort: 65536
-      CidrIp: "0.0.0.0/0"
-      GroupId: !Ref EFASecurityGroup
-      IpProtocol: "-1"
-
-  EFASecurityGroupEgressAllIpv6:
-    Type: "AWS::EC2::SecurityGroupEgress"
-    DependsOn: EFASecurityGroup
-    Properties:
-      Description: Allow the efa worker nodes outbound communication
-      FromPort: 0
-      ToPort: 65536
-      CidrIpv6: "::/0"
-      GroupId: !Ref EFASecurityGroup
-      IpProtocol: "-1"
-
-  EFASecurityGroupIngressControlPlane:
-    Type: "AWS::EC2::SecurityGroupIngress"
-    DependsOn: EFASecurityGroup
-    Properties:
-      Description: Allow pods to communicate with the cluster API Server
-      FromPort: 443
-      ToPort: 443
-      GroupId: !Ref SecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref EFASecurityGroup
-
-  EFASecurityGroupEgressControlPlane:
-    Type: "AWS::EC2::SecurityGroupEgress"
-    DependsOn: EFASecurityGroup
-    Properties:
-      Description: Allow the cluster control plane to communicate with worker Kubelet and pods
-      DestinationSecurityGroupId: !Ref EFASecurityGroup
-      FromPort: 1025
-      ToPort: 65535
-      GroupId: !Ref SecurityGroup
-      IpProtocol: tcp
-
-  ControlPlaneEgressToEFASecurityGroupOn443:
-    Type: "AWS::EC2::SecurityGroupEgress"
-    DependsOn: EFASecurityGroup
-    Properties:
-      Description: Allow the cluster control plane to communicate with pods running extension API servers on port 443
-      DestinationSecurityGroupId: !Ref EFASecurityGroup
-      FromPort: 443
-      ToPort: 443
-      GroupId: !Ref SecurityGroup
-      IpProtocol: tcp
-
-  EFASecurityGroupFromControlPlaneIngress:
-    Type: "AWS::EC2::SecurityGroupIngress"
-    DependsOn: EFASecurityGroup
-    Properties:
-      Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
-      FromPort: 1025
-      ToPort: 65535
-      GroupId: !Ref EFASecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref SecurityGroup
-
-  EFASecurityGroupFromControlPlaneOn443Ingress:
-    Type: "AWS::EC2::SecurityGroupIngress"
-    DependsOn: EFASecurityGroup
-    Properties:
-      Description: Allow pods running extension API servers on port 443 to receive communication from cluster control plane
-      FromPort: 443
-      ToPort: 443
-      GroupId: !Ref EFASecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref SecurityGroup
-
   NodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -209,224 +101,224 @@ Resources:
                 DeviceIndex: 0
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 1
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 2
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 3
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 4
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 5
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 6
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 7
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 8
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 9
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 10
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 11
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 12
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 13
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 14
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 15
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 16
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 17
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 18
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 19
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 20
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 21
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 22
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 23
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 24
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 25
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 26
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 27
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 28
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 29
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 30
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
               - Description: NetworkInterfaces Configuration For EFA and EKS
                 NetworkCardIndex: 31
                 DeviceIndex: 1
                 InterfaceType: efa
                 Groups:
-                  - !Ref EFASecurityGroup
+                  - !Ref SecurityGroup
                 DeleteOnTermination: true
             - Fn::If:
                 - IsP4Node
@@ -436,28 +328,28 @@ Resources:
                     DeviceIndex: 0
                     InterfaceType: efa
                     Groups:
-                      - !Ref EFASecurityGroup
+                      - !Ref SecurityGroup
                     DeleteOnTermination: true
                   - Description: NetworkInterfaces Configuration For EFA and EKS
                     NetworkCardIndex: 1
                     DeviceIndex: 1
                     InterfaceType: efa
                     Groups:
-                      - !Ref EFASecurityGroup
+                      - !Ref SecurityGroup
                     DeleteOnTermination: true
                   - Description: NetworkInterfaces Configuration For EFA and EKS
                     NetworkCardIndex: 2
                     DeviceIndex: 1
                     InterfaceType: efa
                     Groups:
-                      - !Ref EFASecurityGroup
+                      - !Ref SecurityGroup
                     DeleteOnTermination: true
                   - Description: NetworkInterfaces Configuration For EFA and EKS
                     NetworkCardIndex: 3
                     DeviceIndex: 1
                     InterfaceType: efa
                     Groups:
-                      - !Ref EFASecurityGroup
+                      - !Ref SecurityGroup
                     DeleteOnTermination: true
                 - Fn::If:
                     - IsTRN1Node
@@ -467,56 +359,56 @@ Resources:
                         DeviceIndex: 0
                         InterfaceType: efa
                         Groups:
-                          - !Ref EFASecurityGroup
+                          - !Ref SecurityGroup
                         DeleteOnTermination: true
                       - Description: NetworkInterfaces Configuration For EFA and EKS
                         NetworkCardIndex: 1
                         DeviceIndex: 1
                         InterfaceType: efa
                         Groups:
-                          - !Ref EFASecurityGroup
+                          - !Ref SecurityGroup
                         DeleteOnTermination: true
                       - Description: NetworkInterfaces Configuration For EFA and EKS
                         NetworkCardIndex: 2
                         DeviceIndex: 1
                         InterfaceType: efa
                         Groups:
-                          - !Ref EFASecurityGroup
+                          - !Ref SecurityGroup
                         DeleteOnTermination: true
                       - Description: NetworkInterfaces Configuration For EFA and EKS
                         NetworkCardIndex: 3
                         DeviceIndex: 1
                         InterfaceType: efa
                         Groups:
-                          - !Ref EFASecurityGroup
+                          - !Ref SecurityGroup
                         DeleteOnTermination: true
                       - Description: NetworkInterfaces Configuration For EFA and EKS
                         NetworkCardIndex: 4
                         DeviceIndex: 1
                         InterfaceType: efa
                         Groups:
-                          - !Ref EFASecurityGroup
+                          - !Ref SecurityGroup
                         DeleteOnTermination: true
                       - Description: NetworkInterfaces Configuration For EFA and EKS
                         NetworkCardIndex: 5
                         DeviceIndex: 1
                         InterfaceType: efa
                         Groups:
-                          - !Ref EFASecurityGroup
+                          - !Ref SecurityGroup
                         DeleteOnTermination: true
                       - Description: NetworkInterfaces Configuration For EFA and EKS
                         NetworkCardIndex: 6
                         DeviceIndex: 1
                         InterfaceType: efa
                         Groups:
-                          - !Ref EFASecurityGroup
+                          - !Ref SecurityGroup
                         DeleteOnTermination: true
                       - Description: NetworkInterfaces Configuration For EFA and EKS
                         NetworkCardIndex: 7
                         DeviceIndex: 1
                         InterfaceType: efa
                         Groups:
-                          - !Ref EFASecurityGroup
+                          - !Ref SecurityGroup
                         DeleteOnTermination: true
                     - []
         UserData:

--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
@@ -64,6 +64,85 @@ Conditions:
   IsUserDataMIMEPart: !Equals [true, !Ref UserDataIsMIMEPart]
 
 Resources:
+  Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      Description: Allow node to communicate with each other
+      FromPort: 0
+      ToPort: 65535
+      GroupId: !Ref SecurityGroup
+      IpProtocol: "-1"
+      SourceSecurityGroupId: !Ref SecurityGroup
+
+  EFASecurityGroupIngressControlPlane:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      Description: Allow pods to communicate with the cluster API Server
+      FromPort: 443
+      ToPort: 443
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref SecurityGroup
+
+  EFASecurityGroupFromControlPlaneIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
+      FromPort: 1025
+      ToPort: 65535
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref SecurityGroup
+
+  EFASecurityGroupEgress:
+    Type: "AWS::EC2::SecurityGroupEgress"
+    Properties:
+      Description: Allow the efa worker nodes outbound communication
+      DestinationSecurityGroupId: !Ref SecurityGroup
+      FromPort: 0
+      ToPort: 65536
+      GroupId: !Ref SecurityGroup
+      IpProtocol: "-1"
+  
+  EFASecurityGroupEgressAllIpv4:
+    Type: "AWS::EC2::SecurityGroupEgress"
+    Properties:
+      Description: Allow the efa worker nodes outbound communication
+      FromPort: 0
+      ToPort: 65536
+      CidrIp: "0.0.0.0/0"
+      GroupId: !Ref SecurityGroup
+      IpProtocol: "-1"
+
+  EFASecurityGroupEgressAllIpv6:
+    Type: "AWS::EC2::SecurityGroupEgress"
+    Properties:
+      Description: Allow the efa worker nodes outbound communication
+      FromPort: 0
+      ToPort: 65536
+      CidrIpv6: "::/0"
+      GroupId: !Ref SecurityGroup
+      IpProtocol: "-1"
+
+  EFASecurityGroupEgressControlPlane:
+    Type: "AWS::EC2::SecurityGroupEgress"
+    Properties:
+      Description: Allow the cluster control plane to communicate with worker Kubelet and pods
+      DestinationSecurityGroupId: !Ref SecurityGroup
+      FromPort: 1025
+      ToPort: 65535
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+
+  ControlPlaneEgressToEFASecurityGroupOn443:
+    Type: "AWS::EC2::SecurityGroupEgress"
+    Properties:
+      Description: Allow the cluster control plane to communicate with pods running extension API servers on port 443
+      DestinationSecurityGroupId: !Ref SecurityGroup
+      FromPort: 443
+      ToPort: 443
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+
   NodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:

--- a/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
+++ b/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml
@@ -64,7 +64,8 @@ Conditions:
   IsUserDataMIMEPart: !Equals [true, !Ref UserDataIsMIMEPart]
 
 Resources:
-  Type: "AWS::EC2::SecurityGroupIngress"
+  EFASecurityGroupIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
       Description: Allow node to communicate with each other
       FromPort: 0


### PR DESCRIPTION
*Issue #, if available:*
* Fix the node group deletion failed caused by the ENI leakage for EFA security group. 
* The EFA Security group is created in the [unmanaged-nodegroup-efa.yaml](https://github.com/aws/aws-k8s-tester/blob/72ebc98f2d01f5ff539c6619a5082010e316e9bf/kubetest2/internal/deployers/eksapi/templates/unmanaged-nodegroup-efa.yaml#L67-L74) which is a customized security group specified in the node launch template, so it will be created and deleted during unmanaged nodegroup stack creation and deletion.
* The reason why our [old leaked eni clean up in infra.go](https://github.com/aws/aws-k8s-tester/blob/main/kubetest2/internal/deployers/eksapi/deployer.go#L335) doesn't work as expected is because we are using customized security group in node launch template instead of the default cluster security group. It will be deleted during the node group stack deletion after ASG tear down [happened in here](https://github.com/aws/aws-k8s-tester/blob/main/kubetest2/internal/deployers/eksapi/deployer.go#L328), but the old leaked eni clean up is handled during cluster cleaned up after the node group stack already teared down.

To resolve above issue, we can use the default cluster security group and update the EFA required ingress and egress in it instead of creating a new security group for EFA in node group stack. And the eni leakage handler in infra.go we already have can handle eni leakage in the default security group for us.

Test in local below are logs in reverse order:
```
January 03, 2025 at 00:02 (UTC-8:00)
I0103 08:02:04.602210 14 infra.go:245] deleted infrastructure stack: kubetest2-eksapi-cdd2510e-a5eb-485d-82e8-eb9a6fcee279
	
January 03, 2025 at 00:00 (UTC-8:00)
I0103 08:00:34.844267 14 infra.go:232] waiting for infrastructure stack to be deleted: kubetest2-eksapi-cdd2510e-a5eb-485d-82e8-eb9a6fcee279
	
January 03, 2025 at 00:00 (UTC-8:00)
I0103 08:00:34.708164 14 infra.go:222] deleting infrastructure stack: kubetest2-eksapi-cdd2510e-a5eb-485d-82e8-eb9a6fcee279
	
January 02, 2025 at 23:58 (UTC-8:00)
I0103 07:58:24.977376 14 cluster.go:164] waiting for cluster to be deleted: arn:aws:eks:eu-south-1:235947055528:cluster/kubetest2-eksapi-cdd2510e-a5eb-485d-82e8-eb9a6fcee279
	
January 02, 2025 at 23:58 (UTC-8:00)
I0103 07:58:24.799182 14 infra.go:329] deleted 2 leaked ENI(s)!
	
January 02, 2025 at 23:58 (UTC-8:00)
I0103 07:58:24.799203 14 cluster.go:154] deleting cluster...
	
January 02, 2025 at 23:58 (UTC-8:00)
I0103 07:58:24.447365 14 infra.go:321] deleting leaked ENI: eni-081330c11228821c9
	
January 02, 2025 at 23:58 (UTC-8:00)
I0103 07:58:24.100503 14 infra.go:321] deleting leaked ENI: eni-0cec5610de4df59a5
	
January 02, 2025 at 23:58 (UTC-8:00)
I0103 07:58:23.959241 14 infra.go:314] waiting for 2 leaked ENI(s) to become available: [eni-0cec5610de4df59a5 eni-081330c11228821c9]
	
January 02, 2025 at 23:58 (UTC-8:00)
I0103 07:58:23.725848 14 node.go:593] nodegroup does not exist: kubetest2-eksapi-cdd2510e-a5eb-485d-82e8-eb9a6fcee279
	
January 02, 2025 at 23:58 (UTC-8:00)
I0103 07:58:23.588672 14 node.go:637] deleted unmanaged nodegroup stack: kubetest2-eksapi-cdd2510e-a5eb-485d-82e8-eb9a6fcee279-unmanaged-nodegroup
	
January 02, 2025 at 23:58 (UTC-8:00)
I0103 07:58:23.588692 14 node.go:588] deleting nodegroup...
```


