### PR TITLE
fix: nil pointer when cluster creation fails

### DIFF
--- a/internal/deployers/eksapi/cluster.go
+++ b/internal/deployers/eksapi/cluster.go
@@ -105,8 +105,10 @@ func (m *ClusterManager) waitForClusterActive(clusterName string) (*Cluster, err
 	out, err := eks.NewClusterActiveWaiter(m.clients.EKS()).WaitForOutput(context.TODO(), &eks.DescribeClusterInput{
 		Name: aws.String(clusterName),
 	}, clusterCreationTimeout)
-	// log whether there was an error or not
-	klog.Infof("cluster details: %+v", out.Cluster)
+	// log when possible, whether there was an error or not
+	if out != nil {
+		klog.Infof("cluster details: %+v", out.Cluster)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed waiting for cluster be active: %v", err)
 	}


### PR DESCRIPTION
*Description of changes:*

If the cluster waiter has never received a response from `eks:DescribeCluster` (for whatever reason) then `out` may be `nil`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
