### PR TITLE
fix(nvidia,containerd): skip ecr sandbox image check if localhost ima…

### DIFF
--- a/test/cases/nvidia/manifests/daemonset-containerd-check.yaml
+++ b/test/cases/nvidia/manifests/daemonset-containerd-check.yaml
@@ -40,11 +40,15 @@ spec:
             exit 1
           fi
 
-          # 4. Check that $sandbox_image references .ecr.
-          if [[ "$sandbox_image" != *".ecr."* ]]; then
-            echo "FAIL: no .ecr. reference in $sandbox_image"
-            echo "=== debug ==="
-            exit 1
+          # 4. Check that $sandbox_image references .ecr. or is provided on the instance
+          if [[ "$sandbox_image" == "localhost"* ]]; then
+            echo "INFO: skipping .ecr. check for localhost sandbox image"
+          else
+            if [[ "$sandbox_image" != *".ecr."* ]]; then
+              echo "FAIL: no .ecr. reference in $sandbox_image"
+              echo "=== debug ==="
+              exit 1
+            fi
           fi
 
           # 5. Check for 'nvidia-container-runtime'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

EKS AL2023 images will fail this check before the sandbox is built into the AMI as `localhost/kubernetes/pause`. add a branch to skip this check if the image name begins with `localhost`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
