### PR TITLE
add wait time to check neuron capacity ready

### DIFF
--- a/test/cases/neuron-inference/main_test.go
+++ b/test/cases/neuron-inference/main_test.go
@@ -98,10 +98,10 @@ func discoverNeuronCoreCapacity(ctx context.Context, config *envconf.Config) (co
 	if err != nil {
 		return ctx, fmt.Errorf("failed to verify Neuron device capacity on nodes: %w", err)
 	}
-	log.Println("Neuron devices check passed - all nodes have non-zero capacity")
+	log.Println("[INFO] Neuron devices check passed - all nodes have non-zero capacity")
 
 	// Check Neuron cores
-	log.Println("Checking Neuron core capacity on nodes")
+	log.Println("[INFO] Checking Neuron core capacity on nodes")
 	err = wait.For(
 		fwext.NewConditionExtension(config.Client().Resources()).AllNodesHaveNonZeroResourceCapacity("aws.amazon.com/neuroncore"),
 		wait.WithTimeout(time.Second*60),
@@ -110,7 +110,7 @@ func discoverNeuronCoreCapacity(ctx context.Context, config *envconf.Config) (co
 	if err != nil {
 		return ctx, fmt.Errorf("failed to verify Neuron core capacity on nodes: %w", err)
 	}
-	log.Println("Neuron cores check passed - all nodes have non-zero capacity")
+	log.Println("[INFO] Neuron cores check passed - all nodes have non-zero capacity")
 
 	log.Println("[INFO] Neuron capacity discovery complete.")
 	return ctx, nil

--- a/test/cases/neuron-inference/main_test.go
+++ b/test/cases/neuron-inference/main_test.go
@@ -89,7 +89,7 @@ func discoverNeuronCoreCapacity(ctx context.Context, config *envconf.Config) (co
 	log.Println("[INFO] Discovering cluster's Neuron capacity...")
 
 	// Check Neuron devices
-	log.Println("Checking Neuron device capacity on nodes")
+	log.Println("[INFO] Checking Neuron device capacity on nodes")
 	err := wait.For(
 		fwext.NewConditionExtension(config.Client().Resources()).AllNodesHaveNonZeroResourceCapacity("aws.amazon.com/neuron"),
 		wait.WithTimeout(time.Second*60),

--- a/test/cases/neuron-inference/main_test.go
+++ b/test/cases/neuron-inference/main_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/aws-k8s-tester/test/manifests"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -89,50 +88,29 @@ func TestMain(m *testing.M) {
 func discoverNeuronCoreCapacity(ctx context.Context, config *envconf.Config) (context.Context, error) {
 	log.Println("[INFO] Discovering cluster's Neuron capacity...")
 
-	cs, err := kubernetes.NewForConfig(config.Client().RESTConfig())
+	// Check Neuron devices
+	log.Println("Checking Neuron device capacity on nodes")
+	err := wait.For(
+		fwext.NewConditionExtension(config.Client().Resources()).AllNodesHaveNonZeroResourceCapacity("aws.amazon.com/neuron"),
+		wait.WithTimeout(time.Second*60),
+		wait.WithInterval(time.Second*5),
+	)
 	if err != nil {
-		return ctx, fmt.Errorf("failed to create kubernetes client: %w", err)
+		return ctx, fmt.Errorf("failed to verify Neuron device capacity on nodes: %w", err)
 	}
+	log.Println("Neuron devices check passed - all nodes have non-zero capacity")
 
-	nodes, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	// Check Neuron cores
+	log.Println("Checking Neuron core capacity on nodes")
+	err = wait.For(
+		fwext.NewConditionExtension(config.Client().Resources()).AllNodesHaveNonZeroResourceCapacity("aws.amazon.com/neuroncore"),
+		wait.WithTimeout(time.Second*60),
+		wait.WithInterval(time.Second*5),
+	)
 	if err != nil {
-		return ctx, fmt.Errorf("failed to list nodes: %w", err)
+		return ctx, fmt.Errorf("failed to verify Neuron core capacity on nodes: %w", err)
 	}
-	if len(nodes.Items) == 0 {
-		return ctx, fmt.Errorf("no nodes found in the cluster")
-	}
-
-	var totalNeuron, totalNeuronCore int
-	for _, node := range nodes.Items {
-		instanceType := node.Labels["node.kubernetes.io/instance-type"]
-		neuronCap, hasNeuron := node.Status.Capacity["aws.amazon.com/neuron"]
-		neuronCoreCap, hasNeuronCore := node.Status.Capacity["aws.amazon.com/neuroncore"]
-
-		if hasNeuron {
-			totalNeuron += int(neuronCap.Value())
-		} else {
-			log.Printf("[WARN] Node %s (type=%s) lacks 'aws.amazon.com/neuron'.", node.Name, instanceType)
-		}
-
-		if hasNeuronCore {
-			totalNeuronCore += int(neuronCoreCap.Value())
-		} else {
-			log.Printf("[WARN] Node %s (type=%s) lacks 'aws.amazon.com/neuroncore'.", node.Name, instanceType)
-		}
-	}
-
-	nodeCount := len(nodes.Items)
-	if nodeCount > 0 {
-		neuronPerNode = totalNeuron / nodeCount
-		neuronCorePerNode = totalNeuronCore / nodeCount
-	}
-
-	log.Printf("[INFO] Discovered neuronPerNode=%d, neuronCorePerNode=%d (across %d node(s))",
-		neuronPerNode, neuronCorePerNode, nodeCount)
-
-	if neuronCorePerNode <= 0 {
-		return ctx, fmt.Errorf("discovered %d neuronCorePerNode => no Neuron capacity found", neuronCorePerNode)
-	}
+	log.Println("Neuron cores check passed - all nodes have non-zero capacity")
 
 	log.Println("[INFO] Neuron capacity discovery complete.")
 	return ctx, nil


### PR DESCRIPTION
*Issue #, if available:*
* neuron inference test failed with no Neuron capacity found. Neuron training and nccom could pass the validate which add the wait time, could just latency issue. [reuse the AllNodesHaveNonZeroResourceCapacity helpful function with wait time to check the neuron capacity ready same as neuron training test](https://github.com/aws/aws-k8s-tester/blob/main/test/cases/neuron-training/main_test.go#L185-L206)
```
2025/05/16 08:20:14 [INFO] Discovering cluster's Neuron capacity...
	
2025/05/16 08:20:14 [WARN] Node ip-192-168-164-46.us-west-2.compute.internal (type=inf2.48xlarge) lacks 'aws.amazon.com/neuron'.
	
2025/05/16 08:20:14 [WARN] Node ip-192-168-164-46.us-west-2.compute.internal (type=inf2.48xlarge) lacks 'aws.amazon.com/neuroncore'.

2025/05/16 08:20:14 [INFO] Discovered neuronPerNode=0, neuronCorePerNode=0 (across 1 node(s))
	
F0516 08:20:14.836342 38 env.go:375] Setup failure: discovered 0 neuronCorePerNode => no Neuron capacity found
	
F0516 08:20:14.841007 31 exec.go:100] failed to run exec tester: exit status 255
```

