### PR TITLE
fix: only register internal version of MPIJobFacade for unit tests

### DIFF
--- a/internal/e2e/mpioperator/types.go
+++ b/internal/e2e/mpioperator/types.go
@@ -9,10 +9,17 @@ import (
 var (
 	facadeSchemeBuilder = runtime.NewSchemeBuilder(addFacadeTypes)
 	AddFacadesToScheme  = facadeSchemeBuilder.AddToScheme
+
+	// for unit tests
+	registerInternalVersion = false
 )
 
 func addFacadeTypes(s *runtime.Scheme) error {
-	for _, version := range []string{"v2beta1", runtime.APIVersionInternal} {
+	versions := []string{"v2beta1"}
+	if registerInternalVersion {
+		versions = append(versions, runtime.APIVersionInternal)
+	}
+	for _, version := range versions {
 		s.AddKnownTypeWithName(schema.GroupVersionKind{
 			Group:   "kubeflow.org",
 			Version: version,

--- a/internal/e2e/mpioperator/types_test.go
+++ b/internal/e2e/mpioperator/types_test.go
@@ -20,6 +20,9 @@ status:
 `
 
 func Test_serialization(t *testing.T) {
+	// the internal sentinel version must be registered for the type for us to decode it
+	registerInternalVersion = true
+
 	scheme := runtime.NewScheme()
 	err := AddFacadesToScheme(scheme)
 	if err != nil {


### PR DESCRIPTION
*Description of changes:*

Fixes an issue seen in the `nvidia` test cases:
```
    mpi_test.go:71: multiple GroupVersionKinds associated with Go type *mpioperator.MPIJobFacade within the Scheme, this can happen when a type is registered for multiple GVKs at the same time: callers can either fix their type registration to only register it once, or specify the GroupVersionKind to use for object passed in; refusing to guess at one: ["kubeflow.org/v2beta1, Kind=MPIJob" "kubeflow.org/__internal, Kind=MPIJob"]
```

The `_internal` version this is referring to is necessary when decoding types with a scheme, but causes this error when the scheme is used to map types to API types in the framework's client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
