### PR TITLE
Fix nil pointer when cluster creation fails

### DIFF
--- a/internal/deployers/eksapi/logs.go
+++ b/internal/deployers/eksapi/logs.go
@@ -43,6 +43,10 @@ func (m *logManager) gatherLogsFromNodes(k8sClient *k8sClient, opts *deployerOpt
 		klog.Info("--log-bucket is empty, no logs will be gathered!")
 		return nil
 	}
+	if k8sClient == nil {
+		klog.Infof("no k8s client available, no logs will be gathered!")
+		return nil
+	}
 	if opts.AutoMode {
 		return m.gatherLogsUsingNodeDiagnostic(k8sClient, opts, phase)
 	}


### PR DESCRIPTION
*Description of changes:*

When cluster creation fails, `k8sClient` is `nil`, causing a panic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
