### PR TITLE
fix(test/neuron-training): Add neuron-training image to git workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,3 +41,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: docker build --file test/images/nvidia-inference/Dockerfile test/images/nvidia-inference
+  build-image-neuron-training:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: docker build --file test/images/neuron-training/Dockerfile test/images/neuron-training


### PR DESCRIPTION
*Description of changes:*

Add the `neuron-training` image (`/home/mattcjo/github-aws-mattcjo/aws-k8s-tester/test/images/neuron-training/Dockerfile`) to the git workflow. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
