### PR TITLE
feat(test/nvidia): Add Containerd Test to NVIDIA Suite for ECR and Systemd Validation

### DIFF
--- a/internal/e2e/logs.go
+++ b/internal/e2e/logs.go
@@ -1,0 +1,94 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// PrintDaemonSetPodLogs retrieves logs from each container in each pod of a DaemonSet.
+// namespace & labelSelector identify the DaemonSet's pods (e.g. "default", "app=containerd-check").
+func PrintDaemonSetPodLogs(
+	ctx context.Context,
+	restConfig *rest.Config,
+	namespace string,
+	labelSelector string,
+	t *testing.T,
+) {
+	clientset, err := getClientset(restConfig)
+	if err != nil {
+		t.Logf("failed to create typed clientset: %v", err)
+		return
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		t.Logf("failed to list pods: %v", err)
+		return
+	}
+	if len(pods.Items) == 0 {
+		t.Logf("No pods found for DaemonSet with label %q in namespace %q.", labelSelector, namespace)
+		return
+	}
+
+	for _, pod := range pods.Items {
+		t.Logf("Pod %s status: %s", pod.Name, pod.Status.Phase)
+		for _, container := range pod.Spec.Containers {
+			logs, logErr := readPodLogs(ctx, clientset, pod.Namespace, pod.Name, container.Name)
+			if logErr != nil {
+				t.Logf("Failed reading logs from %s/%s: %v", pod.Name, container.Name, logErr)
+			} else {
+				t.Logf("=== Logs from %s/%s ===\n%s", pod.Name, container.Name, logs)
+			}
+		}
+	}
+}
+
+// readPodLogs streams logs for a specific container in a pod.
+func readPodLogs(
+	ctx context.Context,
+	clientset *kubernetes.Clientset,
+	namespace, podName, containerName string,
+) (string, error) {
+	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: containerName,
+	})
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to open log stream for %s/%s: %w", podName, containerName, err)
+	}
+	defer stream.Close()
+
+	var out string
+	buf := make([]byte, 4096)
+	for {
+		n, readErr := stream.Read(buf)
+		if n > 0 {
+			out += string(buf[:n])
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return out, fmt.Errorf("error reading logs: %w", readErr)
+		}
+	}
+	return out, nil
+}
+
+// getClientset returns a typed Kubernetes clientset from the given rest.Config.
+func getClientset(restConfig *rest.Config) (*kubernetes.Clientset, error) {
+	cs, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create clientset: %w", err)
+	}
+	return cs, nil
+}

