### PR TITLE
feat(test/quick): Add test to detect io_uring hangs with npm install 

### DIFF
--- a/test/cases/quick/io_uring_test.go
+++ b/test/cases/quick/io_uring_test.go
@@ -3,16 +3,21 @@
 package quick
 
 import (
+	"bytes"
 	"context"
 	"log"
 	"testing"
 	"time"
 
-	"github.com/aws/aws-k8s-tester/internal/e2e"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+
+	"github.com/aws/aws-k8s-tester/internal/e2e"
 
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"
@@ -20,28 +25,56 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
+func execInPod(config *rest.Config, namespace, podName, containerName string, command []string) (string, string, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", "", err
+	}
+
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec")
+
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: containerName,
+		Command:   command,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return "", "", err
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	return stdout.String(), stderr.String(), err
+}
+
 func TestNpmInstallWithCPULimits(t *testing.T) {
 	feat := features.New("npm-install-cpu-limits").
 		WithLabel("suite", "quick").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			log.Println("[Setup] Verifying ARM64 nodes...")
+			log.Println("[Setup] Verifying cluster nodes...")
 			var nodeList corev1.NodeList
 			if err := cfg.Client().Resources().List(ctx, &nodeList); err != nil {
 				t.Fatalf("Failed to list nodes: %v", err)
 			}
 
-			hasArm64Node := false
+			// Log node information
 			for _, node := range nodeList.Items {
 				arch := node.Labels["kubernetes.io/arch"]
-				t.Logf("Node: %s, Architecture: %s", node.Name, arch)
-				if arch == "arm64" {
-					hasArm64Node = true
-					break
-				}
-			}
-
-			if !hasArm64Node {
-				t.Fatal("No ARM64 nodes found in cluster")
+				kernelVersion := node.Status.NodeInfo.KernelVersion
+				t.Logf("Node: %s, Architecture: %s, Kernel: %s", node.Name, arch, kernelVersion)
 			}
 			return ctx
 		}).
