### PR TITLE
Fix job type check

### DIFF
--- a/internal/e2e/client.go
+++ b/internal/e2e/client.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/aws/aws-k8s-tester/internal/e2e/mpioperator"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,10 +130,10 @@ func GetJobLogs(restConfig *rest.Config, job k8s.Object) (string, error) {
 		return "", err
 	}
 	var jobLabel string
-	switch job.GetObjectKind().GroupVersionKind().Kind {
-	case "MPIJob":
+	switch job.(type) {
+	case *mpioperator.MPIJobFacade:
 		jobLabel = fmt.Sprintf("job-name=%s-launcher", job.GetName())
-	case "Job":
+	case *batchv1.Job:
 		jobLabel = fmt.Sprintf("job-name=%s", job.GetName())
 	default:
 		return "", fmt.Errorf("unsupported job type %T", job)


### PR DESCRIPTION
*Description of changes:*

The check for `Kind` is not effective, we need to revert to the previous impl, but use the `MPIJobFacade`.

https://github.com/aws/aws-k8s-tester/blob/9bdcb4f19f9176f5e04cbbdb69c65274ea66294c/e2e2/internal/framework_extensions/client.go#L133-L140

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
