### PR TITLE
fix: error when none of the provided instance types are valid

### DIFF
--- a/internal/deployers/eksapi/node.go
+++ b/internal/deployers/eksapi/node.go
@@ -145,6 +145,9 @@ func (m *nodeManager) resolveInstanceTypes(opts *deployerOptions) (err error) {
 	if err != nil {
 		return err
 	}
+	if len(validInstanceTypes) == 0 {
+		return fmt.Errorf("none of the instance types %v were valid", instanceTypes)
+	}
 	opts.InstanceTypes = validInstanceTypes
 	klog.Infof("using instance types: %v", opts.InstanceTypes)
 	return nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When using a managed nodegroup you will see something like the following if you provide `--instance-types` that end up getting filtered out by `nodeManager.getValidInstanceTypes`:

```
node.go:736] Eliminating instance type g3.4xlarge as an option
node.go:149] using instance types: []
```

in this scenario i expect that the kubetest2 deployer will abort due to being unable to launch any of my desired instance types, but instead it launches instances using the defaults. (ex. `t3.medium`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
