### PR TITLE
feat: add tests to validate EFA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: docker build --build-arg=KUBERNETES_MINOR_VERSION=latest --file Dockerfile .
+  build-image-efa:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: docker build --file test/images/efa/Dockerfile .
   build-image-neuronx:
     runs-on: ubuntu-latest
     steps:

--- a/internal/e2e/ec2.go
+++ b/internal/e2e/ec2.go
@@ -1,0 +1,35 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-k8s-tester/internal/awssdk"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+type EC2Client interface {
+	DescribeInstanceType(instanceType string) (ec2types.InstanceTypeInfo, error)
+}
+
+type ec2Client struct {
+	client *ec2.Client
+}
+
+func NewEC2Client() *ec2Client {
+	return &ec2Client{
+		client: ec2.NewFromConfig(awssdk.NewConfig()),
+	}
+}
+
+func (c *ec2Client) DescribeInstanceType(instanceType string) (ec2types.InstanceTypeInfo, error) {
+	describeResponse, err := c.client.DescribeInstanceTypes(context.TODO(), &ec2.DescribeInstanceTypesInput{
+		InstanceTypes: []ec2types.InstanceType{ec2types.InstanceType(instanceType)},
+	})
+	if err != nil {
+		return ec2types.InstanceTypeInfo{}, fmt.Errorf("failed to describe instance type: %s: %v", instanceType, err)
+	} else {
+		return describeResponse.InstanceTypes[0], nil
+	}
+}

