### PR TITLE
fix: return nonzero inside download binary func

### DIFF
--- a/hack/download-kubernetes-binaries.sh
+++ b/hack/download-kubernetes-binaries.sh
@@ -35,13 +35,15 @@ function download_binaries() {
   for BUNDLE in ${BUNDLES[@]}; do
     echo >&2 "Downloading bundle: ${BUNDLE}"
     local TARBALL="${BUNDLE}.tar.gz"
-    wget --quiet --output-document=${TARBALL} $basePath/${KUBERNETES_VERSION}/${BUNDLE}-${OS}-${ARCH}.tar.gz
+    if ! wget --quiet --output-document=${TARBALL} $basePath/${KUBERNETES_VERSION}/${BUNDLE}-${OS}-${ARCH}.tar.gz; then
+      return 1
+    fi
     tar xzf ${TARBALL}
     rm ${TARBALL}
   done
 }
 
-if ! download_binaries https://storage.googleapis.com/kubernetes-release/release || true; then
+if ! download_binaries https://storage.googleapis.com/kubernetes-release/release; then
   echo >&2 "binary download failed from release bucket, falling back to ci dev release"
   download_binaries https://storage.googleapis.com/k8s-release-dev/ci
 fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

this was a fix that should have gone with https://github.com/aws/aws-k8s-tester/pull/602.

fix fallback mechanism, non-zero return codes were not bubbled up from inner routine.

the [workflow from the previous PR](https://github.com/aws/aws-k8s-tester/actions/runs/14365987157/job/40278912677?pr=602#step:3:13364) ended up showing some incorrect behavior that passed, so the signal was lost

```
#19 [stage-1  9/14] RUN ./download-kubernetes-binaries.sh "latest" "linux" "amd64"
#19 0.132 Release marker: latest.txt
#19 0.310 Kubernetes version: v1.32.0-alpha.0
#19 0.311 Downloading bundle: kubernetes-client
#19 1.730 Downloading bundle: kubernetes-test
#19 5.908 binary download failed from release bucket, falling back to ci dev release
#19 6.074 Kubernetes version: v1.34.0-alpha.0.7+88dfcb225d4132
#19 6.074 Downloading bundle: kubernetes-client
#19 8.270 Downloading bundle: kubernetes-test
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*Testing:*

[workflow is correct](https://github.com/aws/aws-k8s-tester/actions/runs/14366993124/job/40282224937?pr=603#step:3:13372).

verify build in container works.
```bash
> docker build --build-arg=KUBERNETES_MINOR_VERSION=1.33 --file Dockerfile . --progress=plain
...

#19 [stage-1  9/14] RUN ./download-kubernetes-binaries.sh "1.33" "linux" "amd64"
#19 0.428 Release marker: latest-1.33.txt
#19 0.521 Kubernetes version: <?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-release/release/latest-1.33.txt</Details></Error>
#19 0.522 Downloading bundle: kubernetes-client
#19 0.656 binary download failed from release bucket, falling back to ci dev release
#19 0.779 Kubernetes version: v1.33.0-beta.0.708+640489ae0cefea
#19 0.779 Downloading bundle: kubernetes-client
#19 2.196 Downloading bundle: kubernetes-test
#19 DONE 11.7s

```