### PR TITLE
fix: prevent CI / build-image failures caused by opencensus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN  wget -O go.tar.gz https://go.dev/dl/$(cat go-version.txt).${TARGETOS}-${TAR
     tar -C /usr/local -xzf go.tar.gz
 ENV GOPATH=/usr/local/go
 ENV PATH=$PATH:$GOPATH/bin
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org,direct
 ARG KUBETEST2_VERSION=v0.0.0-20231113220322-d7fcb799ce84
 RUN go install sigs.k8s.io/kubetest2/...@${KUBETEST2_VERSION}
 


### PR DESCRIPTION
CI/build-image failed with the following error:
```
https fetch: Get "https://go.opencensus.io/?go-get=1": tls: failed to verify certificate: x509: certificate has expired or is not yet valid
```

Fix:
Setting `GOPROXY='https://proxy.golang.org,direct'` helps avoid this issue.

Implemented the fix as described [in this issue](https://github.com/googleapis/google-cloud-go/issues/11481#issuecomment-2607790138)

More about the used proxy:
https://sum.golang.org/

>[proxy.golang.org](https://proxy.golang.org/) - a module mirror which implements the [module proxy protocol](https://golang.org/ref/mod#goproxy-protocol). For users downloading large numbers of modules (e.g. for bulk static analysis), the mirror supports a separate endpoint /cached-only that instructs the proxy to return only cached content. This will avoid slow downloads, at the cost of possibly missing some rarely-used modules.
