### PR TITLE
fix(nvidia/hpc-benchmarks): run job with 1 completion

### DIFF
--- a/test/cases/nvidia/manifests/job-hpc-benchmarks.yaml
+++ b/test/cases/nvidia/manifests/job-hpc-benchmarks.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: hpc-benckmarks-job
 spec:
-  completions: 20
+  completions: 1
   parallelism: 1
   template:
     metadata:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We run this job with mpirun creating 1 process for each GPU. I really don't see why we would want 20 completions here, and functionally that takes a bit over an hour to complete - which means runs of this are likely to just timeout since most users would apply a 60 minute or less timeout. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
