### PR TITLE
feat(deployer/eksctl): allow deleting nodegroupds with --down, skip draining nodegroups option

### DIFF
--- a/internal/deployers/eksctl/deployer.go
+++ b/internal/deployers/eksctl/deployer.go
@@ -27,7 +27,6 @@ type deployer struct {
 	awsConfig      aws.Config
 	eksClient      *eks.Client
 	KubeconfigPath string `flag:"kubeconfig" desc:"Path to kubeconfig"`
-	SkipDrain      bool   `flag:"skip-drain" desc:"Disable draining nodes before deletion (default: false)"`
 	// ClusterName is the effective cluster name (from flag or RunID)
 	clusterName string
 }

--- a/internal/deployers/eksctl/deployer.go
+++ b/internal/deployers/eksctl/deployer.go
@@ -27,6 +27,7 @@ type deployer struct {
 	awsConfig      aws.Config
 	eksClient      *eks.Client
 	KubeconfigPath string `flag:"kubeconfig" desc:"Path to kubeconfig"`
+	SkipDrain      bool   `flag:"skip-drain" desc:"Disable draining nodes before deletion (default: false)"`
 	// ClusterName is the effective cluster name (from flag or RunID)
 	clusterName string
 }

--- a/internal/deployers/eksctl/down.go
+++ b/internal/deployers/eksctl/down.go
@@ -14,8 +14,7 @@ func (d *deployer) Down() error {
 
 	if d.DeployTarget == "nodegroup" {
 		klog.Infof("deleting nodegroup %s from cluster %s", d.NodegroupName, d.clusterName)
-		args := []string{"delete", "nodegroup", "--cluster", d.clusterName, "--name", d.NodegroupName, "--drain=false", "--wait"}
-		err = util.ExecuteCommand("eksctl", args...)
+		err = util.ExecuteCommand("eksctl", "delete", "nodegroup", "--cluster", d.clusterName, "--name", d.NodegroupName, "--drain=false", "--wait")
 		if err != nil {
 			return fmt.Errorf("failed to delete nodegroup: %v", err)
 		}

--- a/internal/deployers/eksctl/down.go
+++ b/internal/deployers/eksctl/down.go
@@ -1,16 +1,38 @@
 package eksctl
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-k8s-tester/internal/util"
 	"k8s.io/klog"
 )
 
 func (d *deployer) Down() error {
-	klog.Infof("deleting cluster %s", d.commonOptions.RunID())
-	err := util.ExecuteCommand("eksctl", "delete", "cluster", "--name", d.commonOptions.RunID(), "--wait")
-	if err != nil {
-		return err
+	d.initClusterName()
+
+	var err error
+
+	if d.DeployTarget == "nodegroup" {
+		klog.Infof("deleting nodegroup %s from cluster %s", d.NodegroupName, d.clusterName)
+		args := []string{"delete", "nodegroup", "--cluster", d.clusterName, "--name", d.NodegroupName}
+		if d.SkipDrain {
+			args = append(args, "--drain=false")
+		}
+		args = append(args, "--wait")
+		err = util.ExecuteCommand("eksctl", args...)
+		if err != nil {
+			return fmt.Errorf("failed to delete nodegroup: %v", err)
+		}
+		klog.Infof("Successfully deleted nodegroup: %s from cluster: %s", d.NodegroupName, d.clusterName)
+	} else if d.DeployTarget == "cluster" {
+		klog.Infof("deleting cluster %s", d.clusterName)
+		err = util.ExecuteCommand("eksctl", "delete", "cluster", "--name", d.clusterName, "--wait")
+		if err != nil {
+			return fmt.Errorf("failed to delete cluster: %v", err)
+		}
+		klog.Infof("Successfully deleted cluster: %s", d.clusterName)
+	} else {
+		return fmt.Errorf("Unsupported deploy target: %s, supported options: `cluster`, `nodegroup`.", d.DeployTarget)
 	}
-	klog.Infof("deleted cluster: %s", d.commonOptions.RunID())
 	return nil
 }

--- a/internal/deployers/eksctl/down.go
+++ b/internal/deployers/eksctl/down.go
@@ -14,11 +14,7 @@ func (d *deployer) Down() error {
 
 	if d.DeployTarget == "nodegroup" {
 		klog.Infof("deleting nodegroup %s from cluster %s", d.NodegroupName, d.clusterName)
-		args := []string{"delete", "nodegroup", "--cluster", d.clusterName, "--name", d.NodegroupName}
-		if d.SkipDrain {
-			args = append(args, "--drain=false")
-		}
-		args = append(args, "--wait")
+		args := []string{"delete", "nodegroup", "--cluster", d.clusterName, "--name", d.NodegroupName, "--drain=false", "--wait"}
 		err = util.ExecuteCommand("eksctl", args...)
 		if err != nil {
 			return fmt.Errorf("failed to delete nodegroup: %v", err)


### PR DESCRIPTION
*Issue #, if available:*
[#595 ](https://github.com/aws/aws-k8s-tester/issues/595)
*Description of changes:*

This PR adds the capability to **delete** EKS nodegroups using the --down flag. The changes include:

- Added a new SkipDrain flag option to control node draining behavior during deletion
  - The nodegroup deletion supports an optional --drain=false flag to skip draining nodes before deletion
- Enhanced the Down() function to support two deployment targets:
  - nodegroup: Deletes a specific nodegroup from a cluster
  - cluster: Deletes the entire EKS cluster (existing behavior)
- Added proper error handling and logging for both nodegroup and cluster deletion operations


Tests Done
```
kubetest2 eksctl \
--cluster-name=my-cluster-130 \
--nodegroup-name=aarch64-aws-k8s-130 \
--region=us-west-2 \
--kubernetes-version=1.30 \
--ami-family=Bottlerocket \
--ami=ami-017b2a28378e53647 \
--instance-types=m7g.xlarge \
--nodes=3 \
--deploy-target nodegroup \
--skip-drain \
--up \
--down
```
```
kubetest2 eksctl \
--cluster-name=my-cluster-130 \
--nodegroup-name=aarch64-aws-k8s-130 \
--region=us-west-2 \
--kubernetes-version=1.30 \
--ami-family=Bottlerocket \
--ami=ami-017b2a28378e53647 \
--instance-types=m7g.xlarge \
--nodes=3 \
--deploy-target nodegroup \
--skip-drain \
--up \
--down \
--test ginkgo -- \
--focus-regex='\[Conformance\]' \
--parallel=6 \
--skip-regex='\[Serial\]|\[Disruptive\]|\[Slow\]|Garbage.collector'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
