### PR TITLE
build(nvidia): pin cuda-samples version

### DIFF
--- a/test/images/nvidia/Dockerfile
+++ b/test/images/nvidia/Dockerfile
@@ -45,7 +45,7 @@ RUN apt install -y \
   libglu1-mesa-dev \
   datacenter-gpu-manager
 
-RUN git clone https://github.com/NVIDIA/cuda-samples.git && \
+RUN git clone https://github.com/NVIDIA/cuda-samples.git --branch v12.5 && \
     cd cuda-samples && cd Samples && \
     cd 0_Introduction/vectorAdd && make && cp vectorAdd /usr/bin && cd - && \
     cd 1_Utilities/deviceQuery && make && cp deviceQuery /usr/bin && cd - && \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

a new tag `v12.8` was released for https://github.com/NVIDIA/cuda-samples.git that changes the build system and several other features. 

This PR pins this repository to the tag it was originally built with.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