--- a/internal/e2e/logs.go
+++ b/internal/e2e/logs.go
@@ -15,11 +15,11 @@ import (
 // PrintDaemonSetPodLogs retrieves logs from each container in each pod of a DaemonSet.
 // namespace & labelSelector identify the DaemonSet's pods (e.g. "default", "app=containerd-check").
 func PrintDaemonSetPodLogs(
+	t *testing.T,
 	ctx context.Context,
 	restConfig *rest.Config,
 	namespace string,
 	labelSelector string,
-	t *testing.T,
 ) {
 	clientset, err := getClientset(restConfig)
 	if err != nil {

--- a/test/cases/nvidia/containerd_test.go
+++ b/test/cases/nvidia/containerd_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	fwext "github.com/aws/aws-k8s-tester/internal/e2e" // adjust if you store these helpers elsewhere
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	// For embedding the DaemonSet manifest
 	_ "embed"
 )
 

--- a/test/cases/nvidia/containerd_test.go
+++ b/test/cases/nvidia/containerd_test.go
@@ -50,7 +50,7 @@ func TestContainerdConfig(t *testing.T) {
 			)
 			if err != nil {
 				t.Logf("[Assess] containerd-check DS did not become Ready: %v", err)
-				e2e.PrintDaemonSetPodLogs(ctx, cfg.Client().RESTConfig(), dsNS, "app=containerd-check", t)
+				e2e.PrintDaemonSetPodLogs(t, ctx, cfg.Client().RESTConfig(), dsNS, "app=containerd-check")
 				t.Fatalf("containerd-check DS not Ready within 1 minute")
 			}
 

--- a/test/cases/nvidia/containerd_test.go
+++ b/test/cases/nvidia/containerd_test.go
@@ -1,0 +1,148 @@
+//go:build e2e
+
+package nvidia
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"testing"
+	"time"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	_ "embed"
+)
+
+//go:embed manifests/daemonset-containerd-check.yaml
+var containerdCheckDS []byte
+
+func TestContainerdConfig(t *testing.T) {
+	feat := features.New("containerd-config-check").
+		WithLabel("suite", "nvidia").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			log.Println("[Setup] Applying containerd-check DaemonSet manifest.")
+			err := fwext.ApplyManifests(cfg.Client().RESTConfig(), containerdCheckDS)
+			if err != nil {
+				t.Fatalf("failed to apply containerd-check DS: %v", err)
+			}
+			return ctx
+		}).
+		Assess("DaemonSet becomes ready", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ds := &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "containerd-check",
+					Namespace: "default",
+				},
+			}
+
+			log.Println("[Assess] Waiting up to 1 minute for containerd-check DS to become Ready...")
+			err := wait.For(
+				fwext.NewConditionExtension(cfg.Client().Resources()).DaemonSetReady(ds),
+				wait.WithTimeout(1*time.Minute),
+			)
+			if err != nil {
+				t.Logf("[Assess] containerd-check DS did not become Ready: %v", err)
+				// Attempt to retrieve DS pod logs for debugging
+				printDaemonSetPodLogs(ctx, cfg, "default", "app=containerd-check", t)
+				t.Fatalf("containerd-check DS not Ready within 1 minute")
+			}
+
+			log.Println("[Assess] containerd-check DS is Ready.")
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Log("[Teardown] Dumping DS logs before removal.")
+			printDaemonSetPodLogs(ctx, cfg, "default", "app=containerd-check", t)
+
+			err := fwext.DeleteManifests(cfg.Client().RESTConfig(), containerdCheckDS)
+			if err != nil {
+				t.Fatalf("failed to delete containerd-check DS: %v", err)
+			}
+			t.Log("[Teardown] containerd-check DS removed successfully.")
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}
+
+func printDaemonSetPodLogs(ctx context.Context, cfg *envconf.Config, namespace, labelSelector string, t *testing.T) {
+	clientset, err := getClientset(cfg.Client().RESTConfig())
+	if err != nil {
+		t.Logf("failed to create clientset: %v", err)
+		return
+	}
+
+	// List pods by label
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		t.Logf("failed to list pods for label %q: %v", labelSelector, err)
+		return
+	}
+	if len(pods.Items) == 0 {
+		t.Log("No pods found for containerd-check DS.")
+		return
+	}
+
+	// Fetch logs from each container in each pod
+	for _, p := range pods.Items {
+		t.Logf("Pod %s status: %s", p.Name, p.Status.Phase)
+		for _, c := range p.Spec.Containers {
+			logs, logErr := readPodLogs(ctx, clientset, p.Namespace, p.Name, c.Name)
+			if logErr != nil {
+				t.Logf("Failed to get logs from %s/%s: %v", p.Name, c.Name, logErr)
+			} else {
+				t.Logf("=== Logs from %s/%s ===\n%s", p.Name, c.Name, logs)
+			}
+		}
+	}
+}
+
+func readPodLogs(ctx context.Context, clientset *kubernetes.Clientset, namespace, podName, containerName string) (string, error) {
+	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &v1.PodLogOptions{
+		Container: containerName,
+	})
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to open log stream: %w", err)
+	}
+	defer stream.Close()
+
+	buf := make([]byte, 4096)
+	var logs string
+	for {
+		n, rerr := stream.Read(buf)
+		if n > 0 {
+			logs += string(buf[:n])
+		}
+		if rerr != nil {
+			if rerr == io.EOF {
+				break
+			}
+			return logs, fmt.Errorf("error reading logs: %w", rerr)
+		}
+	}
+	return logs, nil
+}
+
+func getClientset(restConfig *rest.Config) (*kubernetes.Clientset, error) {
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
+	}
+	return clientset, nil
+}

