### PR TITLE
DCGM Exporter Setup

### DIFF
--- a/test/cases/nvidia-training/main_test.go
+++ b/test/cases/nvidia-training/main_test.go
@@ -74,9 +74,9 @@ func TestMain(m *testing.M) {
 		},
 
 		// Wait for DaemonSets using helper
-		deployDaemonSet("nvidia-device-plugin-daemonset", "kube-system", "NVIDIA Device Plugin"),
-		deployDaemonSet("aws-efa-k8s-device-plugin-daemonset", "kube-system", "EFA Device Plugin"),
-		deployDaemonSet("dcgm-exporter", "kube-system", "DCGM Exporter"),
+		deployDaemonSet("nvidia-device-plugin-daemonset", "kube-system"),
+		deployDaemonSet("aws-efa-k8s-device-plugin-daemonset", "kube-system"),
+		deployDaemonSet("dcgm-exporter", "kube-system"),
 
 		checkNodeTypes, // Dynamically check node types and capacities after device plugins are ready
 	)
@@ -157,9 +157,9 @@ func checkNodeTypes(ctx context.Context, config *envconf.Config) (context.Contex
 	return ctx, nil
 }
 // Helper function to deploy DaemonSet + Wait for Ready
-func deployDaemonSet(name, namespace, logLabel string) env.Func {
+func deployDaemonSet(name, namespace string) env.Func {
 	return func(ctx context.Context, config *envconf.Config) (context.Context, error) {
-		log.Printf("Waiting for %s daemonset to be ready.", logLabel)
+		log.Printf("Waiting for %s daemonset to be ready.", name)
 		daemonset := appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		}
@@ -168,9 +168,9 @@ func deployDaemonSet(name, namespace, logLabel string) env.Func {
 			wait.WithTimeout(5*time.Minute),
 		)
 		if err != nil {
-			return ctx, fmt.Errorf("%s daemonset is not ready: %w", logLabel, err)
+			return ctx, fmt.Errorf("%s daemonset is not ready: %w", name, err)
 		}
-		log.Printf("%s daemonset is ready.", logLabel)
+		log.Printf("%s daemonset is ready.", name)
 		return ctx, nil
 	}
 }

--- a/test/manifests/assets/dcgm-exporter.yaml
+++ b/test/manifests/assets/dcgm-exporter.yaml
@@ -1,21 +1,9 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+# Derived from: Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: "dcgm-exporter"
+  namespace: "kube-system"
   labels:
     app.kubernetes.io/name: "dcgm-exporter"
     app.kubernetes.io/version: "4.1.3"
@@ -64,6 +52,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: "dcgm-exporter"
+  namespace: "kube-system"
   labels:
     app.kubernetes.io/name: "dcgm-exporter"
     app.kubernetes.io/version: "4.1.3"

--- a/test/manifests/assets/dcgm-exporter.yaml
+++ b/test/manifests/assets/dcgm-exporter.yaml
@@ -1,0 +1,76 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: "dcgm-exporter"
+  labels:
+    app.kubernetes.io/name: "dcgm-exporter"
+    app.kubernetes.io/version: "4.1.3"
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "dcgm-exporter"
+      app.kubernetes.io/version: "4.1.3"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "dcgm-exporter"
+        app.kubernetes.io/version: "4.1.3"
+      name: "dcgm-exporter"
+    spec:
+      containers:
+      - image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04"
+        env:
+        - name: "DCGM_EXPORTER_LISTEN"
+          value: ":9400"
+        - name: "DCGM_EXPORTER_KUBERNETES"
+          value: "true"
+        name: "dcgm-exporter"
+        ports:
+        - name: "metrics"
+          containerPort: 9400
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - name: "pod-gpu-resources"
+          readOnly: true
+          mountPath: "/var/lib/kubelet/pod-resources"
+      volumes:
+      - name: "pod-gpu-resources"
+        hostPath:
+          path: "/var/lib/kubelet/pod-resources"
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: "dcgm-exporter"
+  labels:
+    app.kubernetes.io/name: "dcgm-exporter"
+    app.kubernetes.io/version: "4.1.3"
+spec:
+  selector:
+    app.kubernetes.io/name: "dcgm-exporter"
+    app.kubernetes.io/version: "4.1.3"
+  ports:
+  - name: "metrics"
+    port: 9400

--- a/test/manifests/raw.go
+++ b/test/manifests/raw.go
@@ -17,4 +17,8 @@ var (
 	NeuronDevicePluginRbacManifest []byte
 	//go:embed assets/k8s-neuron-device-plugin.yml
 	NeuronDevicePluginManifest []byte
+
+	//go:embed assets/dcgm-exporter.yaml
+	DCGMExporterManifest []byte
+
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR is to add DCGM Exporter to the test environment for eventual CloudWatch integration to view GPU metrics. Changes involve: Added DCGM Exporter DaemonSet in the default namespace, []byte array declared in `raw.go` and applied manifest + supporting function in `main_test.go`. 
On running `./nvidia-training.test` we can view the dcgm pods running before clean up:                                            
```
>> kubectl get pods -n default -l app.kubernetes.io/name=dcgm-exporter

NAME                  READY   STATUS    RESTARTS   AGE
dcgm-exporter-7575j   1/1     Running   0          8m1s
dcgm-exporter-jjv7r   1/1     Running   0          8m1s
dcgm-exporter-lcqtq   1/1     Running   0          8m1s
dcgm-exporter-nzd44   1/1     Running   0          8m1s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
