### PR TITLE
fix: use rendered manifest for single-node training teardown

### DIFF
--- a/test/cases/nvidia/mpi_test.go
+++ b/test/cases/nvidia/mpi_test.go
@@ -43,12 +43,15 @@ type ncclTestManifestTplVars struct {
 }
 
 func TestMPIJobPytorchTraining(t *testing.T) {
+	var renderedSingleNodeManifest []byte
+
 	singleNode := features.New("single-node").
 		WithLabel("suite", "nvidia").
 		WithLabel("hardware", "gpu").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			t.Log("Applying single node manifest")
-			renderedSingleNodeManifest, err := fwext.RenderManifests(mpiJobPytorchTrainingSingleNodeManifest, struct {
+			var err error
+			renderedSingleNodeManifest, err = fwext.RenderManifests(mpiJobPytorchTrainingSingleNodeManifest, struct {
 				PytorchTestImage string
 			}{
 				PytorchTestImage: *pytorchImage,
@@ -91,7 +94,7 @@ func TestMPIJobPytorchTraining(t *testing.T) {
 			}
 			t.Log("Test log for pytorch-training-single-node:")
 			t.Log(log)
-			err = fwext.DeleteManifests(cfg.Client().RESTConfig(), mpiJobPytorchTrainingSingleNodeManifest)
+			err = fwext.DeleteManifests(cfg.Client().RESTConfig(), renderedSingleNodeManifest)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
cr: https://code.amazon.com/reviews/CR-178940369

*Issue #, if available:*

*Description of changes:*

fixes an error where the manifest was not rendered in the `Teardown` phase of the single node MPI job test.

```
mpi_test.go:96: yaml: invalid map key: map[interface {}]interface {}{".PytorchTestImage":interface {}(nil)}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