--- a/test/cases/nvidia/containerd_test.go
+++ b/test/cases/nvidia/containerd_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-k8s-tester/internal/e2e" // single import alias
+	"github.com/aws/aws-k8s-tester/internal/e2e"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/cases/nvidia/manifests/daemonset-containerd-check.yaml
+++ b/test/cases/nvidia/manifests/daemonset-containerd-check.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: containerd-check
+  namespace: default
+  labels:
+    app: containerd-check
+spec:
+  selector:
+    matchLabels:
+      app: containerd-check
+  template:
+    metadata:
+      labels:
+        app: containerd-check
+    spec:
+      containers:
+      - name: grep-containerd
+        image: public.ecr.aws/docker/library/busybox:latest
+        command:
+        - sh
+        - -c
+        - |
+          rc=0
+
+          # Check for ECR
+          grep -Eq '\.ecr\.' /host-etc/containerd/config.toml || {
+            echo "FAIL: no .ecr. reference in sandbox_image"
+            rc=1
+          }
+
+          # Check for NVIDIA runtime
+          grep -q 'nvidia-container-runtime' /host-etc/containerd/config.toml || {
+            echo "FAIL: no nvidia-container-runtime found"
+            rc=1
+          }
+
+          # Check for systemd cgroup
+          ( grep -q 'systemd_cgroup = true' /host-etc/containerd/config.toml \
+            || grep -q 'SystemdCgroup = true' /host-etc/containerd/config.toml ) || {
+            echo "FAIL: no systemd cgroup setting"
+            rc=1
+          }
+
+          # If rc != 0, print debug info and exit
+          if [ "$rc" -ne 0 ]; then
+            echo "=== config.toml contents ==="
+            cat /host-etc/containerd/config.toml
+            exit 1
+          fi
+
+          echo "containerd config check PASSED."
+
+          # Keep container running; let Kubelet mark it Ready
+          tail -f /dev/null
+
+        volumeMounts:
+        - name: containerd-config
+          mountPath: /host-etc/containerd
+          readOnly: true
+      volumes:
+      - name: containerd-config
+        hostPath:
+          path: /etc/containerd

--- a/test/cases/nvidia/manifests/daemonset-containerd-check.yaml
+++ b/test/cases/nvidia/manifests/daemonset-containerd-check.yaml
@@ -16,39 +16,55 @@ spec:
     spec:
       containers:
       - name: grep-containerd
-        image: public.ecr.aws/docker/library/busybox:latest
+        image: public.ecr.aws/amazonlinux/amazonlinux:latest
         command:
         - sh
         - -c
         - |
-          rc=0
+          # 1. Ensure the script fails on any command or pipeline error
+          set -e
+          set -o pipefail
+
           echo "=== content read by the container ==="
           cat /host-etc/containerd/config.toml
 
-          grep -Eq '\.ecr\.' /host-etc/containerd/config.toml || {
-            echo "FAIL: no .ecr. reference in sandbox_image"
-            rc=1
-          }
+          # 2. Attempt to extract 'sandbox_image' from the config
+          #    If grep returns nothing, pipefail triggers an error
+          #    OR you can explicitly check if the variable is empty
+          source <(grep sandbox_image /host-etc/containerd/config.toml | tr -d ' "')
 
-          grep -q 'nvidia-container-runtime' /host-etc/containerd/config.toml || {
+          # 3. If sandbox_image is missing, fail explicitly
+          if [ -z "$sandbox_image" ]; then
+            echo "FAIL: no sandbox_image line found"
+            echo "=== debug ==="
+            exit 1
+          fi
+
+          # 4. Check that $sandbox_image references .ecr.
+          if [[ "$sandbox_image" != *".ecr."* ]]; then
+            echo "FAIL: no .ecr. reference in $sandbox_image"
+            echo "=== debug ==="
+            exit 1
+          fi
+
+          # 5. Check for 'nvidia-container-runtime'
+          if ! grep -q "nvidia-container-runtime" /host-etc/containerd/config.toml; then
             echo "FAIL: no nvidia-container-runtime found"
-            rc=1
-          }
+            echo "=== debug ==="
+            exit 1
+          fi
 