@@ -58,25 +91,11 @@ func TestNpmInstallWithCPULimits(t *testing.T) {
 					},
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{
-						"kubernetes.io/arch": "arm64",
-					},
 					Containers: []corev1.Container{
 						{
 							Name:    "test-container",
 							Image:   "ubuntu:noble-20241015",
-							Command: []string{"/bin/sh", "-c"},
-							Args: []string{`
-								set -x
-								echo "[Test] Starting npm installation test..."
-								mkdir asd && 
-								cd asd && 
-								apt-get update && 
-								apt-get install -y npm nodejs && 
-								echo "[Test] Starting npm install express..."
-								npm install express --loglevel verbose || exit 1
-								echo "[Test] npm install completed successfully"
-							`},
+							Command: []string{"sleep", "100000000000000"},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -97,18 +116,35 @@ func TestNpmInstallWithCPULimits(t *testing.T) {
 				t.Fatalf("[Assess] Failed to create pod: %v", err)
 			}
 
-			log.Printf("[Assess] Waiting up to 5 minutes for pod %s to complete...", podName)
+			// Wait for pod to be running
+			log.Printf("[Assess] Waiting for pod %s to be running...", podName)
 			err := wait.For(
 				e2e.NewConditionExtension(cfg.Client().Resources()).ResourceMatch(pod, func(object k8s.Object) bool {
 					pod := object.(*corev1.Pod)
-					return pod.Status.Phase == corev1.PodSucceeded
+					return pod.Status.Phase == corev1.PodRunning
 				}),
-				wait.WithTimeout(5*time.Minute),
+				wait.WithTimeout(2*time.Minute),
 			)
 			if err != nil {
-				t.Logf("[Assess] Pod did not complete successfully: %v", err)
-				e2e.PrintDaemonSetPodLogs(t, ctx, cfg.Client().RESTConfig(), podNS, "app=npm-install-test")
-				t.Fatal("Pod did not complete within 5 minutes - possible io_uring hang detected")
+				t.Fatalf("[Assess] Pod did not start running: %v", err)
+			}
+
+			// Execute commands in the pod
+			execCmd := []string{
+				"bash", "-c",
+				`mkdir asd && 
+				cd asd && 
+				apt-get update && 
+				apt-get install -y npm nodejs && 
+				npm install karma@~6.4.0 --loglevel verbose`,
+			}
+
+			log.Printf("[Assess] Executing npm install in pod...")
+			stdout, stderr, err := execInPod(cfg.Client().RESTConfig(), podNS, podName, "test-container", execCmd)
+			if err != nil {
+				t.Logf("stdout: %s", stdout)
+				t.Logf("stderr: %s", stderr)
+				t.Fatal("npm install failed or hung")
 			}
 
 			log.Printf("[Assess] Pod %s completed successfully", podName)

--- a/test/cases/quick/io_uring_test.go
+++ b/test/cases/quick/io_uring_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-k8s-tester/internal/e2e"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/e2e-framework/klient/k8s"
@@ -67,16 +66,16 @@ func TestNpmInstallWithCPULimits(t *testing.T) {
 								npm install webpack --loglevel verbose || exit 1
 								echo "[Test] npm install completed successfully"
 							`},
-							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500m"),
-									corev1.ResourceMemory: resource.MustParse("1Gi"),
-								},
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500m"),
-									corev1.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
+							// Resources: corev1.ResourceRequirements{
+							// 	Limits: corev1.ResourceList{
+							// 		corev1.ResourceCPU:    resource.MustParse("500m"),
+							// 		corev1.ResourceMemory: resource.MustParse("1Gi"),
+							// 	},
+							// 	Requests: corev1.ResourceList{
+							// 		corev1.ResourceCPU:    resource.MustParse("500m"),
+							// 		corev1.ResourceMemory: resource.MustParse("1Gi"),
+							// 	},
+							// },
 						},
 					},
 					RestartPolicy: corev1.RestartPolicyNever,

--- a/test/cases/quick/io_uring_test.go
+++ b/test/cases/quick/io_uring_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNpmInstallWithCPULimits(t *testing.T) {
-	feat := features.New("npm-install-cpu-limits").
+	feat := features.New("npm-install").
 		WithLabel("suite", "quick").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			log.Println("[Setup] Verifying cluster nodes...")

--- a/test/cases/quick/io_uring_test.go
+++ b/test/cases/quick/io_uring_test.go
@@ -37,7 +37,7 @@ func TestNpmInstallWithCPULimits(t *testing.T) {
 			}
 			return ctx
 		}).
-		Assess("Pod can successfully run npm install with CPU limits", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("Pod can successfully run npm install", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			podName := "npm-install-test"
 			podNS := "default"
 
@@ -66,16 +66,6 @@ func TestNpmInstallWithCPULimits(t *testing.T) {
 								npm install webpack --loglevel verbose || exit 1
 								echo "[Test] npm install completed successfully"
 							`},
-							// Resources: corev1.ResourceRequirements{
-							// 	Limits: corev1.ResourceList{
-							// 		corev1.ResourceCPU:    resource.MustParse("500m"),
-							// 		corev1.ResourceMemory: resource.MustParse("1Gi"),
-							// 	},
-							// 	Requests: corev1.ResourceList{
-							// 		corev1.ResourceCPU:    resource.MustParse("500m"),
-							// 		corev1.ResourceMemory: resource.MustParse("1Gi"),
-							// 	},
-							// },
 						},
 					},
 					RestartPolicy: corev1.RestartPolicyNever,

