### PR TITLE
Add upstream kubetest2 tools to artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,4 @@ include ${BGO_MAKEFILE}
 
 pre-release::
 	go test -c -tags=e2e ./test/... -o $(GOBIN)
+	go install sigs.k8s.io/kubetest2/...@latest


### PR DESCRIPTION
*Description of changes:*

We need to install the upstream kubetest2 tools in addition to our own.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
