### PR TITLE
Fixed Dockerfile for NCCL installation

### DIFF
--- a/test/images/nvidia-training/Dockerfile
+++ b/test/images/nvidia-training/Dockerfile
@@ -4,6 +4,10 @@ ARG CUDA_MINOR_VERSION=8
 # Use the NVIDIA CUDA runtime as a parent image
 FROM nvidia/cuda:$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION.0-devel-ubuntu22.04
 
+# Redeclare build arguments
+ARG CUDA_MAJOR_VERSION
+ARG CUDA_MINOR_VERSION
+
 # Set environment variable to disable interactive prompts
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -112,7 +116,7 @@ RUN apt update \
  && apt install -y \
         libnccl2=$LIBNCCL_VERSION+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
         libnccl-dev=$LIBNCCL_VERSION+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
- && rm -rf /var/lib/apt/lists/* \
+ && rm -rf /var/lib/apt/lists/* 
 
 # Install AWS-OFI-NCCL plugin
 ARG AWS_OFI_NCCL_VERSION=1.14.2


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
1. Re-declared `CUDA_MAJOR_VERSION `and `CUDA_MINOR_VERSION` to fix the below error during build
```
3.702 E: Version '2.26.2-1+cuda.' for 'libnccl2' was not found
3.702 E: Version '2.26.2-1+cuda.' for 'libnccl-dev' was not found 
``` 

2. Removed trailing backslash at the end of the NCCL installation command
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
