### PR TITLE
Stabilize neuron training test

### DIFF
--- a/internal/e2e/conditions.go
+++ b/internal/e2e/conditions.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"log"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -77,10 +78,12 @@ func (c *ConditionExtension) ResourceCapacityNonZero(resourceLabel string) apima
         for _, node := range nodeList.Items {
             resource, ok := node.Status.Capacity[v1.ResourceName(resourceLabel)]
             if !ok {
-                return false, fmt.Errorf("Node %s does not have %s capacity defined", node.Name, resourceLabel)
+                log.Printf("Node %s does not have %s capacity defined", node.Name, resourceLabel)
+                return false, nil
             }
             if resource.Value() <= 0 {
-                return false, fmt.Errorf("Node %s has zero %s capacity", node.Name, resourceLabel)
+                log.Printf("Node %s has zero %s capacity", node.Name, resourceLabel)
+                return false, nil
             }
         }
         return true, nil

--- a/internal/e2e/conditions.go
+++ b/internal/e2e/conditions.go
@@ -66,7 +66,7 @@ func (c *ConditionExtension) JobSucceeded(job k8s.Object) apimachinerywait.Condi
 	}
 }
 
-func (c *ConditionExtension) ResourceCapacityNonZero(resourceLabel string) apimachinerywait.ConditionWithContextFunc {
+func (c *ConditionExtension) AllNodesHaveNonZeroResourceCapacity(resourceLabel string) apimachinerywait.ConditionWithContextFunc {
     return func(ctx context.Context) (done bool, err error) {
         nodeList := &v1.NodeList{}
         if err := c.resources.List(ctx, nodeList); err != nil {
@@ -78,11 +78,9 @@ func (c *ConditionExtension) ResourceCapacityNonZero(resourceLabel string) apima
         for _, node := range nodeList.Items {
             resource, ok := node.Status.Capacity[v1.ResourceName(resourceLabel)]
             if !ok {
-                log.Printf("Node %s does not have %s capacity defined", node.Name, resourceLabel)
                 return false, nil
             }
             if resource.Value() <= 0 {
-                log.Printf("Node %s has zero %s capacity", node.Name, resourceLabel)
                 return false, nil
             }
         }

--- a/internal/e2e/conditions.go
+++ b/internal/e2e/conditions.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"log"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"

--- a/test/cases/neuron-training/main_test.go
+++ b/test/cases/neuron-training/main_test.go
@@ -191,36 +191,36 @@ func checkNonZeroResourceCapacity(ctx context.Context, config *envconf.Config) (
     // Check Neuron devices
     log.Println("Checking Neuron device capacity on nodes")
     err := wait.For(
-        fwext.NewConditionExtension(config.Client().Resources()).ResourceCapacityNonZero("aws.amazon.com/neuron"),
+        fwext.NewConditionExtension(config.Client().Resources()).AllNodesHaveNonZeroResourceCapacity("aws.amazon.com/neuron"),
         wait.WithTimeout(time.Second*60),
         wait.WithInterval(time.Second*5),
     )
     if err != nil {
-        return ctx, fmt.Errorf("timeout waiting for Neuron devices to be available: %w", err)
+        return ctx, fmt.Errorf("failed to verify Neuron device capacity on nodes: %w", err)
     }
     log.Println("Neuron devices check passed - all nodes have non-zero capacity")
 
     // Check Neuron cores
     log.Println("Checking Neuron core capacity on nodes")
     err = wait.For(
-        fwext.NewConditionExtension(config.Client().Resources()).ResourceCapacityNonZero("aws.amazon.com/neuroncore"),
+        fwext.NewConditionExtension(config.Client().Resources()).AllNodesHaveNonZeroResourceCapacity("aws.amazon.com/neuroncore"),
         wait.WithTimeout(time.Second*60),
         wait.WithInterval(time.Second*5),
     )
     if err != nil {
-        return ctx, fmt.Errorf("timeout waiting for Neuron cores to be available: %w", err)
+        return ctx, fmt.Errorf("failed to verify Neuron core capacity on nodes: %w", err)
     }
     log.Println("Neuron cores check passed - all nodes have non-zero capacity")
 
     // Check EFA devices
     log.Println("Checking EFA device capacity on nodes")
     err = wait.For(
-        fwext.NewConditionExtension(config.Client().Resources()).ResourceCapacityNonZero("vpc.amazonaws.com/efa"),
+        fwext.NewConditionExtension(config.Client().Resources()).AllNodesHaveNonZeroResourceCapacity("vpc.amazonaws.com/efa"),
         wait.WithTimeout(time.Second*60),
         wait.WithInterval(time.Second*5),
     )
     if err != nil {
-        return ctx, fmt.Errorf("timeout waiting for EFA devices to be available: %w", err)
+        return ctx, fmt.Errorf("failed to verify EFA device capacity on nodes: %w", err)
     }
     log.Println("EFA devices check passed - all nodes have non-zero capacity")
 

--- a/test/cases/neuron-training/manifests/bert-training.yaml
+++ b/test/cases/neuron-training/manifests/bert-training.yaml
@@ -8,6 +8,7 @@ spec:
   completionMode: Indexed
   completions: {{.NodeCount}}
   parallelism: {{.NodeCount}}
+  backoffLimit: 0
   template:
     spec:
       restartPolicy: Never

--- a/test/cases/neuron-training/vars.go
+++ b/test/cases/neuron-training/vars.go
@@ -17,6 +17,7 @@ var (
 	efaPerNode        int
 	neuronPerNode     int
 	neuronCorePerNode int
+	retries           *int
 )
 
 func init() {
@@ -24,4 +25,5 @@ func init() {
 	bertTrainingImage = flag.String("bertTrainingImage", "", "Docker image used for BERT training workload")
 	efaEnabled = flag.Bool("efaEnabled", false, "Enable Elastic Fabric Adapter (EFA)")
 	nodeType = flag.String("nodeType", "", "Instance type for cluster nodes (e.g., inf1.24xlarge)")
+	retries = flag.Int("retries", 2, "Number of retries to attempt before marking the test as failed.")
 }

--- a/test/images/neuron-training/train.py
+++ b/test/images/neuron-training/train.py
@@ -88,6 +88,12 @@ def main():
         init_method="xla://"
     )
 
+    print(f"[RANK {RANK}] waiting for all processes to join")
+    # need to make sure all processes are initialized together. variance in compilation times
+    # and whatnot can cause later failures if processes on different nodes start first epoch
+    # earlier than others
+    dist.barrier()
+
     # print info with xla runtime functions to sanity check run context correctly propagates to backend
     print(f"Starting train.py with rank={xr.global_ordinal()}, world_size={xr.world_size()}")
 

--- a/test/images/neuron-training/train.py
+++ b/test/images/neuron-training/train.py
@@ -88,12 +88,6 @@ def main():
         init_method="xla://"
     )
 
-    print(f"[RANK {RANK}] waiting for all processes to join")
-    # need to make sure all processes are initialized together. variance in compilation times
-    # and whatnot can cause later failures if processes on different nodes start first epoch
-    # earlier than others
-    dist.barrier()
-
     # print info with xla runtime functions to sanity check run context correctly propagates to backend
     print(f"Starting train.py with rank={xr.global_ordinal()}, world_size={xr.world_size()}")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Neuron training seems to have a NCCL timeout at the first step mark for the first epoch on the very first run on a node, i.e., when the image has to pull. This gets around that by retrying it, since on the retry the image would already be present. The most obvious solution would be using some sort of barrier (e.g. xm.rendezvous() or dist.barrier()) before the first mark step, but those do not seem to accomplish the desired behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
