### PR TITLE
fix the node clean up failure without auto mode

### DIFF
--- a/kubetest2/internal/deployers/eksapi/deployer.go
+++ b/kubetest2/internal/deployers/eksapi/deployer.go
@@ -321,11 +321,11 @@ func (d *deployer) Down() error {
 	if d.deployerOptions.StaticClusterName != "" {
 		return d.staticClusterManager.TearDownNodeForStaticCluster()
 	}
-	return deleteResources(d.infraManager, d.clusterManager, d.nodeManager, d.k8sClient)
+	return deleteResources(d.infraManager, d.clusterManager, d.nodeManager, d.k8sClient, &d.deployerOptions)
 }
 
-func deleteResources(im *InfrastructureManager, cm *ClusterManager, nm *nodeManager /* nillable */, k8sClient *k8sClient) error {
-	if err := nm.deleteNodes(k8sClient); err != nil {
+func deleteResources(im *InfrastructureManager, cm *ClusterManager, nm *nodeManager /* nillable */, k8sClient *k8sClient, opts *deployerOptions) error {
+	if err := nm.deleteNodes(k8sClient, opts); err != nil {
 		return err
 	}
 	// the EKS-managed cluster security group may be associated with a leaked ENI

--- a/kubetest2/internal/deployers/eksapi/janitor.go
+++ b/kubetest2/internal/deployers/eksapi/janitor.go
@@ -68,7 +68,7 @@ func (j *janitor) Sweep(ctx context.Context) error {
 			clusterManager := NewClusterManager(clients, resourceID)
 			nodeManager := NewNodeManager(clients, resourceID)
 			klog.Infof("deleting resources (%v old): %s", resourceAge, resourceID)
-			if err := deleteResources(infraManager, clusterManager, nodeManager /* TODO: pass a k8sClient */, nil); err != nil {
+			if err := deleteResources(infraManager, clusterManager, nodeManager /* TODO: pass a k8sClient */, nil, nil); err != nil {
 				errs = append(errs, fmt.Errorf("failed to delete resources: %s: %v", resourceID, err))
 			}
 		}

--- a/kubetest2/internal/deployers/eksapi/node.go
+++ b/kubetest2/internal/deployers/eksapi/node.go
@@ -550,7 +550,7 @@ func (m *nodeManager) createUnmanagedNodegroupWithEFA(infra *Infrastructure, clu
 // deleteNodes cleans up any nodes in the cluster
 // it will be called outside the context of a deployer run (by the janitor, for example)
 // so will try to delete nodes of any type
-func (m *nodeManager) deleteNodes(k8sClient *k8sClient) error {
+func (m *nodeManager) deleteNodes(k8sClient *k8sClient, opts *deployerOptions) error {
 	if err := m.deleteUnmanagedNodegroup(); err != nil {
 		return err
 	}
@@ -559,7 +559,7 @@ func (m *nodeManager) deleteNodes(k8sClient *k8sClient) error {
 	}
 	// we only have a k8sClient when this is called by the deployer, not by the janitor
 	// TODO implement cleanup of Auto nodes in the janitor
-	if k8sClient != nil {
+	if k8sClient != nil && opts != nil && opts.AutoMode {
 		if err := m.deletePlaceholderDeployment(k8sClient); err != nil {
 			return err
 		}


### PR DESCRIPTION
*Issue #, if available:*
Find below error when deleting unmanaged node group without AutoMode. Fix by only clean up these resources when it is AutoMode
```
January 06, 2025 at 15:02 (UTC-8:00)
Error: failed to delete node pool: no matches for kind "NodePool" in version "karpenter.sh/v1"
	
January 06, 2025 at 15:02 (UTC-8:00)
I0106 23:02:28.920402 12 node.go:289] placeholder deployment does not exist: kubetest2-eksapi-f0b52762-d024-466e-b8dd-08ba7cf96d3e
	
January 06, 2025 at 15:02 (UTC-8:00)
I0106 23:02:28.920421 12 node.go:218] deleting node pool...
	
January 06, 2025 at 15:02 (UTC-8:00)
I0106 23:02:28.205830 12 node.go:586] nodegroup does not exist: kubetest2-eksapi-f0b52762-d024-466e-b8dd-08ba7cf96d3e
	
January 06, 2025 at 15:02 (UTC-8:00)
I0106 23:02:28.205850 12 node.go:286] deleting placeholder deployment...
```
