### PR TITLE
ci: free up disk space before build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    # hack to free up disk space for build
+    # ref: https://github.com/easimon/maximize-build-space/blob/master/action.yml
+    - run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        docker image prune --all --force
+        docker builder prune -a
     - run: |
         docker build --file test/images/nvidia-inference/Dockerfile test/images/nvidia-inference \
           --build-arg PYTORCH_BUILD_ENV="MAX_JOBS=$(($(nproc) - 2)) USE_MKLDNN=0 USE_DISTRIBUTED=0 USE_CUDA=0 USE_ROCM=0 USE_CAFFE2=0 USE_QNNPACK=0 USE_NNPACK=0 USE_XNNPACK=0 USE_MPS=0 BUILD_SHARED_LIBS=OFF USE_FLASH_ATTENTION=0 USE_MEM_EFF_ATTENTION=0 BUILD_TEST=0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

One of the nvidia image builds fails due to running out of disk space. there is space that can be reclaimed, so we're attempting to do that before initializing the docker build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