--- a/test/cases/quick/io_uring_test.go
+++ b/test/cases/quick/io_uring_test.go
@@ -1,0 +1,136 @@
+//go:build e2e
+
+package quick
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-k8s-tester/internal/e2e"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestNpmInstallWithCPULimits(t *testing.T) {
+	feat := features.New("npm-install-cpu-limits").
+		WithLabel("suite", "quick").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			log.Println("[Setup] Verifying ARM64 nodes...")
+			var nodeList corev1.NodeList
+			if err := cfg.Client().Resources().List(ctx, &nodeList); err != nil {
+				t.Fatalf("Failed to list nodes: %v", err)
+			}
+
+			hasArm64Node := false
+			for _, node := range nodeList.Items {
+				arch := node.Labels["kubernetes.io/arch"]
+				t.Logf("Node: %s, Architecture: %s", node.Name, arch)
+				if arch == "arm64" {
+					hasArm64Node = true
+					break
+				}
+			}
+
+			if !hasArm64Node {
+				t.Fatal("No ARM64 nodes found in cluster")
+			}
+			return ctx
+		}).
+		Assess("Pod can successfully run npm install with CPU limits", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			podName := "npm-install-test"
+			podNS := "default"
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: podNS,
+					Labels: map[string]string{
+						"app": "npm-install-test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/arch": "arm64",
+					},
+					Containers: []corev1.Container{
+						{
+							Name:    "test-container",
+							Image:   "ubuntu:noble-20241015",
+							Command: []string{"/bin/sh", "-c"},
+							Args: []string{`
+								set -x
+								echo "[Test] Starting npm installation test..."
+								mkdir asd && 
+								cd asd && 
+								apt-get update && 
+								apt-get install -y npm nodejs && 
+								echo "[Test] Starting npm install express..."
+								npm install express --loglevel verbose || exit 1
+								echo "[Test] npm install completed successfully"
+							`},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			}
+
+			if err := cfg.Client().Resources().Create(ctx, pod); err != nil {
+				t.Fatalf("[Assess] Failed to create pod: %v", err)
+			}
+
+			log.Printf("[Assess] Waiting up to 5 minutes for pod %s to complete...", podName)
+			err := wait.For(
+				e2e.NewConditionExtension(cfg.Client().Resources()).ResourceMatch(pod, func(object k8s.Object) bool {
+					pod := object.(*corev1.Pod)
+					return pod.Status.Phase == corev1.PodSucceeded
+				}),
+				wait.WithTimeout(5*time.Minute),
+			)
+			if err != nil {
+				t.Logf("[Assess] Pod did not complete successfully: %v", err)
+				e2e.PrintDaemonSetPodLogs(t, ctx, cfg.Client().RESTConfig(), podNS, "app=npm-install-test")
+				t.Fatal("Pod did not complete within 5 minutes - possible io_uring hang detected")
+			}
+
+			log.Printf("[Assess] Pod %s completed successfully", podName)
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			podName := "npm-install-test"
+			podNS := "default"
+
+			t.Logf("[Teardown] Cleaning up pod %s/%s...", podNS, podName)
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: podNS,
+				},
+			}
+			if err := cfg.Client().Resources().Delete(ctx, pod); err != nil {
+				t.Logf("[Teardown] Failed to delete pod: %v", err)
+			}
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}

--- a/test/cases/quick/main_test.go
+++ b/test/cases/quick/main_test.go
@@ -3,17 +3,37 @@
 package quick
 
 import (
+	"context"
+	_ "embed"
+	"log"
 	"os"
+	"os/signal"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
 var (
 	testenv env.Environment
+	_       = time.Now()
 )
 
 func TestMain(m *testing.M) {
-	testenv = env.New()
+	cfg, err := envconf.NewFromFlags()
+	if err != nil {
+		log.Fatalf("failed to initialize test environment: %v", err)
+	}
+	testenv = env.NewWithConfig(cfg)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	testenv = testenv.WithContext(ctx)
+
+	testenv.Setup(func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+		log.Println("Starting quick test suite...")
+		return ctx, nil
+	})
+
 	os.Exit(testenv.Run(m))
 }