--- a/test/cases/efa/commons.go
+++ b/test/cases/efa/commons.go
@@ -1,0 +1,102 @@
+//go:build e2e
+
+package efa
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-k8s-tester/internal/e2e"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	testenv   env.Environment
+	ec2Client e2e.EC2Client
+
+	testImage *string
+
+	pingPongSize            *string
+	pingPongIters           *int
+	pingPongDeadlineSeconds *int
+
+	nodeType               *string
+	expectedEFADeviceCount *int
+
+	verbose *bool
+)
+
+const (
+	EFA_RESOURCE_NAME   = "vpc.amazonaws.com/efa"
+	TEST_NAMESPACE_NAME = "efa-tests"
+)
+
+func getEfaCapacity(node corev1.Node) int {
+	capacity, ok := node.Status.Capacity[v1.ResourceName(EFA_RESOURCE_NAME)]
+	if !ok {
+		return 0
+	}
+	return int(capacity.Value())
+}
+
+func getEfaNodes(ctx context.Context, config *envconf.Config) ([]corev1.Node, error) {
+	var efaNodes []corev1.Node
+	clientset, err := kubernetes.NewForConfig(config.Client().RESTConfig())
+	if err != nil {
+		return []corev1.Node{}, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return []corev1.Node{}, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	if len(nodes.Items) == 0 {
+		return []corev1.Node{}, fmt.Errorf("no nodes found in the cluster")
+	}
+
+	for _, node := range nodes.Items {
+		instanceType := node.Labels["node.kubernetes.io/instance-type"]
+
+		if aws.ToString(nodeType) != "" && instanceType != aws.ToString(nodeType) {
+			log.Printf("[INFO] Skipping node %s (type: %s), node is not of target type %s", node.Name, instanceType, aws.ToString(nodeType))
+			continue
+		}
+
+		numEfaDevices, err := e2e.GetNonZeroResourceCapacity(&node, EFA_RESOURCE_NAME)
+		if err != nil {
+			log.Printf("[INFO] Skipping node %s (type: %s): %v", node.Name, instanceType, err)
+			continue
+		}
+
+		expectedDeviceCount := aws.ToInt(expectedEFADeviceCount)
+		if expectedDeviceCount == 0 {
+			instanceInfo, err := ec2Client.DescribeInstanceType(instanceType)
+			if err != nil {
+				return []corev1.Node{}, err
+			}
+			expectedDeviceCount = int(aws.ToInt32(instanceInfo.NetworkInfo.EfaInfo.MaximumEfaInterfaces))
+		}
+
+		if expectedDeviceCount != numEfaDevices {
+			return []corev1.Node{}, fmt.Errorf("unexpected EFA device capacity on node %s: expected %d, got %d", node.Name, expectedDeviceCount, numEfaDevices)
+		}
+
+		efaNodes = append(efaNodes, node)
+	}
+
+	if len(efaNodes) == 0 {
+		return []corev1.Node{}, fmt.Errorf("no nodes with EFA capacity found in the cluster")
+	}
+
+	return efaNodes, nil
+}

--- a/test/cases/efa/main_test.go
+++ b/test/cases/efa/main_test.go
@@ -1,0 +1,104 @@
+//go:build e2e
+
+package efa
+
+import (
+	"context"
+	_ "embed"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-k8s-tester/internal/e2e"
+	"github.com/aws/aws-k8s-tester/test/manifests"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+func getTestNamespace() *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: TEST_NAMESPACE_NAME,
+		},
+	}
+}
+
+func deployEFAPlugin(ctx context.Context, config *envconf.Config) (context.Context, error) {
+	err := e2e.ApplyManifests(config.Client().RESTConfig(), manifests.EfaDevicePluginManifest)
+	if err != nil {
+		return ctx, err
+	}
+	efaDS := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "aws-efa-k8s-device-plugin-daemonset", Namespace: "kube-system"},
+	}
+	err = wait.For(e2e.NewConditionExtension(config.Client().Resources()).DaemonSetReady(&efaDS),
+		wait.WithContext(ctx),
+		wait.WithTimeout(5*time.Minute),
+	)
+	if err != nil {
+		return ctx, err
+	}
+
+	return ctx, nil
+}
+
+func TestMain(m *testing.M) {
+	testImage = flag.String("testImage", "", "container image to use for tests")
+	pingPongSize = flag.String("pingPongSize", "all", "sizes to use for ping pong")
+	pingPongIters = flag.Int("pingPongIters", 10000, "number of iterations to use for ping pong")
+	pingPongDeadlineSeconds = flag.Int("pingPongDeadlineSeconds", 120, "maximum run time for a ping pong attempt")
+	nodeType = flag.String("nodeType", "", "instance type to target for tests")
+	expectedEFADeviceCount = flag.Int("expectedEFADeviceCount", 0, "expected number of efa devices for the target nodes")
+	verbose = flag.Bool("verbose", true, "use verbose mode for tests")
+
+	cfg, err := envconf.NewFromFlags()
+	if err != nil {
+		log.Fatalf("failed to initialize test environment: %v", err)
+	}
+
+	if *testImage == "" {
+		log.Fatal("--testImage must be set, use https://github.com/aws/aws-k8s-tester/blob/main/test/efa/Dockerfile to build the image")
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	timedCtx, _ := context.WithTimeout(ctx, 55*time.Minute)
+	defer cancel()
+
+	testenv = env.NewWithConfig(cfg)
+	testenv = testenv.WithContext(timedCtx)
+
+	ec2Client = e2e.NewEC2Client()
+
+	testenv.Setup(
+		deployEFAPlugin,
+		func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+			select {
+			case <-ctx.Done():
+			// Cooldown to let device plugin update node object with resources
+			case <-time.After(15 * time.Second):
+			}
+
+			return ctx, cfg.Client().Resources().Create(ctx, getTestNamespace())
+		},
+	)
+
+	testenv.Finish(
+		func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+			cfg.Client().Resources().Delete(context.TODO(), getTestNamespace())
+			err := e2e.DeleteManifests(cfg.Client().RESTConfig(), manifests.EfaDevicePluginManifest)
+			if err != nil {
+				return ctx, err
+			}
+			return ctx, nil
+		},
+	)
+
+	os.Exit(testenv.Run(m))
+}

