### PR TITLE
feat: install latest kubetest2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,4 @@ include ${BGO_MAKEFILE}
 
 pre-release::
 	go test -c -tags=e2e ./test/... -o $(GOBIN)
-	# --flake-attempts flag was removed in: https://github.com/kubernetes-sigs/kubetest2/commit/7dee8a65e642615a9b753455f5b3c23dd3411a3d
-	# so we'll pin to the previous commit for now: https://github.com/kubernetes-sigs/kubetest2/commit/d7fcb799ce84ceda66c8b9b1ec8eefcbe226f293
-	# TODO: remove dependency on this flag
-	go install sigs.k8s.io/kubetest2/...@v0.0.0-20231113220322-d7fcb799ce84
+	go install sigs.k8s.io/kubetest2/...@latest


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This could cause tests directly calling `--flake-attempts` as a tester arg to fail, or any other flags that might have been removed in the diff.

The main benefit this change gets is shifting to test package info store in https://dl.k8s.io rather than the bucket
 https://github.com/kubernetes-sigs/kubetest2/commit/7dee8a65e642615a9b753455f5b3c23dd3411a3d

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
