### PR TITLE
Pass build tags for test executables

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: go test -c ./test/...
+    - run: go test -c -tags=e2e ./test/...
   build-image:
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN go install sigs.k8s.io/kubetest2/...@${KUBETEST2_VERSION}
 WORKDIR $GOPATH/src/github.com/aws/aws-k8s-tester
 COPY . .
 RUN go install ./...
-RUN go test -c ./test/... -o $GOPATH/bin/
+RUN go test -c -tags=e2e ./test/... -o $GOPATH/bin/
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 ARG TARGETOS


### PR DESCRIPTION
*Description of changes:*

This adds the `e2e` build tag for test compilation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
