### PR TITLE
Attach EKS auto policies for Auto cluster only

### DIFF
--- a/internal/deployers/eksapi/infra.go
+++ b/internal/deployers/eksapi/infra.go
@@ -128,6 +128,10 @@ func (m *InfrastructureManager) createInfrastructureStack(opts *deployerOptions)
 				ParameterKey:   aws.String("Subnet02AZ"),
 				ParameterValue: aws.String(subnetAzs[1]),
 			},
+			{
+				ParameterKey:   aws.String("AutoMode"),
+				ParameterValue: aws.String(fmt.Sprintf("%t", opts.AutoMode)),
+			},
 		},
 	}
 	if opts.ClusterRoleServicePrincipal != "" {

--- a/internal/deployers/eksapi/templates/infra.yaml
+++ b/internal/deployers/eksapi/templates/infra.yaml
@@ -42,6 +42,13 @@ Parameters:
   Subnet02AZ:
     Type: String
 
+  AutoMode:
+    Type: String
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "false"
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -60,6 +67,8 @@ Conditions:
       - Fn::Equals:
         - ""
         - !Ref AdditionalClusterRoleServicePrincipal
+
+  IsAutoMode: !Equals [!Ref AutoMode, "true"]
 
 Resources:
   #
@@ -415,26 +424,38 @@ Resources:
           - - "arn:"
             - !Ref "AWS::Partition"
             - ":iam::aws:policy/AmazonEKSClusterPolicy"
-        - !Join
-          - ""
-          - - "arn:"
-            - !Ref "AWS::Partition"
-            - ":iam::aws:policy/AmazonEKSBlockStoragePolicy"
-        - !Join
-          - ""
-          - - "arn:"
-            - !Ref "AWS::Partition"
-            - ":iam::aws:policy/AmazonEKSComputePolicy"
-        - !Join
-          - ""
-          - - "arn:"
-            - !Ref "AWS::Partition"
-            - ":iam::aws:policy/AmazonEKSLoadBalancingPolicy"
-        - !Join
-          - ""
-          - - "arn:"
-            - !Ref "AWS::Partition"
-            - ":iam::aws:policy/AmazonEKSNetworkingPolicy"
+        - !If
+          - IsAutoMode
+          - !Join
+            - ""
+            - - "arn:"
+              - !Ref "AWS::Partition"
+              - ":iam::aws:policy/AmazonEKSBlockStoragePolicy"
+          - !Ref "AWS::NoValue"
+        - !If
+          - IsAutoMode
+          - !Join
+            - ""
+            - - "arn:"
+              - !Ref "AWS::Partition"
+              - ":iam::aws:policy/AmazonEKSComputePolicy"
+          - !Ref "AWS::NoValue"
+        - !If
+          - IsAutoMode
+          - !Join
+            - ""
+            - - "arn:"
+              - !Ref "AWS::Partition"
+              - ":iam::aws:policy/AmazonEKSLoadBalancingPolicy"
+          - !Ref "AWS::NoValue"
+        - !If
+          - IsAutoMode
+          - !Join
+            - ""
+            - - "arn:"
+              - !Ref "AWS::Partition"
+              - ":iam::aws:policy/AmazonEKSNetworkingPolicy"
+          - !Ref "AWS::NoValue"
 
   NodeRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
*Issue #, if available:*
The cluster creation may fail due to the policy not exist in EKS Auto non-GA regions

*Description of changes:*
The policy will be attached when the auto mode flag is true. and this flag should be controlled by clients in those regions GAed EKS Auto

Tests Done: 
build and tested in personal dev account for both auto-mode and non-auto-mode

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
