### PR TITLE
Add t3.large to eksapi default x86-64 instance types

### DIFF
--- a/internal/deployers/eksapi/node.go
+++ b/internal/deployers/eksapi/node.go
@@ -39,6 +39,7 @@ var (
 		"m6i.xlarge",
 		"m6i.large",
 		"m5.large",
+		"t3.large",
 	}
 
 	defaultInstanceTypes_arm64 = []string{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`t3.large` is a highly available instance type, so this helps ensure test capacity.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