--- a/test/cases/efa/pingpong_test.go
+++ b/test/cases/efa/pingpong_test.go
@@ -1,0 +1,185 @@
+//go:build e2e
+
+package efa
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/aws/aws-k8s-tester/internal/e2e"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	PING_PONG_SERVICE_NAME = "pingpong-service"
+	SERVER_POD_NAME        = "pingpong-server"
+	CLIENT_POD_NAME        = "pingpong-client"
+	PINGPONG_COMMAND       = "fi_pingpong"
+)
+
+func getPingPongPodName(server bool) string {
+	if server {
+		return SERVER_POD_NAME
+	} else {
+		return CLIENT_POD_NAME
+	}
+}
+
+func getPingPongArgs(server bool) (args []string) {
+	args = []string{"-S", aws.ToString(pingPongSize), "-I", fmt.Sprint(aws.ToInt(pingPongIters)), "-p", "efa"}
+	if aws.ToBool(verbose) {
+		args = append(args, "-v")
+	}
+	if !server {
+		args = append(args, fmt.Sprintf("%s.%s", SERVER_POD_NAME, PING_PONG_SERVICE_NAME))
+	}
+	return
+}
+
+func getPingPongResourceLabels(server bool) map[string]string {
+	return map[string]string{
+		"test-suite":      "pingpong",
+		"pingpong-server": fmt.Sprint(server),
+	}
+}
+
+func generatePingPongServiceManifest() corev1.Service {
+	return corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PING_PONG_SERVICE_NAME,
+			Namespace: TEST_NAMESPACE_NAME,
+		},
+		Spec: v1.ServiceSpec{
+			Selector:  getPingPongResourceLabels(true),
+			ClusterIP: "None",
+		},
+	}
+}
+
+func generatePingPongPodManifest(server bool, node corev1.Node) corev1.Pod {
+	efaResourceQuantity := resource.MustParse(fmt.Sprint(getEfaCapacity(node)))
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getPingPongPodName(server),
+			Namespace: TEST_NAMESPACE_NAME,
+			Labels:    getPingPongResourceLabels(server),
+		},
+		Spec: corev1.PodSpec{
+			Hostname:      getPingPongPodName(server),
+			Subdomain:     PING_PONG_SERVICE_NAME,
+			RestartPolicy: v1.RestartPolicyOnFailure,
+			// TODO: centralize re-usable logic for pod spec formatting
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "kubernetes.io/hostname",
+										Operator: "In",
+										Values: []string{
+											node.Name,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "pingpong",
+					Image:   aws.ToString(testImage),
+					Command: []string{"timeout", fmt.Sprintf("%ds", aws.ToInt(pingPongDeadlineSeconds)), PINGPONG_COMMAND},
+					Args:    getPingPongArgs(server),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							EFA_RESOURCE_NAME: efaResourceQuantity,
+						},
+						Limits: corev1.ResourceList{
+							EFA_RESOURCE_NAME: efaResourceQuantity,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getPingPongPods(ctx context.Context, config *envconf.Config) (corev1.Pod, corev1.Pod, error) {
+	efaNodes, err := getEfaNodes(ctx, config)
+	if err != nil {
+		return corev1.Pod{}, corev1.Pod{}, err
+	}
+
+	if len(efaNodes) < 2 {
+		return corev1.Pod{}, corev1.Pod{}, fmt.Errorf("need at least 2 nodes with EFA capacity, got %d", len(efaNodes))
+	}
+
+	serverNode := efaNodes[0]
+	log.Printf("[INFO] Using node %s (type: %s), as server", serverNode.Name, serverNode.Labels["node.kubernetes.io/instance-type"])
+
+	clientNode := efaNodes[1]
+	log.Printf("[INFO] Using node %s (type: %s), as client", clientNode.Name, clientNode.Labels["node.kubernetes.io/instance-type"])
+
+	return generatePingPongPodManifest(true, serverNode), generatePingPongPodManifest(false, clientNode), nil
+}
+
+func TestPingPong(t *testing.T) {
+	var err error
+	var pingPongService corev1.Service
+	var client, server corev1.Pod
+	pingpong := features.New("pingpong").
+		WithLabel("suite", "efa").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			pingPongService = generatePingPongServiceManifest()
+			client, server, err = getPingPongPods(ctx, cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.NoError(t, cfg.Client().Resources().Create(ctx, &pingPongService))
+			assert.NoError(t, cfg.Client().Resources().Create(ctx, &server))
+			assert.NoError(t, cfg.Client().Resources().Create(ctx, &client))
+			return ctx
+		}).
+		Assess("Pingpong between nodes succeeds", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			assert.NoError(t, wait.For(conditions.New(cfg.Client().Resources()).PodPhaseMatch(&server, v1.PodSucceeded),
+				wait.WithTimeout(15*time.Minute),
+				wait.WithContext(ctx),
+			))
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			serverPodLogs, err := e2e.ReadPodLogs(ctx, cfg.Client().RESTConfig(), server.Namespace, server.Name, server.Spec.Containers[0].Name)
+			if err != nil {
+				t.Logf("Could not get pods for server")
+			}
+			t.Logf("Logs for server\n%s", serverPodLogs)
+
+			assert.NoError(t, cfg.Client().Resources().Delete(ctx, &pingPongService))
+			assert.NoError(t, cfg.Client().Resources().Delete(ctx, &server))
+			assert.NoError(t, cfg.Client().Resources().Delete(ctx, &client))
+			return ctx
+		}).
+		Feature()
+	testenv.Test(t, pingpong)
+}

