### PR TITLE
feat(nvidia): build nccl from source

### DIFF
--- a/test/images/nvidia-training/Dockerfile
+++ b/test/images/nvidia-training/Dockerfile
@@ -112,11 +112,11 @@ RUN curl -sL https://efa-installer.amazonaws.com/aws-efa-installer-$EFA_INSTALLE
 
 # Install NCCL
 ARG LIBNCCL_VERSION=2.27.5-1
-RUN apt update \
- && apt install -y \
-        libnccl2=$LIBNCCL_VERSION+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
-        libnccl-dev=$LIBNCCL_VERSION+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
- && rm -rf /var/lib/apt/lists/* 
+RUN git clone https://github.com/NVIDIA/nccl.git --branch v$LIBNCCL_VERSION /tmp/nccl \
+ && cd /tmp/nccl \
+ && make -j $(nproc) \
+ && make install \
+ && cd && rm -rf /tmp/nccl
 
 # Install AWS-OFI-NCCL plugin
 ARG AWS_OFI_NCCL_VERSION=1.16.0

--- a/test/images/nvidia/Dockerfile
+++ b/test/images/nvidia/Dockerfile
@@ -68,11 +68,11 @@ RUN curl -sL https://efa-installer.amazonaws.com/aws-efa-installer-$EFA_INSTALLE
 
 # Install NCCL
 ARG LIBNCCL_VERSION=2.27.5-1
-RUN apt update \
- && apt install -y \
-      libnccl2=$LIBNCCL_VERSION+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
-      libnccl-dev=$LIBNCCL_VERSION+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
- && rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/NVIDIA/nccl.git --branch v$LIBNCCL_VERSION /tmp/nccl \
+ && cd /tmp/nccl \
+ && make -j $(nproc) \
+ && make install \
+ && cd && rm -rf /tmp/nccl
 
 # Install AWS-OFI-NCCL plugin
 ARG AWS_OFI_NCCL_VERSION=1.16.0
@@ -96,6 +96,7 @@ RUN git clone https://github.com/NVIDIA/nccl-tests /tmp/nccl-tests \
       MPI=1 \
       MPI_HOME=/opt/amazon/openmpi/ \
       CUDA_HOME=/usr/local/cuda \
+      NCCL_HOME=/usr/local/lib \
  && mkdir -p /opt/nccl-tests \
  && mv build /opt/nccl-tests/build \
  && cd && rm -rf /tmp/nccl-tests


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR updates nvidia test images to build NCCL using the cuda version that ships with the container, rather than trying to match with the correct package from upstream repository (apt in this case).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