-          ( grep -q 'systemd_cgroup = true' /host-etc/containerd/config.toml \
-            || grep -q 'SystemdCgroup = true' /host-etc/containerd/config.toml ) || {
+          # 6. Check for 'systemd_cgroup = true' or 'SystemdCgroup = true'
+          if ! ( grep -q 'systemd_cgroup = true' /host-etc/containerd/config.toml || \
+                 grep -q 'SystemdCgroup = true' /host-etc/containerd/config.toml ); then
             echo "FAIL: no systemd cgroup setting"
-            rc=1
-          }
-
-          if [ "$rc" -ne 0 ]; then
             echo "=== debug ==="
             exit 1
           fi
 
           echo "containerd config check PASSED."
-          tail -f /dev/null   # Keep the pod running so DS can be marked Ready
-
+          # Keep container running so DS can be marked Ready
+          tail -f /dev/null
         volumeMounts:
         - name: containerd-config
           mountPath: /host-etc/containerd

--- a/test/cases/nvidia/manifests/daemonset-containerd-check.yaml
+++ b/test/cases/nvidia/manifests/daemonset-containerd-check.yaml
@@ -15,7 +15,7 @@ spec:
         app: containerd-check
     spec:
       containers:
-      - name: grep-containerd
+      - name: containerd-check
         image: public.ecr.aws/amazonlinux/amazonlinux:latest
         command:
         - sh

--- a/test/cases/nvidia/manifests/daemonset-containerd-check.yaml
+++ b/test/cases/nvidia/manifests/daemonset-containerd-check.yaml
@@ -22,37 +22,32 @@ spec:
         - -c
         - |
           rc=0
+          echo "=== content read by the container ==="
+          cat /host-etc/containerd/config.toml
 
-          # Check for ECR
           grep -Eq '\.ecr\.' /host-etc/containerd/config.toml || {
             echo "FAIL: no .ecr. reference in sandbox_image"
             rc=1
           }
 
-          # Check for NVIDIA runtime
           grep -q 'nvidia-container-runtime' /host-etc/containerd/config.toml || {
             echo "FAIL: no nvidia-container-runtime found"
             rc=1
           }
 
-          # Check for systemd cgroup
           ( grep -q 'systemd_cgroup = true' /host-etc/containerd/config.toml \
             || grep -q 'SystemdCgroup = true' /host-etc/containerd/config.toml ) || {
             echo "FAIL: no systemd cgroup setting"
             rc=1
           }
 
-          # If rc != 0, print debug info and exit
           if [ "$rc" -ne 0 ]; then
-            echo "=== config.toml contents ==="
-            cat /host-etc/containerd/config.toml
+            echo "=== debug ==="
             exit 1
           fi
 
           echo "containerd config check PASSED."
-
-          # Keep container running; let Kubelet mark it Ready
-          tail -f /dev/null
+          tail -f /dev/null   # Keep the pod running so DS can be marked Ready
 
         volumeMounts:
         - name: containerd-config


