### PR TITLE
fix(nvidia): remove chunksize conflicting with alltoall perf

### DIFF
--- a/test/cases/nvidia/manifests/mpi-job-nccl-test-multi-node.yaml
+++ b/test/cases/nvidia/manifests/mpi-job-nccl-test-multi-node.yaml
@@ -39,8 +39,6 @@ spec:
             - -x
             - NCCL_BUFFSIZE={{.NcclBuffSize}}
             - -x
-            - NCCL_P2P_NET_CHUNKSIZE="524288"
-            - -x
             - NCCL_TUNER_PLUGIN=/opt/aws-ofi-nccl/install/lib/libnccl-ofi-tuner.so
             - --mca
             - pml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This static `NCCL_P2P_NET_CHUNKSIZE` value was causing failure in `alltoall` nccl-test perfs, and removing them fixed the issue.

Would see issues like the following if the value was incorrectly set:
```
[1,0]<stdout>:multi-node-nccl-test-worker-0: Test NCCL failure alltoall.cu:62 'unhandled cuda error (run with NCCL_DEBUG=INFO for details) / '
[1,3]<stdout>:[2025-07-01 22:28:44] multi-node-nccl-test-worker-0:26:54 [3] proxy.cc:1665 NCCL WARN [Service thread] Error encountered progressing operation=Connect, res=3, closing connection
```

May need more investigation, or just not a value that should be statically optimized.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
