### PR TITLE
print job logs when the job failed for debugging

### DIFF
--- a/test/cases/nvidia-inference/bert_inference_test.go
+++ b/test/cases/nvidia-inference/bert_inference_test.go
@@ -76,8 +76,8 @@ func TestBertInference(t *testing.T) {
 				wait.WithTimeout(20*time.Minute),
 			); err != nil {
 				log.Println("[ERROR] BERT inference job failed. Gathering logs...")
-				if err := printJobLogs(ctx, cfg, "default", "neuron-inference"); err != nil {
-					t.Logf("[WARNING] Failed to retrieve neuron-inference job logs: %v", err)
+				if err := printJobLogs(ctx, cfg, "default", "bert-inference"); err != nil {
+					t.Logf("[WARNING] Failed to retrieve bert-inference job logs: %v", err)
 				}
 				t.Fatalf("[ERROR] BERT inference job did not succeed: %v", err)
 			}


### PR DESCRIPTION
*Issue #, if available:*
* Add the job logs print for nvidia training, nvidia inference, neuron inference when the test failed which is easier for us to debugging the issue
* We already have the job log print for neuron training when it failed https://github.com/aws/aws-k8s-tester/blob/ecc47a9911a50e907dc0d5c065049cf89a067ce4/test/cases/neuron-training/bert_training_test.go#L102-L109


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
