### PR TITLE
Delete ENIs leaked by the IPAM controller

### DIFF
--- a/kubetest2/internal/deployers/eksapi/infra.go
+++ b/kubetest2/internal/deployers/eksapi/infra.go
@@ -34,6 +34,9 @@ const (
 const (
 	// the VPC CNI will always add this tag to ENI's that it creates
 	vpcCNIENITagKey = "node.k8s.amazonaws.com/createdAt"
+
+	// the IPAM controller will add this tag to the ENI's that it creates
+	ipamControllerENITagKey = "eks:kubernetes-cni-node-name"
 )
 
 // eksEndpointURLTag is the key for an optional tag on the infrastructure CloudFormation stack,
@@ -345,7 +348,7 @@ func (m *InfrastructureManager) getVPCCNINetworkInterfaceIds(vpcId string) ([]st
 			},
 			{
 				Name:   aws.String("tag-key"),
-				Values: []string{vpcCNIENITagKey},
+				Values: []string{vpcCNIENITagKey, ipamControllerENITagKey},
 			},
 		},
 	})


### PR DESCRIPTION
*Description of changes:*

The tag key we use to locate leaked ENIs prior to infrastructure stack deletion differs for ENIs created by the VPC CNI and the IPAM controller. This PR adds the tag key for the latter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
