### PR TITLE
feat(al2023): enable DRA in kubelet for 1.33

### DIFF
--- a/internal/deployers/eksapi/node.go
+++ b/internal/deployers/eksapi/node.go
@@ -349,7 +349,7 @@ func (m *nodeManager) createUnmanagedNodegroup(infra *Infrastructure, cluster *C
 	var capacityReservationId string
 	stackName := m.getUnmanagedNodegroupStackName()
 	klog.Infof("creating unmanaged nodegroup stack %s...", stackName)
-	userData, userDataIsMimePart, err := generateUserData(opts.UserDataFormat, cluster)
+	userData, userDataIsMimePart, err := generateUserData(opts.UserDataFormat, cluster, opts)
 	if err != nil {
 		return err
 	}

--- a/internal/deployers/eksapi/templates/templates.go
+++ b/internal/deployers/eksapi/templates/templates.go
@@ -66,6 +66,7 @@ type UserDataTemplateData struct {
 	CertificateAuthority string
 	CIDR                 string
 	APIServerEndpoint    string
+	KubeletFeatureGates  map[string]bool
 }
 
 var (

--- a/internal/deployers/eksapi/templates/userdata_nodeadm.yaml.mimepart.template
+++ b/internal/deployers/eksapi/templates/userdata_nodeadm.yaml.mimepart.template
@@ -10,3 +10,11 @@ spec:
     apiServerEndpoint: {{.APIServerEndpoint}}
     certificateAuthority: {{.CertificateAuthority}}
     cidr: {{.CIDR}}
+{{- if .KubeletFeatureGates}}
+  kubelet:
+    config:
+      featureGates:
+        {{- range $gate, $value := .KubeletFeatureGates }}
+        {{$gate}}: {{$value}}
+        {{- end }}
+{{- end }}

--- a/internal/deployers/eksapi/userdata_test.go
+++ b/internal/deployers/eksapi/userdata_test.go
@@ -69,7 +69,7 @@ func Test_generateUserData(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.format, func(t *testing.T) {
-			actual, isMimePart, err := generateUserData(c.format, &cluster)
+			actual, isMimePart, err := generateUserData(c.format, &cluster, &deployerOptions{})
 			if err != nil {
 				t.Log(err)
 				t.Error(err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

add kubelet featureGate to `NodeConfig` if the kubernetes version is 1.33 which applies only to AL2023 nodes created by the `eksapi` deployer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
