### PR TITLE
Handle NoSuchEntity properly when sweeping instance profiles

### DIFF
--- a/internal/deployers/eksapi/infra.go
+++ b/internal/deployers/eksapi/infra.go
@@ -259,8 +259,7 @@ func (m *InfrastructureManager) deleteLeakedInstanceProfiles(infra *Infrastructu
 	if err != nil {
 		var notFound *iamtypes.NoSuchEntityException
 		if errors.As(err, &notFound) {
-			klog.Infof("instance profile for role does not exist: %s", m.resourceID)
-			// continue deletion
+			return nil
 		}
 		return fmt.Errorf("failed to list instance profiles for role name: '%s': %v", infra.nodeRoleName, err)
 	} else if len(out.InstanceProfiles) > 0 {


### PR DESCRIPTION
*Description of changes:*

Missing return caused unintentional error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
