### PR TITLE
Filter out local zones when selecting AZs in infra.go

### DIFF
--- a/internal/deployers/eksapi/deployer.go
+++ b/internal/deployers/eksapi/deployer.go
@@ -85,6 +85,7 @@ type deployerOptions struct {
 	UnmanagedNodes      bool          `flag:"unmanaged-nodes" desc:"Use an AutoScalingGroup instead of an EKS-managed nodegroup. Requires --ami"`
 	UpClusterHeaders    []string      `flag:"up-cluster-header" desc:"Additional header to add to eks:CreateCluster requests. Specified in the same format as curl's -H flag."`
 	UserDataFormat      string        `flag:"user-data-format" desc:"Format of the node instance user data"`
+	ZoneType            string        `flag:"zone-type" desc:"Type of zone to use for infrastructure (availability-zone, local-zone, etc). Defaults to availability-zone"`
 }
 
 // NewDeployer implements deployer.New for EKS using the EKS (and other AWS) API(s) directly (no cloudformation)
@@ -253,6 +254,10 @@ func (d *deployer) verifyUpFlags() error {
 	if d.IPFamily == "" {
 		d.IPFamily = string(ekstypes.IpFamilyIpv4)
 		klog.Infof("Using default IP family: %s", d.IPFamily)
+	}
+	if d.ZoneType == "" {
+		d.ZoneType = "availability-zone"
+		klog.Infof("Using default zone type: %s", d.ZoneType)
 	}
 	if d.ClusterCreationTimeout == 0 {
 		d.ClusterCreationTimeout = time.Minute * 15

--- a/internal/deployers/eksapi/infra.go
+++ b/internal/deployers/eksapi/infra.go
@@ -95,17 +95,17 @@ func (m *InfrastructureManager) createInfrastructureStack(opts *deployerOptions)
 	// TODO: create a subnet in every AZ
 	// get two AZs for the subnets
 	azs, err := m.clients.EC2().DescribeAvailabilityZones(context.TODO(), &ec2.DescribeAvailabilityZonesInput{
-    Filters: []ec2types.Filter{
-        	{
+		Filters: []ec2types.Filter{
+			{
 				Name:   aws.String("zone-type"),
 				Values: []string{opts.ZoneType},
-        	},
-    	},
+			},
+		},
 	})
 	if err != nil {
 		return nil, err
 	}
-	
+
 	var allowedAZs []string
 	for i := 0; i < numInfraAZs; i++ {
 		allowedAZs = append(allowedAZs, aws.ToString(azs.AvailabilityZones[i].ZoneName))
@@ -428,7 +428,7 @@ func (m *InfrastructureManager) getRankedAZsForInstanceTypes(opts *deployerOptio
 			{
 				Name:   aws.String("location"),
 				Values: allowedAZs,
-        	},
+			},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
For `Error: failed to wait for infrastructure stack creation: waiter state transitioned to Failure` on creating cluster due to IPv6 CIDR not being supported in local AZs.
*Issue #, if available:*

*Description of changes:*. 
Added filtering in `DescribeAvailabilityZones` to only request regular availability zones (`zone-type=availability-zone`). Modified `counts` to consider regular AZs only.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
