### PR TITLE
CloudWatch Agent integration for nvidia-training

### DIFF
--- a/test/cases/nvidia-training/vars.go
+++ b/test/cases/nvidia-training/vars.go
@@ -14,6 +14,9 @@ var (
 	bertTrainingImage *string
 	efaEnabled        *bool
 	nodeType          *string
+	kubernetesVersion *string
+	amiVariant	  	  *string
+	teamIdentifier    *string
 
 	nodeCount  int
 	gpuPerNode int
@@ -24,4 +27,7 @@ func init() {
 	bertTrainingImage = flag.String("bertTrainingImage", "", "Docker image used for BERT training workload")
 	efaEnabled = flag.Bool("efaEnabled", false, "Enable Elastic Fabric Adapter (EFA)")
 	nodeType = flag.String("nodeType", "", "Instance type for cluster nodes")
+	kubernetesVersion = flag.String("kubernetesVersion", "1.32", "Kubernetes version for the cluster")
+	amiVariant = flag.String("amiVariant", "al2023", "AMI variant for the cluster nodes")
+	teamIdentifier = flag.String("teamIdentifier", "node-runtime", "Team identifier for resource tagging")
 }

--- a/test/manifests/assets/cloudwatch-agent.yaml
+++ b/test/manifests/assets/cloudwatch-agent.yaml
@@ -1,0 +1,130 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-cwagentconfig
+  namespace: amazon-cloudwatch
+data:
+  cwagentconfig.json: |
+    {
+      "agent": {
+        "debug": true,
+        "region": "{{.REGION}}"
+      },
+      "logs": {
+        "metrics_collected": {
+          "prometheus": {
+            "prometheus_config_path": "/etc/prometheusconfig/prometheus.yaml",
+            "emf_processor": {
+              "metric_declaration": [
+                {
+                  "source_labels": ["job"],
+                  "label_matcher": "dcgm-exporter",
+                  "dimensions": [["TestType", "KubernetesVersion", "Variant", "InstanceType", "TeamIdentifier"]],
+                  "metric_selectors": [
+                    "^DCGM_FI_DEV_GPU_UTIL$",
+                    "^DCGM_FI_DEV_MEM_COPY_UTIL$",
+                    "^DCGM_FI_DEV_FB_USED$",
+                    "^DCGM_FI_DEV_FB_FREE$",
+                    "^DCGM_FI_DEV_POWER_USAGE$"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "force_flush_interval": 5
+      }
+    }
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: amazon-cloudwatch
+data:
+  prometheus.yaml: |
+    global:
+      scrape_interval: 1m
+      scrape_timeout: 10s
+    scrape_configs:
+      - job_name: dcgm-exporter
+        static_configs:
+          - targets:
+            - dcgm-exporter.kube-system.svc.cluster.local:9400
+        metrics_path: /metrics
+        scrape_interval: 30s
+        metric_relabel_configs:
+          - action: replace
+            source_labels: [job]
+            target_label: job
+            replacement: "dcgm-exporter"
+          - action: replace
+            source_labels: [job]
+            target_label: KubernetesVersion
+            replacement: "{{.VERSION}}"
+          - action: replace
+            source_labels: [job]
+            target_label: Variant
+            replacement: "{{.VARIANT}}"
+          - action: replace
+            source_labels: [job]
+            target_label: InstanceType
+            replacement: "{{.INSTANCE_TYPE}}"
+          - action: replace
+            source_labels: [job]
+            target_label: TeamIdentifier
+            replacement: "{{.TEAM_IDENTIFIER}}"
+          - action: replace
+            source_labels: [job]
+            target_label: TestType
+            replacement: "{{.TEST_NAME}}"
+
+
+
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cwagent-prometheus
+  namespace: amazon-cloudwatch
+spec:
+  selector:
+    matchLabels:
+      app: cwagent-prometheus
+  template:
+    metadata:
+      labels:
+        app: cwagent-prometheus
+    spec:
+      serviceAccountName: cwagent-prometheus
+      dnsPolicy: ClusterFirst 
+      containers:
+        - name: cloudwatch-agent
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          imagePullPolicy: Always
+          env:
+            - name: RUN_WITH_IRSA
+              value: "True"
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+            requests:
+              cpu: 200m
+              memory: 200Mi
+          volumeMounts:
+            - name: prometheus-cwagentconfig
+              mountPath: /etc/cwagentconfig
+            - name: prometheus-config
+              mountPath: /etc/prometheusconfig
+      volumes:
+        - name: prometheus-cwagentconfig
+          configMap:
+            name: prometheus-cwagentconfig
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+      terminationGracePeriodSeconds: 60
+---

--- a/test/manifests/assets/dcgm-exporter.yaml
+++ b/test/manifests/assets/dcgm-exporter.yaml
@@ -57,6 +57,7 @@ metadata:
     app.kubernetes.io/name: "dcgm-exporter"
     app.kubernetes.io/version: "4.1.3"
 spec:
+  clusterIP: "None"
   selector:
     app.kubernetes.io/name: "dcgm-exporter"
     app.kubernetes.io/version: "4.1.3"

--- a/test/manifests/raw.go
+++ b/test/manifests/raw.go
@@ -21,4 +21,7 @@ var (
 	//go:embed assets/dcgm-exporter.yaml
 	DCGMExporterManifest []byte
 
+	//go:embed assets/cloudwatch-agent.yaml
+	CloudWatchAgentManifest []byte
+
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
NOTE: This will only work after CW Infra is also successfully deployed (https://github.com/aws/aws-k8s-tester/pull/648)
Changes include: 
- Added amiVariant, teamIdentifier, and KubernetesVersion flags with default versions enabled
- CloudWatch agent manifest configured to scrape Prometheus compatible DCGM GPU metrics with proper labeling
- Small change in DCGM to ensure headless service discovery
- Created additional function to scrape Region from node labels
- Applied manifest in main_test.go after rendering with required parameters once DCGM Exporter runs

Testing:

- Verified CloudWatch agent deploys successfully with pods showing that 90+ metrics are collected successfully
- Metrics are actively visible under ContainerInsights/Prometheus under the dimensions ["TestType", "KubernetesVersion", "Variant", "InstanceType", "TeamIdentifier"]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
