### PR TITLE
Wait for deletion of auto mode nodes

### DIFF
--- a/kubetest2/internal/deployers/eksapi/deployer.go
+++ b/kubetest2/internal/deployers/eksapi/deployer.go
@@ -321,17 +321,16 @@ func (d *deployer) Down() error {
 	if d.deployerOptions.StaticClusterName != "" {
 		return d.staticClusterManager.TearDownNodeForStaticCluster()
 	}
-	return deleteResources(d.infraManager, d.clusterManager, d.nodeManager)
+	return deleteResources(d.infraManager, d.clusterManager, d.nodeManager, d.k8sClient)
 }
 
-func deleteResources(im *InfrastructureManager, cm *ClusterManager, nm *nodeManager) error {
-	if err := nm.deleteNodes(); err != nil {
+func deleteResources(im *InfrastructureManager, cm *ClusterManager, nm *nodeManager /* nillable */, k8sClient *k8sClient) error {
+	if err := nm.deleteNodes(k8sClient); err != nil {
 		return err
 	}
 	// the EKS-managed cluster security group may be associated with a leaked ENI
 	// so we need to make sure we've deleted leaked ENIs before we delete the cluster
 	// otherwise, the cluster security group will be left behind and will block deletion of our VPC
-
 	if err := im.deleteLeakedENIs(); err != nil {
 		return err
 	}

--- a/kubetest2/internal/deployers/eksapi/janitor.go
+++ b/kubetest2/internal/deployers/eksapi/janitor.go
@@ -68,7 +68,7 @@ func (j *janitor) Sweep(ctx context.Context) error {
 			clusterManager := NewClusterManager(clients, resourceID)
 			nodeManager := NewNodeManager(clients, resourceID)
 			klog.Infof("deleting resources (%v old): %s", resourceAge, resourceID)
-			if err := deleteResources(infraManager, clusterManager, nodeManager); err != nil {
+			if err := deleteResources(infraManager, clusterManager, nodeManager /* TODO: pass a k8sClient */, nil); err != nil {
 				errs = append(errs, fmt.Errorf("failed to delete resources: %s: %v", resourceID, err))
 			}
 		}


### PR DESCRIPTION
*Description of changes:*

This aims to address an issue where the cluster's security group is left behind if we wait for nodes to be deleted by `eks:DeleteCluster`. We'll delete our "placeholder deployment" and the `NodePool`, then wait for all `Node` objects to be deleted, prior to calling `eks:DeleteCluster`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
