### PR TITLE
fix(templates): refactor template to have network interface

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: go build ./...
+    - run: go test ./...
   build-test:
     runs-on: ubuntu-latest
     steps:

--- a/internal/deployers/eksapi/templates/templates.go
+++ b/internal/deployers/eksapi/templates/templates.go
@@ -14,7 +14,18 @@ var (
 	UnmanagedNodegroup         = template.Must(template.New("unmanagedNodegroup").Parse(unmanagedNodegroupTemplate))
 )
 
+type NetworkInterface struct {
+	Description         *string
+	NetworkCardIndex    *int
+	DeviceIndex         *int
+	InterfaceType       *string
+	Groups              []string
+	SubnetId            *string
+	DeleteOnTermination *bool
+}
+
 type UnmanagedNodegroupTemplateData struct {
+	NetworkInterfaces  []NetworkInterface
 	KubernetesVersion string
 	InstanceTypes     []string
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

fixes test error:

```
--- FAIL: Test_UnmanagedNodegroup (0.00s)
    templates_test.go:19: template: unmanagedNodegroup:129:14: executing "unmanagedNodegroup" at <.NetworkInterfaces>: can't evaluate field NetworkInterfaces in type templates.UnmanagedNodegroupTemplateData
```

due to the template not being used in the kubetest2 deployer code path in favor of an inline struct type. this PR adds the `NetworkInterfaces` field to the template definitions and updates the usages in the deployer.

also adds a `go test ./...` call to the build workflow.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