--- a/test/cases/efa/unit_test.go
+++ b/test/cases/efa/unit_test.go
@@ -1,0 +1,143 @@
+//go:build e2e
+
+package efa
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-k8s-tester/internal/e2e"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func generateUnitTestManifest(node corev1.Node, testIndex int) corev1.Pod {
+	efaAllocatable := fmt.Sprint(getEfaCapacity(node))
+	efaResourceQuantity := resource.MustParse(efaAllocatable)
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("efa-unit-%d", testIndex),
+			Namespace: TEST_NAMESPACE_NAME,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: v1.RestartPolicyOnFailure,
+			// TODO: centralize re-usable logic for pod spec fkormatting
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "kubernetes.io/hostname",
+										Operator: "In",
+										Values: []string{
+											node.Name,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "unit-test",
+					Image:   aws.ToString(testImage),
+					Command: []string{"./scripts/unit-test.sh"},
+					Env: []v1.EnvVar{
+						{
+							Name:  "EXPECTED_EFA_DEVICE_COUNT",
+							Value: efaAllocatable,
+						},
+						{
+							Name:  "EC2_INSTANCE_TYPE",
+							Value: node.Labels["node.kubernetes.io/instance-type"],
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							EFA_RESOURCE_NAME: efaResourceQuantity,
+						},
+						Limits: corev1.ResourceList{
+							EFA_RESOURCE_NAME: efaResourceQuantity,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getUnitTestPodManifests(ctx context.Context, config *envconf.Config) ([]corev1.Pod, error) {
+	var podManifests []corev1.Pod
+	efaNodes, err := getEfaNodes(ctx, config)
+	if err != nil {
+		return []corev1.Pod{}, err
+	}
+
+	for nodeIndex, node := range efaNodes {
+		podManifests = append(podManifests, generateUnitTestManifest(node, nodeIndex))
+	}
+
+	return podManifests, err
+}
+
+func TestUnit(t *testing.T) {
+	var err error
+	var pods []corev1.Pod
+	unit := features.New("unit").
+		WithLabel("suite", "efa").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			pods, err = getUnitTestPodManifests(ctx, cfg)
+			if err != nil {
+				t.Fatalf("Failed to generate unit test manifests: %v", err)
+			}
+
+			for _, pod := range pods {
+				assert.NoError(t, cfg.Client().Resources().Create(ctx, &pod))
+			}
+
+			return ctx
+		}).
+		Assess("Unit test succeeds", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			suiteCtx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+			defer cancel()
+			for _, pod := range pods {
+				assert.NoError(t, wait.For(conditions.New(cfg.Client().Resources()).PodPhaseMatch(&pod, v1.PodSucceeded),
+					wait.WithContext(suiteCtx),
+				))
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			for _, pod := range pods {
+				podLogs, err := e2e.ReadPodLogs(ctx, cfg.Client().RESTConfig(), pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
+				if err != nil {
+					t.Logf("Could not get logs for pod %q", pod.Name)
+				} else {
+					t.Logf("Logs for pod %q\n%s", pod.Name, podLogs)
+				}
+			}
+
+			for _, pod := range pods {
+				assert.NoError(t, cfg.Client().Resources().Delete(ctx, &pod))
+			}
+			return ctx
+		}).
+		Feature()
+	testenv.Test(t, unit)
+}

--- a/test/images/efa/Dockerfile
+++ b/test/images/efa/Dockerfile
@@ -1,0 +1,53 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+RUN dnf -y swap gnupg2-minimal gnupg2 && \
+    dnf install -y \
+    gcc gcc-c++ make \  
+    ca-certificates \
+    cmake \
+    emacs \
+    git \
+    jq \
+    wget \
+    unzip \
+    vim \
+    zlib-devel \      
+    openssl \
+    openssl-devel \    
+    sqlite-devel \   
+    gdbm-devel \      
+    glibc-devel \     
+    bzip2-devel \     
+    ncurses-devel \    
+    tk-devel \        
+    libffi-devel \     
+    libcap-devel \  
+    tar \
+    gnupg2 
+
+ENV PATH="$PATH:/opt/amazon/efa/bin"
+
+RUN cd $HOME \
+    && curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz \
+    && wget https://efa-installer.amazonaws.com/aws-efa-installer.key && gpg --import aws-efa-installer.key \
+    && cat aws-efa-installer.key | gpg --fingerprint \
+    && wget https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz.sig && gpg --verify ./aws-efa-installer-latest.tar.gz.sig \
+    && tar -xf aws-efa-installer-latest.tar.gz \
+    && cd aws-efa-installer \
+    && ./efa_installer.sh -y -d --skip-kmod --skip-limit-conf --no-verify \
+    && cd $HOME \
+    && rm -rf aws-efa-installer
+
+RUN dnf clean all
+
+RUN INSTALL_DIR=$(mktemp -d) && \
+    cd $INSTALL_DIR && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install  && \
+    cd && \ 
+    rm -rf $INSTALL_DIR
+
+COPY test/images/efa/scripts ./scripts
+
+RUN chmod -R +x ./scripts

--- a/test/images/efa/scripts/unit-test.sh
+++ b/test/images/efa/scripts/unit-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eu
+
+get_instance_type()
+{
+
+    local token=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
+
+    if [ -n "$token" ]; then
+        curl -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/instance-type
+    else
+        curl http://169.254.169.254/latest/meta-data/instance-type
+    fi
+}
+
+get_expected_efa_device_count() 
+{
+    aws ec2 describe-instance-types --instance-type="$EC2_INSTANCE_TYPE" | jq -r '.InstanceTypes[].NetworkInfo.EfaInfo.MaximumEfaInterfaces'
+}
+
+EC2_INSTANCE_TYPE=${EC2_INSTANCE_TYPE:-$(get_instance_type)}
+EXPECTED_EFA_DEVICE_COUNT=${EXPECTED_EFA_DEVICE_COUNT:-$(get_expected_efa_device_count)}
+
+echo "Running test on a $EC2_INSTANCE_TYPE"
+
+fi_info -p efa
+DGRAM_ENDPOINT_COUNT=$(fi_info -p efa | grep 'type:\sFI_EP_DGRAM$' | wc -l)
+if ! test $EXPECTED_EFA_DEVICE_COUNT -le $DGRAM_ENDPOINT_COUNT; then
+    echo "Expected at least $EXPECTED_EFA_DEVICE_COUNT DGRAM endpoint(s) but found $DGRAM_ENDPOINT_COUNT"
+    exit 1
+else
+    echo "Verified at least $EXPECTED_EFA_DEVICE_COUNT DGRAM endpoint(s) are available (found $DGRAM_ENDPOINT_COUNT)"
+fi
+
+RDM_ENDPOINT_COUNT=$(fi_info -p efa | grep 'type:\sFI_EP_RDM$' | wc -l)
+if ! test $EXPECTED_EFA_DEVICE_COUNT -le $RDM_ENDPOINT_COUNT; then
+    echo "Expected at least $EXPECTED_EFA_DEVICE_COUNT RDM endpoint(s) but found $RDM_ENDPOINT_COUNT"
+    exit 1
+else
+    echo "Verified at least $EXPECTED_EFA_DEVICE_COUNT RDM endpoint(s) are available (found $RDM_ENDPOINT_COUNT)"
+fi
+
+echo "Success!"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds some initial tests to validate just EFA capacity. This is useful to run as a pre-flight check before running neuron or nvidia test cases that may use or require EFA, but also for testing EFA directly and on instance types which support it but don't have accelerators.

These are mainly intended as smoke tests at the moment, but sets up for more advanced future testing. At the moment, this will:
1. Verify that the EFA device capacity on the nodes is consistent with the expected.
2. Verify that all the requested number of EFA devices are visible within the container.
3. Verify that RDM and DGRAM endpoints are available for each EFA device.
4. Verify that two different pods can ping pong traffic between each other via efa (using the libfabric `fi_pingpong` utility)

Sample output (verbose logs cropped):
```
=== RUN   TestPingPong
=== RUN   TestPingPong/pingpong
2025/06/02 18:26:19 [INFO] Using node ip-192-168-41-150.us-west-2.compute.internal (type: r6i.32xlarge), as server
2025/06/02 18:26:19 [INFO] Using node ip-192-168-55-210.us-west-2.compute.internal (type: r6i.32xlarge), as client
=== RUN   TestPingPong/pingpong/Pingpong_between_nodes_succeeds
=== NAME  TestPingPong/pingpong
    pingpong_test.go:176: Logs for server
        bytes   #sent   #ack     total       time     MB/sec    usec/xfer   Mxfers/sec
        0       10k     =10k     0           0.21s      0.00      10.38       0.10
        1       10k     =10k     19k         0.21s      0.10      10.37       0.10
        2       10k     =10k     39k         0.21s      0.19      10.36       0.10
        3       10k     =10k     58k         0.21s      0.29      10.36       0.10
        4       10k     =10k     78k         0.21s      0.39      10.35       0.10
        6       10k     =10k     117k        0.21s      0.58      10.38       0.10
        8       10k     =10k     156k        0.21s      0.77      10.35       0.10
        12      10k     =10k     234k        0.21s      1.16      10.35       0.10
        16      10k     =10k     312k        0.21s      1.54      10.36       0.10
        24      10k     =10k     468k        0.21s      2.32      10.35       0.10
        32      10k     =10k     625k        0.21s      3.09      10.36       0.10
        48      10k     =10k     937k        0.21s      4.48      10.71       0.09
        64      10k     =10k     1.2m        0.22s      5.94      10.77       0.09
        96      10k     =10k     1.8m        0.22s      8.86      10.83       0.09
        128     10k     =10k     2.4m        0.22s     11.78      10.87       0.09
        192     10k     =10k     3.6m        0.22s     17.67      10.86       0.09
        256     10k     =10k     4.8m        0.22s     23.56      10.87       0.09
        384     10k     =10k     7.3m        0.22s     35.32      10.87       0.09
        512     10k     =10k     9.7m        0.22s     47.05      10.88       0.09
        768     10k     =10k     14m         0.22s     70.21      10.94       0.09
        1k      10k     =10k     19m         0.22s     93.41      10.96       0.09
        1.5k    10k     =10k     29m         0.22s    139.30      11.03       0.09
        2k      10k     =10k     39m         0.22s    184.72      11.09       0.09
        3k      10k     =10k     58m         0.22s    273.50      11.23       0.09
        4k      10k     =10k     78m         0.23s    357.52      11.46       0.09
        6k      10k     =10k     117m        0.24s    511.76      12.01       0.08
        8k      10k     =10k     156m        0.25s    650.53      12.59       0.08
--- PASS: TestPingPong (25.25s)
    --- PASS: TestPingPong/pingpong (25.25s)
        --- PASS: TestPingPong/pingpong/Pingpong_between_nodes_succeeds (25.01s)
=== RUN   TestUnit
=== RUN   TestUnit/unit
=== RUN   TestUnit/unit/Unit_test_succeeds
=== NAME  TestUnit/unit
    unit_test.go:132: Logs for pod "efa-unit-0"
        Running test on a r6i.32xlarge
        provider: efa
            fabric: efa-direct
            domain: efa_0-rdm
            version: 201.0
            type: FI_EP_RDM
            protocol: FI_PROTO_EFA
        provider: efa
            fabric: efa
            domain: efa_0-rdm
            version: 201.0
            type: FI_EP_RDM
            protocol: FI_PROTO_EFA
        provider: efa
            fabric: efa
            domain: efa_0-dgrm
            version: 201.0
            type: FI_EP_DGRAM
            protocol: FI_PROTO_EFA
        Verified at least 1 DGRAM endpoint(s) are available (found 1)
        Verified at least 1 RDM endpoint(s) are available (found 2)
        Success!
    unit_test.go:132: Logs for pod "efa-unit-1"
        Running test on a r6i.32xlarge
        hca_id: efa_0
                transport:                      unspecified (4)
                fw_ver:                         0.0.0.0
                node_guid:                      394b:3d0e:2432:3200
                sys_image_guid:                 0000:0000:0000:0000
                vendor_id:                      0x1d0f
                vendor_part_id:                 61345
                hw_ver:                         0xEFA1
                phys_port_cnt:                  1
                        port:   1
                                state:                  PORT_ACTIVE (4)
                                max_mtu:                4096 (5)
                                active_mtu:             4096 (5)
                                sm_lid:                 0
                                port_lid:               0
                                port_lmc:               0x01
                                link_layer:             Unspecified
        
        Verified 1 EFA device(s) visible
        provider: efa
            fabric: efa-direct
            domain: efa_0-rdm
            version: 201.0
            type: FI_EP_RDM
            protocol: FI_PROTO_EFA
        provider: efa
            fabric: efa
            domain: efa_0-rdm
            version: 201.0
            type: FI_EP_RDM
            protocol: FI_PROTO_EFA
        provider: efa
            fabric: efa
            domain: efa_0-dgrm
            version: 201.0
            type: FI_EP_DGRAM
            protocol: FI_PROTO_EFA
        Verified at least 1 DGRAM endpoint(s) are available (found 1)
        Verified at least 1 RDM endpoint(s) are available (found 2)
        Success!
--- PASS: TestUnit (10.18s)
    --- PASS: TestUnit/unit (10.18s)
        --- PASS: TestUnit/unit/Unit_test_succeeds (10.02s)
PASS
ok      github.com/aws/aws-k8s-tester/test/cases/efa    56.352s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
