### PR TITLE
fix(neuron/multi-node): Wait for neuron device info to propagate, enable run on more than 2 nodes

### DIFF
--- a/internal/e2e/resources.go
+++ b/internal/e2e/resources.go
@@ -6,13 +6,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func GetNonZeroResourceCapacityOrError(node v1.Node, resourceName string) (int, error) {
+func GetNonZeroResourceCapacity(node v1.Node, resourceName string) (int, error) {
 	capacity, ok := node.Status.Capacity[v1.ResourceName(resourceName)]
 	if !ok {
-		return 0, fmt.Errorf("node \"%s\" has no resource \"%s\"", node.Name, resourceName)
+		return 0, fmt.Errorf("node %q has no resource %q", node.Name, resourceName)
 	}
 	if capacity.Value() == 0 {
-		return 0, fmt.Errorf("node \"%s\" has zero capacity for resource \"%s\"", node.Name, resourceName)
+		return 0, fmt.Errorf("node %q has zero capacity for resource %q", node.Name, resourceName)
 	}
 	return int(capacity.Value()), nil
 }

--- a/internal/e2e/resources.go
+++ b/internal/e2e/resources.go
@@ -6,7 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func GetNonZeroResourceCapacity(node v1.Node, resourceName string) (int, error) {
+func GetNonZeroResourceCapacity(node *v1.Node, resourceName string) (int, error) {
 	capacity, ok := node.Status.Capacity[v1.ResourceName(resourceName)]
 	if !ok {
 		return 0, fmt.Errorf("node %q has no resource %q", node.Name, resourceName)

--- a/internal/e2e/resources.go
+++ b/internal/e2e/resources.go
@@ -1,0 +1,18 @@
+package e2e
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func GetNonZeroResourceCapacityOrError(node v1.Node, resourceName string) (int, error) {
+	capacity, ok := node.Status.Capacity[v1.ResourceName(resourceName)]
+	if !ok {
+		return 0, fmt.Errorf("node \"%s\" has no resource \"%s\"", node.Name, resourceName)
+	}
+	if capacity.Value() == 0 {
+		return 0, fmt.Errorf("node \"%s\" has zero capacity for resource \"%s\"", node.Name, resourceName)
+	}
+	return int(capacity.Value()), nil
+}

--- a/test/cases/neuron/main_test.go
+++ b/test/cases/neuron/main_test.go
@@ -108,7 +108,7 @@ func checkNodeTypes(ctx context.Context, config *envconf.Config) (context.Contex
 		return ctx, fmt.Errorf("no nodes found in the cluster")
 	}
 
-	var nodeCount, totalEfaCount, totalNeuronCoreCount, totalNeuronCount int
+	var totalEfaCount, totalNeuronCoreCount, totalNeuronCount int
 	if *nodeType == "" {
 		nodeType = aws.String(nodes.Items[0].Labels["node.kubernetes.io/instance-type"])
 		log.Printf("No node type specified. Using the node type %s in the node groups.", *nodeType)

--- a/test/cases/neuron/main_test.go
+++ b/test/cases/neuron/main_test.go
@@ -115,14 +115,14 @@ func checkNodeTypes(ctx context.Context, config *envconf.Config) (context.Contex
 	}
 	for _, node := range nodes.Items {
 		if node.Labels["node.kubernetes.io/instance-type"] == *nodeType {
-			neuron, err := e2e.GetNonZeroResourceCapacityOrError(node, "aws.amazon.com/neuron")
+			neuron, err := e2e.GetNonZeroResourceCapacity(&node, "aws.amazon.com/neuron")
 			if err != nil {
 				return nil, err
 			}
 			totalNeuronCount += neuron
 
 			// Check for NeuronCore capacity
-			neuronCore, err := e2e.GetNonZeroResourceCapacityOrError(node, "aws.amazon.com/neuroncore")
+			neuronCore, err := e2e.GetNonZeroResourceCapacity(&node, "aws.amazon.com/neuroncore")
 			if err != nil {
 				return nil, err
 			}
@@ -130,7 +130,7 @@ func checkNodeTypes(ctx context.Context, config *envconf.Config) (context.Contex
 
 			// Check for EFA capacity
 			if *efaEnabled {
-				efa, err := e2e.GetNonZeroResourceCapacityOrError(node, "vpc.amazonaws.com/efa")
+				efa, err := e2e.GetNonZeroResourceCapacity(&node, "vpc.amazonaws.com/efa")
 				if err != nil {
 					return nil, err
 				}

--- a/test/cases/neuron/main_test.go
+++ b/test/cases/neuron/main_test.go
@@ -146,7 +146,7 @@ func checkNodeTypes(ctx context.Context, config *envconf.Config) (context.Contex
 		neuronCorePerNode = totalNeuronCoreCount / nodeCount
 		efaPerNode = totalEfaCount / nodeCount
 	} else {
-		return nil, fmt.Errorf("no nodes of type \"%s\"found", *nodeType)
+		return nil, fmt.Errorf("no nodes of type %q found", *nodeType)
 	}
 
 	log.Printf("[INFO] Total Nodes: %d", nodeCount)

--- a/test/cases/neuron/main_test.go
+++ b/test/cases/neuron/main_test.go
@@ -114,30 +114,31 @@ func checkNodeTypes(ctx context.Context, config *envconf.Config) (context.Contex
 		log.Printf("No node type specified. Using the node type %s in the node groups.", *nodeType)
 	}
 	for _, node := range nodes.Items {
-		if node.Labels["node.kubernetes.io/instance-type"] == *nodeType {
-			neuron, err := e2e.GetNonZeroResourceCapacity(&node, "aws.amazon.com/neuron")
-			if err != nil {
-				return nil, err
-			}
-			totalNeuronCount += neuron
-
-			// Check for NeuronCore capacity
-			neuronCore, err := e2e.GetNonZeroResourceCapacity(&node, "aws.amazon.com/neuroncore")
-			if err != nil {
-				return nil, err
-			}
-			totalNeuronCoreCount += neuronCore
-
-			// Check for EFA capacity
-			if *efaEnabled {
-				efa, err := e2e.GetNonZeroResourceCapacity(&node, "vpc.amazonaws.com/efa")
-				if err != nil {
-					return nil, err
-				}
-				totalEfaCount += efa
-			}
-			nodeCount += 1
+		if node.Labels["node.kubernetes.io/instance-type"] != *nodeType {
+			continue
 		}
+		neuron, err := e2e.GetNonZeroResourceCapacity(&node, "aws.amazon.com/neuron")
+		if err != nil {
+			return nil, err
+		}
+		totalNeuronCount += neuron
+
+		// Check for NeuronCore capacity
+		neuronCore, err := e2e.GetNonZeroResourceCapacity(&node, "aws.amazon.com/neuroncore")
+		if err != nil {
+			return nil, err
+		}
+		totalNeuronCoreCount += neuronCore
+
+		// Check for EFA capacity
+		if *efaEnabled {
+			efa, err := e2e.GetNonZeroResourceCapacity(&node, "vpc.amazonaws.com/efa")
+			if err != nil {
+				return nil, err
+			}
+			totalEfaCount += efa
+		}
+		nodeCount += 1
 	}
 
 	// Update global capacities

--- a/test/cases/neuron/manifests/k8s-neuron-device-plugin.yml
+++ b/test/cases/neuron/manifests/k8s-neuron-device-plugin.yml
@@ -69,7 +69,7 @@ spec:
                       - trn2.48xlarge
       containers:
         # Find all neuron-device-plugin images at https://gallery.ecr.aws/neuron/neuron-device-plugin
-      - image: public.ecr.aws/neuron/neuron-device-plugin:2.23.30.0 
+      - image: public.ecr.aws/neuron/neuron-device-plugin:2.23.45.0 
         imagePullPolicy: Always
         name: neuron-device-plugin
         env:

--- a/test/cases/neuron/manifests/multi-node-test-neuron.yaml
+++ b/test/cases/neuron/manifests/multi-node-test-neuron.yaml
@@ -27,18 +27,18 @@ spec:
             args:
             - -c
             - | 
-                WORKER_0_IP=$(getent hosts multi-node-nccom-test-worker-0.multi-node-nccom-test | awk '{print $1}')
-                WORKER_IPS=$WORKER_0_IP
+                WORKER_IPS=()
                 for i in $(seq 1 $(({{.WorkerNodeCount}} - 1))); do
-                  WORKER_IPS="$WORKER_IPS $(getent hosts multi-node-nccom-test-worker-$i.multi-node-nccom-test | awk '{print $1}')"
+                  WORKER_IP=$(getent hosts multi-node-nccom-test-worker-$i.multi-node-nccom-test | awk '{print $1}')
+                  WORKER_IPS+=("$WORKER_IP")
                 done
 
                 export CCOM_SOCKET_IFNAME=eth0
-                export NEURON_RT_ROOT_COMM_ID=$WORKER_0_IP:63182
+                export NEURON_RT_ROOT_COMM_ID=${WORKER_IPS[0]}:63182
                 export OMPI_ALLOW_RUN_AS_ROOT=1
                 export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-                nccom-test -r $(({{.NeuronCorePerNode}}*{{.WorkerNodeCount}})) -N {{.WorkerNodeCount}} -b "8" -e "2G" -f "2" -n "5" -w "5" -d "fp32" allr --hosts $WORKER_IPS --data-collector-host $POD_IP --data-collector-port 60006 --debug
+                nccom-test -r $(({{.NeuronCorePerNode}}*{{.WorkerNodeCount}})) -N {{.WorkerNodeCount}} -b "8" -e "2G" -f "2" -n "5" -w "5" -d "fp32" allr --hosts ${WORKER_IPS[*]} --data-collector-host $POD_IP --data-collector-port 60006 --debug
     Worker:
       replicas: {{.WorkerNodeCount}}
       template:

--- a/test/cases/neuron/manifests/multi-node-test-neuron.yaml
+++ b/test/cases/neuron/manifests/multi-node-test-neuron.yaml
@@ -24,82 +24,35 @@ spec:
                   fieldPath: status.podIP
             command:
             - /bin/sh
+            args:
             - -c
-            - |
-                echo password | sudo -S service ssh start
-
-                # Read the IPs from the hosts.txt file
-                WORKER_0_IP=$(sed -n '1p' /mnt/data/hosts.txt | tr -d '\r' | tr -d '\n' )
-                WORKER_1_IP=$(sed -n '2p' /mnt/data/hosts.txt | tr -d '\r' | tr -d '\n' )
+            - | 
+                WORKER_0_IP=$(getent hosts multi-node-nccom-test-worker-0.multi-node-nccom-test | awk '{print $1}')
+                WORKER_IPS=$WORKER_0_IP
+                for i in $(seq 1 $(({{.WorkerNodeCount}} - 1))); do
+                  WORKER_IPS="$WORKER_IPS $(getent hosts multi-node-nccom-test-worker-$i.multi-node-nccom-test | awk '{print $1}')"
+                done
 
                 export CCOM_SOCKET_IFNAME=eth0
                 export NEURON_RT_ROOT_COMM_ID=$WORKER_0_IP:63182
+                export OMPI_ALLOW_RUN_AS_ROOT=1
+                export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-                # Run the nccom-test command with the extracted IPs
-                NEURON_CORE_PER_NODE={{.NeuronCorePerNode}}
-                WORKER_NODE_COUNT={{.WorkerNodeCount}}
-                nccom-test -r $((NEURON_CORE_PER_NODE*WORKER_NODE_COUNT)) -N {{.WorkerNodeCount}} -b "8" -e "2G" -f "2" -n "5" -w "5" -d "fp32" allr --hosts $WORKER_0_IP $WORKER_1_IP --data-collector-host $POD_IP --data-collector-port 60006 --debug
-            ports:
-            - containerPort: 63182
-            - containerPort: 60006
-            - containerPort: 22
-            securityContext:
-              privileged: false
-            volumeMounts:
-              - name: shared-data
-                mountPath: /mnt/data
-          initContainers:
-          - name: init-worker-ips
-            image: {{.NeuronTestImage}}
-            command:
-            - /bin/sh
-            - -c
-            - |
-
-              WORKER_PODS=""
-              for i in $(seq 0 $(({{.WorkerNodeCount}} - 1))); do
-                WORKER_PODS="$WORKER_PODS multi-node-nccom-test-worker-$i"
-              done
-              WORKER_PODS=$(echo "$WORKER_PODS" | sed 's/ *$//')
-              
-              WORKER_IPS=""
-              # Collect worker pod IPs
-              for pod in $WORKER_PODS; do
-                IP=$(getent hosts $pod.multi-node-nccom-test.default.svc.cluster.local | awk '{print $1}')
-                if [ -z "$IP" ]; then
-                  echo "Error: Could not resolve IP for $pod" && exit 1
-                fi
-                WORKER_IPS="$WORKER_IPS$IP\n"
-              done
-
-              # Write the worker pod IPs to the shared volume
-              echo "$WORKER_IPS" > /mnt/data/hosts.txt
-            volumeMounts:
-              - name: shared-data
-                mountPath: /mnt/data
-          volumes:
-            - name: shared-data
-              emptyDir: {}
+                nccom-test -r $(({{.NeuronCorePerNode}}*{{.WorkerNodeCount}})) -N {{.WorkerNodeCount}} -b "8" -e "2G" -f "2" -n "5" -w "5" -d "fp32" allr --hosts $WORKER_IPS --data-collector-host $POD_IP --data-collector-port 60006 --debug
     Worker:
       replicas: {{.WorkerNodeCount}}
       template:
         spec:
           containers:
           - image: {{.NeuronTestImage}}
-            ports:
-            - containerPort: 63182
-            - containerPort: 60006
-            - containerPort: 22
             name: nccom-test-worker
-            command: ["/bin/sh", "-c"]
-            args: ["echo password | sudo -S service ssh start; while true; do sleep 30; done"]
             imagePullPolicy: Always
-            securityContext:
-              privileged: false
             resources:
               limits:
                 aws.amazon.com/neuron: {{.NeuronPerNode}}
+                aws.amazon.com/neuroncore: {{.NeuronCorePerNode}}
                 vpc.amazonaws.com/efa: {{.EfaInterfacePerNode}}
               requests:
                 aws.amazon.com/neuron: {{.NeuronPerNode}}
+                aws.amazon.com/neuroncore: {{.NeuronCorePerNode}}
                 vpc.amazonaws.com/efa: {{.EfaInterfacePerNode}}

--- a/test/cases/neuron/manifests/multi-node-test-neuron.yaml
+++ b/test/cases/neuron/manifests/multi-node-test-neuron.yaml
@@ -23,12 +23,12 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             command:
-            - /bin/sh
+            - /bin/bash
             args:
             - -c
-            - | 
+            - |
                 WORKER_IPS=()
-                for i in $(seq 1 $(({{.WorkerNodeCount}} - 1))); do
+                for i in $(seq 0 $(({{.WorkerNodeCount}} - 1))); do
                   WORKER_IP=$(getent hosts multi-node-nccom-test-worker-$i.multi-node-nccom-test | awk '{print $1}')
                   WORKER_IPS+=("$WORKER_IP")
                 done

--- a/test/cases/neuron/neuron_test.go
+++ b/test/cases/neuron/neuron_test.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"fmt"
 	"testing"
+	"time"
 
 	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
 	"github.com/aws/aws-k8s-tester/internal/e2e/mpijobs"
@@ -70,7 +71,9 @@ func TestNeuronNodes(t *testing.T) {
 			}
 			t.Log("Waiting for single node job to complete")
 			err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
-				wait.WithContext(ctx))
+				wait.WithContext(ctx),
+				wait.WithTimeout(time.Minute*20),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -126,7 +129,9 @@ func TestNeuronNodes(t *testing.T) {
 			ctx = context.WithValue(ctx, "mpiJob", mpiJob)
 			t.Log("Waiting for MPIJob to complete")
 			err := wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(mpiJob, mpijobs.MPIJobSucceeded),
-				wait.WithContext(ctx))
+				wait.WithContext(ctx),
+				wait.WithTimeout(time.Minute*30),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/cases/nvidia/main_test.go
+++ b/test/cases/nvidia/main_test.go
@@ -1,5 +1,3 @@
-//go:build e2e
-
 package nvidia
 
 import (

--- a/test/cases/nvidia/main_test.go
+++ b/test/cases/nvidia/main_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package nvidia
 
 import (

--- a/test/images/neuron/Dockerfile
+++ b/test/images/neuron/Dockerfile
@@ -1,11 +1,11 @@
 FROM public.ecr.aws/docker/library/ubuntu:22.04
 
 # Neuron SDK components version numbers
-ARG NEURONX_DISTRIBUTED_VERSION=0.10.0
-ARG NEURONX_CC_VERSION=2.16.345.0
+ARG NEURONX_DISTRIBUTED_VERSION=0.10.1
+ARG NEURONX_CC_VERSION=2.16.372.0
 ARG NEURONX_FRAMEWORK_VERSION=2.5.1.2.4.0
-ARG NEURONX_COLLECTIVES_LIB_VERSION=2.23.133.0-3e70920f2
-ARG NEURONX_RUNTIME_LIB_VERSION=2.23.110.0-9b5179492
+ARG NEURONX_COLLECTIVES_LIB_VERSION=2.23.135.0-3e70920f2
+ARG NEURONX_RUNTIME_LIB_VERSION=2.23.112.0-9b5179492
 ARG NEURONX_TOOLS_VERSION=2.20.204.0
 
 ARG PYTHON=python3.10
@@ -69,7 +69,7 @@ RUN echo 'ubuntu:password' | chpasswd
 RUN usermod -aG sudo ubuntu
 
 RUN apt update
-RUN apt install -y openssh-server wget gnupg2 sudo
+RUN apt install -y openssh-server openssh-client wget gnupg2 sudo
 
 # Install Neuron packages
 RUN . /etc/os-release
@@ -186,16 +186,11 @@ RUN HOME_DIR=/root \
 
 RUN curl -o /license.txt  https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.1/license.txt
 
-# Allow ssh to work without password/prompt so mpirun does not get stuck
-RUN sed -i -e 's/#   StrictHostKeyChecking ask/    StrictHostKeyChecking accept-new/g' /etc/ssh/ssh_config
+RUN mkdir -p /var/run/sshd && \
+    sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
+    echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
+    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config
 
 WORKDIR /home/ubuntu
-
-USER ubuntu
-RUN mkdir /home/ubuntu/.ssh
-RUN ssh-keygen -t rsa -f /home/ubuntu/.ssh/id_rsa -N ''
-RUN echo password | sudo -S chmod 600 /home/ubuntu/.ssh/id_rsa
-RUN echo password | sudo -S chmod 600 /home/ubuntu/.ssh/id_rsa.pub
-RUN echo password | sudo -S cat /home/ubuntu/.ssh/id_rsa.pub >> /home/ubuntu/.ssh/authorized_keys
 
 COPY test/images/neuron/tests ./tests


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Some changes so this test can support >2 nodes, and avoid flakes caused by early reads of neuron device information from the node before values are set.

Ran on 4 trn1.32xlarge nodes:
```
$ go test ./... -v -tags=e2e -timeout=60m --test.run=^TestNeuronNodes$/multi-node --efaEnabled=true --neuronTestImage=<IMAGE_URI> --nodeType=trn1.32xlarge 

$ k get pods
NAME                                   READY   STATUS    RESTARTS        AGE
multi-node-nccom-test-launcher-2z5lz   1/1     Running   2 (3m33s ago)   3m36s
multi-node-nccom-test-worker-0         1/1     Running   0               3m36s
multi-node-nccom-test-worker-1         1/1     Running   0               3m36s
multi-node-nccom-test-worker-2         1/1     Running   0               3m36s
multi-node-nccom-test-worker-3         1/1     Running   0               3m36s

[output]
... 
        [1,0]<stdout>:+---+----+[1,0]<stdout>:---------+---------+------------+-------+--------+[1,0]<stdout>:----------+----------+----------+--------+---------+---------+-------+
               size(B)    count(elems)    type    time:avg(us)    algbw(GB/s)    busbw(GB/s)
                     8               2    fp32         1209.66           0.00           0.00
                    16               4    fp32         1212.37           0.00           0.00
                    32               8    fp32         1195.08           0.00           0.00
                    64              16    fp32         1065.07           0.00           0.00
                   128              32    fp32         1200.62           0.00           0.00
                   256              64    fp32         1215.22           0.00           0.00
                   512             128    fp32         1219.41           0.00           0.00
                  1024             256    fp32         1230.95           0.00           0.00
                  2048             512    fp32         1232.07           0.00           0.00
                  4096            1024    fp32          1237.5           0.00           0.01
                  8192            2048    fp32         1226.38           0.01           0.01
                 16384            4096    fp32         1223.28           0.01           0.03
                 32768            8192    fp32         1221.73           0.03           0.05
                 65536           16384    fp32         1234.03           0.05           0.11
                131072           32768    fp32         1229.32           0.11           0.21
                262144           65536    fp32         1234.87           0.21           0.42
                524288          131072    fp32         1245.72           0.42           0.84
               1048576          262144    fp32         1440.84           0.73           1.44
               2097152          524288    fp32         1425.63           1.47           2.92
               4194304         1048576    fp32          682.31           6.15          12.20
               8388608         2097152    fp32          637.75          13.15          26.10
              16777216         4194304    fp32         1026.31          16.35          32.44
              33554432         8388608    fp32          1239.4          27.07          53.72
              67108864        16777216    fp32         2129.18          31.52          62.54
             134217728        33554432    fp32         4342.88          30.91          61.33
             268435456        67108864    fp32         8237.32          32.59          64.67
             536870912       134217728    fp32        13939.16          38.52          76.43
            1073741824       268435456    fp32        22432.64          47.87          94.98
            2147483648       536870912    fp32        44185.72          48.60          96.44
        Avg bus bandwidth:	20.2378GB/s

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