--- a/test/cases/quick/main_test.go
+++ b/test/cases/quick/main_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"testing"
-	"time"
 
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -17,7 +16,6 @@ import (
 
 var (
 	testenv env.Environment
-	_       = time.Now()
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/2070

*Description of changes:*
This PR adds an e2e test to detect io_uring-related hangs that can occur when running npm install with CPU limits. The test:

   - Logs cluster node information including kernel versions
   - Creates a pod with CPU limits (500m) that attempts to install webpack
   - Fails if the installation hangs for more than 10 minutes
   - Passes if the installation completes successfully

This test would have caught the issue reported in #2070 where npm installations would hang indefinitely on certain AMIs (kernel 6.1.115-126.197.amzn2023) due to an io_uring kernel bug. The test uses the ECR-hosted Ubuntu noble image and webpack as a representative large npm package to trigger potential io_uring issues.

*Testing:*

**Bugged AMI (amazon-eks-node-al2023-arm64-standard-1.29-v20241115)**
```
go test -v -tags=e2e . -run TestNpmInstallWithCPULimits
2025/03/03 02:55:09 Starting quick test suite...
        /home/mattcjo/github-aws-mattcjo/aws-k8s-tester/test/cases/quick/io_uring_test.go:143 +0x9f6
sigs.k8s.io/e2e-framework/pkg/env.(*testEnv).executeSteps(0xc000249ef0, {0x2df34a0?, 0xc0004597c0?}, 0xc0002921a0, {0xc00048c740?, 0xc00048c760?, 0x10889bc?})
        /home/mattcjo/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.3.0/pkg/env/env.go:428 +0x8b
sigs.k8s.io/e2e-framework/pkg/env.(*testEnv).processTestFeature.(*testEnv).execFeature.func1.1(0xc0002921a0)
        /home/mattcjo/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.3.0/pkg/env/env.go:466 +0xaa
testing.tRunner(0xc0002921a0, 0xc00040c1b0)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/testing/testing.go:1690 +0xf4
created by testing.(*T).Run in goroutine 11
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/testing/testing.go:1743 +0x390

goroutine 71 [select, 9 minutes]:
github.com/moby/spdystream.(*Stream).Read(0xc00024e280, {0xc000530000, 0x200, 0xcc000293e10?})
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/stream.go:96 +0x95
io.ReadAll({0x7fe57c11a238, 0xc00024e280})
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/io/io.go:712 +0x7e
k8s.io/client-go/tools/remotecommand.watchErrorStream.func1()
        /home/mattcjo/go/pkg/mod/k8s.io/client-go@v0.31.3/tools/remotecommand/errorstream.go:41 +0x6e
created by k8s.io/client-go/tools/remotecommand.watchErrorStream in goroutine 40
        /home/mattcjo/go/pkg/mod/k8s.io/client-go@v0.31.3/tools/remotecommand/errorstream.go:38 +0xac

goroutine 37 [select]:
github.com/moby/spdystream.(*idleAwareFramer).monitor(0xc0004586c0)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:77 +0xd2
created by github.com/moby/spdystream.NewConnection in goroutine 23
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:269 +0x36e

goroutine 38 [IO wait]:
internal/poll.runtime_pollWait(0x7fe58cb43ee8, 0x72)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/runtime/netpoll.go:351 +0x85
internal/poll.(*pollDesc).wait(0xc0001c6b80?, 0xc00047b000?, 0x0)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc0001c6b80, {0xc00047b000, 0x1000, 0x1000})
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/internal/poll/fd_unix.go:165 +0x27a
net.(*netFD).Read(0xc0001c6b80, {0xc00047b000?, 0x170000c0001ab8e0?, 0x15?})
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/net/fd_posix.go:55 +0x25
net.(*conn).Read(0xc000402038, {0xc00047b000?, 0x0?, 0xc000584c40?})
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/net/net.go:189 +0x45
crypto/tls.(*atLeastReader).Read(0xc000622180, {0xc00047b000?, 0x0?, 0xc000622180?})
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/crypto/tls/conn.go:809 +0x3b
bytes.(*Buffer).ReadFrom(0xc0005e17b8, {0x2dd6080, 0xc000622180})
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/bytes/buffer.go:211 +0x98
crypto/tls.(*Conn).readFromUntil(0xc0005e1508, {0x2dd5820, 0xc000402038}, 0xc0001aba28?)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/crypto/tls/conn.go:831 +0xde
crypto/tls.(*Conn).readRecordOrCCS(0xc0005e1508, 0x0)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/crypto/tls/conn.go:629 +0x3cf
crypto/tls.(*Conn).readRecord(...)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/crypto/tls/conn.go:591
crypto/tls.(*Conn).Read(0xc0005e1508, {0xc00011c804, 0x4, 0xfa5629?})
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/crypto/tls/conn.go:1385 +0x150
io.ReadAtLeast({0x7fe57c217380, 0xc0005e1508}, {0xc00011c804, 0x4, 0x4}, 0x4)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/io/io.go:335 +0x90
io.ReadFull(...)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/io/io.go:354
encoding/binary.Read({0x7fe57c217380, 0xc0005e1508}, {0x2df9bd0, 0x4160f80}, {0x26984a0, 0xc0001abe24})
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/encoding/binary/binary.go:244 +0xa5
github.com/moby/spdystream/spdy.(*Framer).ReadFrame(0xc000052ea0)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/spdy/read.go:164 +0x49
github.com/moby/spdystream.(*idleAwareFramer).ReadFrame(0xc0004586c0)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:167 +0x1e
github.com/moby/spdystream.(*Connection).Serve(0xc000410000, 0xc000626340)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:346 +0x265
created by k8s.io/apimachinery/pkg/util/httpstream/spdy.newConnection in goroutine 23
        /home/mattcjo/go/pkg/mod/k8s.io/apimachinery@v0.31.3/pkg/util/httpstream/spdy/connection.go:94 +0x127

goroutine 39 [select]:
k8s.io/apimachinery/pkg/util/httpstream/spdy.(*connection).sendPings(0xc00037dd10, 0x0?)
        /home/mattcjo/go/pkg/mod/k8s.io/apimachinery@v0.31.3/pkg/util/httpstream/spdy/connection.go:192 +0xc6
created by k8s.io/apimachinery/pkg/util/httpstream/spdy.newConnection in goroutine 23
        /home/mattcjo/go/pkg/mod/k8s.io/apimachinery@v0.31.3/pkg/util/httpstream/spdy/connection.go:96 +0x185

goroutine 40 [semacquire, 9 minutes]:
sync.runtime_Semacquire(0x2410b27?)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/runtime/sema.go:71 +0x25
sync.(*WaitGroup).Wait(0xc000406090?)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/sync/waitgroup.go:118 +0x48
k8s.io/client-go/tools/remotecommand.(*streamProtocolV4).stream(0xc000402180, {0x7fe57c11a068?, 0xc00037dd10?})
        /home/mattcjo/go/pkg/mod/k8s.io/client-go@v0.31.3/tools/remotecommand/v4.go:72 +0xd3
k8s.io/client-go/tools/remotecommand.(*spdyStreamExecutor).StreamWithContext.func1()
        /home/mattcjo/go/pkg/mod/k8s.io/client-go@v0.31.3/tools/remotecommand/spdy.go:160 +0x82
created by k8s.io/client-go/tools/remotecommand.(*spdyStreamExecutor).StreamWithContext in goroutine 23
        /home/mattcjo/go/pkg/mod/k8s.io/client-go@v0.31.3/tools/remotecommand/spdy.go:154 +0x1ca

goroutine 29 [chan receive, 9 minutes]:
github.com/moby/spdystream.(*Connection).Serve.func1(0xc00061fdd0)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:327 +0x25
created by github.com/moby/spdystream.(*Connection).Serve in goroutine 38
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:326 +0x154

goroutine 30 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0xc000073a90, 0x153)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/runtime/sema.go:587 +0x159
sync.(*Cond).Wait(0xc00029c4c0?)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/sync/cond.go:71 +0x85
github.com/moby/spdystream.(*PriorityFrameQueue).Pop(0xc00061fdd0)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/priority.go:102 +0x7f
github.com/moby/spdystream.(*Connection).frameHandler(0xc000410000, 0xc00061fdd0, 0xc000626340)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:419 +0x30
github.com/moby/spdystream.(*Connection).Serve.func2(0x0?)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:336 +0x51
created by github.com/moby/spdystream.(*Connection).Serve in goroutine 38
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:332 +0x67

goroutine 31 [chan receive, 9 minutes]:
github.com/moby/spdystream.(*Connection).Serve.func1(0xc00061fe00)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:327 +0x25
created by github.com/moby/spdystream.(*Connection).Serve in goroutine 38
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:326 +0x154

goroutine 32 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0xc000073ad0, 0x19)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/runtime/sema.go:587 +0x159
sync.(*Cond).Wait(0xc000112920?)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/sync/cond.go:71 +0x85
github.com/moby/spdystream.(*PriorityFrameQueue).Pop(0xc00061fe00)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/priority.go:102 +0x7f
github.com/moby/spdystream.(*Connection).frameHandler(0xc000410000, 0xc00061fe00, 0xc000626340)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:419 +0x30
github.com/moby/spdystream.(*Connection).Serve.func2(0x0?)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:336 +0x51
created by github.com/moby/spdystream.(*Connection).Serve in goroutine 38
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:332 +0x67

goroutine 33 [chan receive, 9 minutes]:
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:336 +0x51
created by github.com/moby/spdystream.(*Connection).Serve in goroutine 38
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:332 +0x67

goroutine 83 [chan receive, 9 minutes]:
github.com/moby/spdystream.(*Connection).Serve.func1(0xc00061fe60)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:327 +0x25
created by github.com/moby/spdystream.(*Connection).Serve in goroutine 38
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:326 +0x154

goroutine 84 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0xc000073b50, 0xdb6)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/runtime/sema.go:587 +0x159
sync.(*Cond).Wait(0xc0001128b0?)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/sync/cond.go:71 +0x85
github.com/moby/spdystream.(*PriorityFrameQueue).Pop(0xc00061fe60)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/priority.go:102 +0x7f
github.com/moby/spdystream.(*Connection).frameHandler(0xc000410000, 0xc00061fe60, 0xc000626340)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:419 +0x30
github.com/moby/spdystream.(*Connection).Serve.func2(0xc00059e780?)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:336 +0x51
created by github.com/moby/spdystream.(*Connection).Serve in goroutine 38
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:332 +0x67

goroutine 85 [chan receive, 9 minutes]:
github.com/moby/spdystream.(*Connection).Serve.func1(0xc00061fe90)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:327 +0x25
created by github.com/moby/spdystream.(*Connection).Serve in goroutine 38
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:326 +0x154

goroutine 86 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0xc000073b90, 0x17)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/runtime/sema.go:587 +0x159
sync.(*Cond).Wait(0xc000578450?)
        /home/mattcjo/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/sync/cond.go:71 +0x85
github.com/moby/spdystream.(*PriorityFrameQueue).Pop(0xc00061fe90)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/priority.go:102 +0x7f
github.com/moby/spdystream.(*Connection).frameHandler(0xc000410000, 0xc00061fe90, 0xc000626340)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:419 +0x30
github.com/moby/spdystream.(*Connection).Serve.func2(0xcc00580f430?)
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:336 +0x51
created by github.com/moby/spdystream.(*Connection).Serve in goroutine 38
        /home/mattcjo/go/pkg/mod/github.com/moby/spdystream@v0.4.0/connection.go:332 +0x67
FAIL    github.com/aws/aws-k8s-tester/test/cases/quick  600.025s
FAIL
```

**New AMI (amazon-eks-node-al2023-arm64-standard-1.29-v20250212)**
```
go test -v -tags=e2e . -run TestNpmInstallWithCPULimits
2025/03/03 03:06:32 Starting quick test suite...
=== RUN   TestNpmInstallWithCPULimits
=== RUN   TestNpmInstallWithCPULimits/npm-install-cpu-limits
2025/03/03 03:06:32 [Setup] Verifying cluster nodes...
    io_uring_test.go:77: Node: ip-192-168-184-100.us-west-2.compute.internal, Architecture: arm64, Kernel: 6.1.127-135.201.amzn2023.aarch64
=== RUN   TestNpmInstallWithCPULimits/npm-install-cpu-limits/Pod_can_successfully_run_npm_install_with_CPU_limits
2025/03/03 03:06:33 [Assess] Waiting for pod npm-install-test to be running...
2025/03/03 03:06:38 [Assess] Executing npm install in pod...
2025/03/03 03:10:08 [Assess] Pod npm-install-test completed successfully
=== NAME  TestNpmInstallWithCPULimits/npm-install-cpu-limits
    io_uring_test.go:157: [Teardown] Cleaning up pod default/npm-install-test...
--- PASS: TestNpmInstallWithCPULimits (216.55s)
    --- PASS: TestNpmInstallWithCPULimits/npm-install-cpu-limits (216.55s)
        --- PASS: TestNpmInstallWithCPULimits/npm-install-cpu-limits/Pod_can_successfully_run_npm_install_with_CPU_limits (215.78s)
PASS
ok      github.com/aws/aws-k8s-tester/test/cases/quick  216.570s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