### PR DESCRIPTION
*Issue #, if available:*  
Addresses the known bug in nvidia-container-toolkit `1.17.0` ([bug(nvidia-container-toolkit): incorrect containerd config #2041](https://github.com/awslabs/amazon-eks-ami/issues/2041)) which can drop EKS defaults on Amazon Linux 2 (AL2) AMIs.

*Description of changes:*  
- **Introduces a new containerd test** under `test/cases/nvidia`, verifying each node’s `/etc/containerd/config.toml` includes:
  1. **ECR references** (`.ecr.`) for the sandbox image (avoid fallback to `registry.k8s.io`),
  2. The **NVIDIA GPU runtime** (`nvidia-container-runtime`),
  3. **Systemd** cgroup settings (`systemd_cgroup = true` or `SystemdCgroup = true`).

- **Deploys a DaemonSet** that mounts `/etc/containerd/config.toml` and runs inline grep checks. If any required line is missing, the pod fails fast, preventing the DaemonSet from becoming Ready.

- **Prevents duplicated logs** by only retrieving logs in the Assess phase on failure. On success, pods remain running (`tail -f /dev/null`), letting the DaemonSet achieve Ready status.

- **Ensures a short 1-minute timeout** for quick feedback. If the buggy containerd config is detected (missing ECR or systemd lines), the test times out and provides container logs pinpointing which checks failed.

*Testing:*

- Validated against an **old AL2 AMI** (`amazon-eks-gpu-node-1.31-v20241106`) lacking certain EKS defaults, where pods fail the grep checks and never become Ready, producing logs identifying the missing lines.
```
go test -v -tags=e2e . -run TestContainerdConfig
2025/01/31 05:50:43 No node type specified. Using the node type g6.2xlarge in the node groups.
=== RUN   TestContainerdConfig
=== RUN   TestContainerdConfig/containerd-config-check
2025/01/31 05:50:48 [Setup] Applying containerd-check DaemonSet manifest.
=== RUN   TestContainerdConfig/containerd-config-check/DaemonSet_becomes_ready
2025/01/31 05:50:48 [Assess] Waiting up to 1 minute for containerd-check DS to become Ready...
    containerd_test.go:57: [Assess] containerd-check DS did not become Ready: client rate limiter Wait returned an error: context deadline exceeded
    containerd_test.go:100: Pod containerd-check-h5lkl status: Running
    containerd_test.go:106: === Logs from containerd-check-h5lkl/grep-containerd ===
        === content read by the container ===
        version = 2

        [plugins]

          [plugins."io.containerd.grpc.v1.cri"]

            [plugins."io.containerd.grpc.v1.cri".containerd]
              default_runtime_name = "nvidia"

              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]

                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
                  privileged_without_host_devices = false
                  runtime_engine = ""
                  runtime_root = ""
                  runtime_type = "io.containerd.runc.v2"

                  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
                    BinaryName = "/usr/bin/nvidia-container-runtime"
        FAIL: no sandbox_image line found
        === debug ===
    containerd_test.go:59: containerd-check DS not Ready within 1 minute
=== NAME  TestContainerdConfig/containerd-config-check
    containerd_test.go:67: [Teardown] Removing containerd-check DS (no additional logs).
    containerd_test.go:71: [Teardown] containerd-check DS removed successfully.
--- FAIL: TestContainerdConfig (60.09s)
    --- FAIL: TestContainerdConfig/containerd-config-check (60.09s)
        --- FAIL: TestContainerdConfig/containerd-config-check/DaemonSet_becomes_ready (60.03s)
FAIL
FAIL    github.com/aws/aws-k8s-tester/test/cases/nvidia 72.213s
FAIL
```

- Verified on an **updated AL2 AMI** (`amazon-eks-gpu-node-1.31-v20250123`) where all EKS defaults are present, leading to a Passing DS that becomes Ready within the timeout.
```
go test -v -tags=e2e . -run TestContainerdConfig
2025/01/31 05:54:04 No node type specified. Using the node type g6.2xlarge in the node groups.
=== RUN   TestContainerdConfig
=== RUN   TestContainerdConfig/containerd-config-check
2025/01/31 05:54:09 [Setup] Applying containerd-check DaemonSet manifest.
=== RUN   TestContainerdConfig/containerd-config-check/DaemonSet_becomes_ready
2025/01/31 05:54:09 [Assess] Waiting up to 1 minute for containerd-check DS to become Ready...
2025/01/31 05:54:14 [Assess] containerd-check DS is Ready.
=== NAME  TestContainerdConfig/containerd-config-check
    containerd_test.go:67: [Teardown] Removing containerd-check DS (no additional logs).
    containerd_test.go:71: [Teardown] containerd-check DS removed successfully.
--- PASS: TestContainerdConfig (5.05s)
    --- PASS: TestContainerdConfig/containerd-config-check (5.05s)
        --- PASS: TestContainerdConfig/containerd-config-check/DaemonSet_becomes_ready (5.01s)
PASS
ok      github.com/aws/aws-k8s-tester/test/cases/nvidia 17.075s
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
