### PR TITLE
feat(neuron): run multi-node-nccom-test as non-root

### DIFF
--- a/internal/deployers/eksapi/templates/userdata_bottlerocket.toml.template
+++ b/internal/deployers/eksapi/templates/userdata_bottlerocket.toml.template
@@ -2,6 +2,7 @@
 "cluster-name" = "{{.Name}}"
 "api-server" = "{{.APIServerEndpoint}}"
 "cluster-certificate" = "{{.CertificateAuthority}}"
+device-ownership-from-security-context = true
 
 [settings.host-containers.admin]
 "enabled" = true

--- a/internal/deployers/eksapi/userdata_test.go
+++ b/internal/deployers/eksapi/userdata_test.go
@@ -39,6 +39,7 @@ const bottlerocketUserData = `[settings.kubernetes]
 "cluster-name" = "cluster"
 "api-server" = "https://example.com"
 "cluster-certificate" = "certificateAuthority"
+device-ownership-from-security-context = true
 
 [settings.host-containers.admin]
 "enabled" = true

--- a/test/cases/neuron/manifests/multi-node-test-neuron.yaml
+++ b/test/cases/neuron/manifests/multi-node-test-neuron.yaml
@@ -35,9 +35,6 @@ spec:
 
                 export CCOM_SOCKET_IFNAME=eth0
                 export NEURON_RT_ROOT_COMM_ID=${WORKER_IPS[0]}:63182
-                export OMPI_ALLOW_RUN_AS_ROOT=1
-                export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-
                 nccom-test -r $(({{.NeuronCorePerNode}}*{{.WorkerNodeCount}})) -N {{.WorkerNodeCount}} -b "8" -e "2G" -f "2" -n "5" -w "5" -d "fp32" allr --hosts ${WORKER_IPS[*]} --data-collector-host $POD_IP --data-collector-port 60006 --debug
     Worker:
       replicas: {{.WorkerNodeCount}}
@@ -50,6 +47,8 @@ spec:
           containers:
           - image: {{.NeuronTestImage}}
             name: nccom-test-worker
+            command: ["/bin/bash"]
+            args: ["-c", "echo password | sudo -S /usr/sbin/sshd -D"]
             imagePullPolicy: Always
             resources:
               limits:

--- a/test/cases/neuron/manifests/multi-node-test-neuron.yaml
+++ b/test/cases/neuron/manifests/multi-node-test-neuron.yaml
@@ -43,6 +43,10 @@ spec:
       replicas: {{.WorkerNodeCount}}
       template:
         spec:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 2000
+            fsGroup: 3000
           containers:
           - image: {{.NeuronTestImage}}
             name: nccom-test-worker

--- a/test/cases/neuron/manifests/single-node-test-neuronx.yaml
+++ b/test/cases/neuron/manifests/single-node-test-neuronx.yaml
@@ -27,4 +27,8 @@ spec:
             memory: 1Gi
             aws.amazon.com/neuron: "1"
       restartPolicy: Never
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 2000
+        fsGroup: 3000
   backoffLimit: 4

--- a/test/images/neuron/Dockerfile
+++ b/test/images/neuron/Dockerfile
@@ -63,11 +63,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-# new user to avoid mpirun --allow-run-as-root
-RUN useradd -ms /bin/bash ubuntu
-RUN echo 'ubuntu:password' | chpasswd
-RUN usermod -aG sudo ubuntu
-
 RUN apt update
 RUN apt install -y openssh-server openssh-client wget gnupg2 sudo
 
@@ -161,7 +156,6 @@ RUN cd $HOME \
     && ./efa_installer.sh -y -g -d --skip-kmod --skip-limit-conf --no-verify \
     && cd $HOME
 
-
 # Clean up after apt update
 RUN rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/tmp* \
@@ -172,7 +166,6 @@ RUN rm -rf /var/lib/apt/lists/* \
 # is already installed install it with nodeps
 RUN pip3 install --no-cache-dir --no-deps -U \
     torchvision==0.16.*
-
 
 RUN HOME_DIR=/root \
     && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
@@ -189,8 +182,19 @@ RUN curl -o /license.txt  https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.1/
 RUN mkdir -p /var/run/sshd && \
     sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
     echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
-    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config
+    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config && \
+    sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config && \
+    sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
+
+RUN useradd -ms /bin/bash ubuntu
+RUN echo 'ubuntu:password' | chpasswd
+RUN usermod -aG sudo ubuntu
 
 WORKDIR /home/ubuntu
+USER ubuntu
+
+RUN mkdir -p /home/ubuntu/.ssh && \ 
+    ssh-keygen -t rsa -f /home/ubuntu/.ssh/id_rsa -N '' && \
+    cp /home/ubuntu/.ssh/id_rsa.pub /home/ubuntu/.ssh/authorized_keys
 
 COPY test/images/neuron/tests ./tests


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
More context in #561, enables testing a bottlerocket feature to specify the userID and groupID ownership of neuron devices. It also more generally runs both containers as non-root, except the worker container still needs to be able to run sshd as root, ref https://www.ssh.com/academy/ssh/sshd.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
