### PR TITLE
Updates for Neuron testing

### DIFF
--- a/internal/deployers/eksapi/templates/userdata_bottlerocket.toml.template
+++ b/internal/deployers/eksapi/templates/userdata_bottlerocket.toml.template
@@ -2,6 +2,7 @@
 "cluster-name" = "{{.Name}}"
 "api-server" = "{{.APIServerEndpoint}}"
 "cluster-certificate" = "{{.CertificateAuthority}}"
+device-ownership-from-security-context = true
 
 [settings.host-containers.admin]
 "enabled" = true

--- a/test/cases/neuron/manifests/multi-node-test-neuron.yaml
+++ b/test/cases/neuron/manifests/multi-node-test-neuron.yaml
@@ -84,6 +84,10 @@ spec:
       replicas: {{.WorkerNodeCount}}
       template:
         spec:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 2000
+            fsGroup: 3000
           containers:
           - image: {{.NeuronTestImage}}
             ports:

--- a/test/cases/neuron/manifests/single-node-test-neuronx.yaml
+++ b/test/cases/neuron/manifests/single-node-test-neuronx.yaml
@@ -27,4 +27,8 @@ spec:
             memory: 1Gi
             aws.amazon.com/neuron: "1"
       restartPolicy: Never
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 2000
+        fsGroup: 3000
   backoffLimit: 4


### PR DESCRIPTION
*Description of changes:*
With the merge of https://github.com/bottlerocket-os/bottlerocket/pull/4345, Bottlerocket is adding a new setting `device-ownership-from-security-context`.  This setting will be available on all kubernetes variants. This is to support the same setting in the containerd CRI plugin as described [here](https://kubernetes.io/blog/2021/11/09/non-root-containers-and-devices/)

With this change in Bottlerocket, containers are able to get ownership of requested devices without needing root or privileged capabilities.

This PR is to add this setting to the neuron test cases and update the test Jobs specfiles to specify the user ID and Group ID for ownership of the neuron devices.

---

This change also bumps the Neuron SDK versions to use the latest available from upstream.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
