### PR TITLE
feat(e2e): Add e2e test for Nvidia driver capabilities check

### DIFF
--- a/internal/e2e/conditions.go
+++ b/internal/e2e/conditions.go
@@ -32,6 +32,19 @@ func (c *ConditionExtension) ResourceMatch(obj k8s.Object, matchFetcher func(obj
 	}
 }
 
+func (c *ConditionExtension) PodRunning(pod k8s.Object) apimachinerywait.ConditionWithContextFunc {
+	return func(ctx context.Context) (done bool, err error) {
+		if err := c.resources.Get(ctx, pod.GetName(), pod.GetNamespace(), pod); err != nil {
+			return false, err
+		}
+		status := pod.(*v1.Pod).Status
+		if status.Phase == v1.PodRunning {
+			done = true
+		}
+		return
+	}
+}
+
 func (c *ConditionExtension) DaemonSetReady(daemonset k8s.Object) apimachinerywait.ConditionWithContextFunc {
 	return func(ctx context.Context) (done bool, err error) {
 		if err := c.resources.Get(ctx, daemonset.GetName(), daemonset.GetNamespace(), daemonset); err != nil {

--- a/internal/e2e/conditions.go
+++ b/internal/e2e/conditions.go
@@ -32,17 +32,24 @@ func (c *ConditionExtension) ResourceMatch(obj k8s.Object, matchFetcher func(obj
 	}
 }
 
-func (c *ConditionExtension) PodRunning(pod k8s.Object) apimachinerywait.ConditionWithContextFunc {
+func (c *ConditionExtension) PodSucceeded(pod k8s.Object) apimachinerywait.ConditionWithContextFunc {
 	return func(ctx context.Context) (done bool, err error) {
 		if err := c.resources.Get(ctx, pod.GetName(), pod.GetNamespace(), pod); err != nil {
 			return false, err
 		}
 		status := pod.(*v1.Pod).Status
-		if status.Phase == v1.PodRunning {
+		if status.Phase == v1.PodSucceeded {
 			done = true
 		}
 		return
 	}
+}
+
+func (c *ConditionExtension) GetPodPhase(pod k8s.Object) (v1.PodPhase, error) {
+	if err := c.resources.Get(context.Background(), pod.GetName(), pod.GetNamespace(), pod); err != nil {
+		return v1.PodUnknown, err
+	}
+	return pod.(*v1.Pod).Status.Phase, nil
 }
 
 func (c *ConditionExtension) DaemonSetReady(daemonset k8s.Object) apimachinerywait.ConditionWithContextFunc {

--- a/internal/e2e/conditions.go
+++ b/internal/e2e/conditions.go
@@ -40,16 +40,11 @@ func (c *ConditionExtension) PodSucceeded(pod k8s.Object) apimachinerywait.Condi
 		status := pod.(*v1.Pod).Status
 		if status.Phase == v1.PodSucceeded {
 			done = true
+		} else if status.Phase == v1.PodFailed {
+			return false, fmt.Errorf("Pod in Failed status")
 		}
 		return
 	}
-}
-
-func (c *ConditionExtension) GetPodPhase(pod k8s.Object) (v1.PodPhase, error) {
-	if err := c.resources.Get(context.Background(), pod.GetName(), pod.GetNamespace(), pod); err != nil {
-		return v1.PodUnknown, err
-	}
-	return pod.(*v1.Pod).Status.Phase, nil
 }
 
 func (c *ConditionExtension) DaemonSetReady(daemonset k8s.Object) apimachinerywait.ConditionWithContextFunc {

--- a/test/cases/nvidia/capabilities_test.go
+++ b/test/cases/nvidia/capabilities_test.go
@@ -1,0 +1,91 @@
+//go:build e2e
+
+package nvidia
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-k8s-tester/internal/e2e"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	_ "embed"
+)
+
+//go:embed manifests/nvidia-driver-capabilities-check.yaml
+var capabilitiesCheckPod []byte
+
+func TestNvidiaDriverCapabilities(t *testing.T) {
+	feat := features.New("nvidia-driver-capabilities-check").
+		WithLabel("suite", "nvidia").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			log.Println("[Setup] Applying nvidia driver capabilities check pod manifest.")
+			if err := e2e.ApplyManifests(cfg.Client().RESTConfig(), capabilitiesCheckPod); err != nil {
+				t.Fatalf("Failed to apply capabilities check pod manifest: %v", err)
+			}
+			return ctx
+		}).
+		Assess("Pod becomes ready", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			podName := "moderngl-container"
+			podNS := "default"
+
+			log.Println("[Assess] Waiting up to 1 minute for pod to become Running...")
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: podNS,
+				},
+			}
+			err := wait.For(
+				e2e.NewConditionExtension(cfg.Client().Resources()).PodRunning(pod),
+				wait.WithTimeout(1*time.Minute),
+			)
+			if err != nil {
+				t.Fatalf("nvidia capabilities check pod not in Running within 1 minute")
+			}
+			log.Println("[Assess] nvidia capabilities check pod is Ready.")
+
+			// Check ModernGL functionality
+			pythonCmd := `python3 -c "
+import moderngl
+try:
+    ctx = moderngl.create_standalone_context(backend='egl')
+    print('ModernGL context created successfully')
+    ctx.release()
+except Exception as e:
+    print(f'ModernGL error: {e}')
+    exit(1)
+"`
+			e2e.ApplyManifests(cfg.Client().RESTConfig(), capabilitiesCheckPod)
+			stdout, stderr, err := e2e.ExecuteInPod(cfg.Client().RESTConfig(), podName, podNS, pythonCmd)
+			if err != nil {
+				t.Fatalf("Failed to execute nvidia driver capabilites check in pod: %v\nStdout: %s\nStderr: %s", err, stdout, stderr)
+			}
+
+			if !bytes.Contains(stdout, []byte("ModernGL context created successfully")) {
+				t.Fatalf("nvidia driver capabilites check failed:\nStdout: %s\nStderr: %s", stdout, stderr)
+			}
+			log.Println("[Assess] nvidia capabilities check pass")
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Log("[Teardown] Removing nvidia driver capabilities check pod.")
+			if err := e2e.DeleteManifests(cfg.Client().RESTConfig(), capabilitiesCheckPod); err != nil {
+				t.Fatalf("Failed to delete pod: %v", err)
+			}
+			t.Log("[Teardown] check pod removed successfully.")
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}

--- a/test/cases/nvidia/capabilities_test.go
+++ b/test/cases/nvidia/capabilities_test.go
@@ -58,14 +58,10 @@ func TestNvidiaDriverCapabilities(t *testing.T) {
 				wait.WithTimeout(5*time.Minute),
 			)
 			if err != nil {
-				podPhase, err2 := e2e.NewConditionExtension(cfg.Client().Resources()).GetPodPhase(pod)
-				if err2 != nil {
-					t.Fatalf("[Assess] nvidia capabilities check pod not in succeeded phase within 5 minute: %v, failed to get current pod phase: %v", err, err2)
-				} else if podPhase == v1.PodFailed {
+				if err.Error() == "Pod in Failed status" {
 					t.Fatalf("[Assess] nvidia capabilities pod in Failed status, ModernGL check failed. Could be caused by required library missing")
-				} else {
-					t.Fatalf("[Assess] nvidia capabilities check pod not in compeleted phase (succeeded or failed) within 5 minute: %v, current pod phase: %v", err, podPhase)
 				}
+				t.Fatalf("[Assess] nvidia capabilities check pod not in compeleted phase (succeeded or failed) within 5 minute and waiter timeout: %v", err)
 			}
 			log.Println("[Assess] nvidia driver capabilities check succeeded.")
 			return ctx

--- a/test/cases/nvidia/capabilities_test.go
+++ b/test/cases/nvidia/capabilities_test.go
@@ -3,8 +3,8 @@
 package nvidia
 
 import (
-	"bytes"
 	"context"
+	"fmt"
 	"log"
 	"testing"
 	"time"
@@ -24,57 +24,50 @@ import (
 //go:embed manifests/nvidia-driver-capabilities-check.yaml
 var capabilitiesCheckPod []byte
 
+//go:embed manifests/moderngl-script.py
+var modernglScript []byte
+
+const (
+	PodName      = "moderngl-pod"
+	PodNamespace = "default"
+	ConfigMap    = "moderngl-script"
+)
+
 func TestNvidiaDriverCapabilities(t *testing.T) {
 	feat := features.New("nvidia-driver-capabilities-check").
 		WithLabel("suite", "nvidia").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			log.Println("[Setup] Deploy the config map")
+			e2e.CreateConfigMapFromFile(cfg.Client().RESTConfig(), PodNamespace, ConfigMap, fmt.Sprintf("%s.py", ConfigMap), modernglScript)
 			log.Println("[Setup] Applying nvidia driver capabilities check pod manifest.")
 			if err := e2e.ApplyManifests(cfg.Client().RESTConfig(), capabilitiesCheckPod); err != nil {
 				t.Fatalf("Failed to apply capabilities check pod manifest: %v", err)
 			}
 			return ctx
 		}).
-		Assess("Pod becomes ready", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			podName := "moderngl-container"
-			podNS := "default"
-
-			log.Println("[Assess] Waiting up to 1 minute for pod to become Running...")
+		Assess("Check Pod becomes ready", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			log.Println("[Assess] Waiting up to 5 minute for pod to become Running...")
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      podName,
-					Namespace: podNS,
+					Name:      PodName,
+					Namespace: PodNamespace,
 				},
 			}
 			err := wait.For(
-				e2e.NewConditionExtension(cfg.Client().Resources()).PodRunning(pod),
-				wait.WithTimeout(1*time.Minute),
+				e2e.NewConditionExtension(cfg.Client().Resources()).PodSucceeded(pod),
+				wait.WithTimeout(5*time.Minute),
 			)
 			if err != nil {
-				t.Fatalf("nvidia capabilities check pod not in Running within 1 minute")
+				podPhase, err2 := e2e.NewConditionExtension(cfg.Client().Resources()).GetPodPhase(pod)
+				if err2 != nil {
+					t.Fatalf("[Assess] nvidia capabilities check pod not in succeeded phase within 5 minute: %v, failed to get current pod phase: %v", err, err2)
+				} else if podPhase == v1.PodFailed {
+					t.Fatalf("[Assess] nvidia capabilities pod in Failed status, ModernGL check failed. Could be caused by required library missing")
+				} else {
+					t.Fatalf("[Assess] nvidia capabilities check pod not in compeleted phase (succeeded or failed) within 5 minute: %v, current pod phase: %v", err, podPhase)
+				}
 			}
-			log.Println("[Assess] nvidia capabilities check pod is Ready.")
-
-			// Check ModernGL functionality
-			pythonCmd := `python3 -c "
-import moderngl
-try:
-    ctx = moderngl.create_standalone_context(backend='egl')
-    print('ModernGL context created successfully')
-    ctx.release()
-except Exception as e:
-    print(f'ModernGL error: {e}')
-    exit(1)
-"`
-			e2e.ApplyManifests(cfg.Client().RESTConfig(), capabilitiesCheckPod)
-			stdout, stderr, err := e2e.ExecuteInPod(cfg.Client().RESTConfig(), podName, podNS, pythonCmd)
-			if err != nil {
-				t.Fatalf("Failed to execute nvidia driver capabilites check in pod: %v\nStdout: %s\nStderr: %s", err, stdout, stderr)
-			}
-
-			if !bytes.Contains(stdout, []byte("ModernGL context created successfully")) {
-				t.Fatalf("nvidia driver capabilites check failed:\nStdout: %s\nStderr: %s", stdout, stderr)
-			}
-			log.Println("[Assess] nvidia capabilities check pass")
+			log.Println("[Assess] nvidia driver capabilities check succeeded.")
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -82,7 +75,11 @@ except Exception as e:
 			if err := e2e.DeleteManifests(cfg.Client().RESTConfig(), capabilitiesCheckPod); err != nil {
 				t.Fatalf("Failed to delete pod: %v", err)
 			}
-			t.Log("[Teardown] check pod removed successfully.")
+			t.Log("[Teardown] Removing nvidia driver capabilities script config map.")
+			if err := e2e.DeleteConfigMap(cfg.Client().RESTConfig(), PodNamespace, ConfigMap); err != nil {
+				t.Fatalf("Failed to delete configmap: %v", err)
+			}
+			t.Log("[Teardown] all test resources removed successfully.")
 			return ctx
 		}).
 		Feature()

--- a/test/cases/nvidia/manifests/moderngl-script.py
+++ b/test/cases/nvidia/manifests/moderngl-script.py
@@ -1,0 +1,8 @@
+import moderngl
+try:
+    ctx = moderngl.create_standalone_context(backend='egl')
+    print('ModernGL context created successfully')
+    ctx.release()
+except Exception as e:
+    print(f'ModernGL error: {e}')
+    exit(1)

--- a/test/cases/nvidia/manifests/nvidia-driver-capabilities-check.yaml
+++ b/test/cases/nvidia/manifests/nvidia-driver-capabilities-check.yaml
@@ -19,10 +19,7 @@ spec:
       - -c
       - |
         set -o errexit
-        set -o pipefail
-
         apt-get update
-        
         apt-get install -y \
           python3 \
           python3-pip \

--- a/test/cases/nvidia/manifests/nvidia-driver-capabilities-check.yaml
+++ b/test/cases/nvidia/manifests/nvidia-driver-capabilities-check.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   name: moderngl-pod
 spec:
+  restartPolicy: Never
   tolerations:
   - key: "nvidia.com/gpu"
     operator: "Exists"
@@ -31,8 +32,7 @@ spec:
           mesa-utils \
           xvfb
         pip3 install moderngl
-        
-        sleep 3600
+        python3 /scripts/moderngl-script.py
     resources:
       requests:
         memory: "50Gi"
@@ -41,4 +41,14 @@ spec:
       limits:
         memory: "50Gi"
         "nvidia.com/gpu": "1"
-  restartPolicy: Never
+    volumeMounts:
+        - name: moderngl-script-volume
+          mountPath: /scripts
+          readOnly: true
+  volumes:
+    - name: moderngl-script-volume
+      configMap:
+        name: moderngl-script
+        items:
+          - key: moderngl-script.py
+            path: moderngl-script.py

--- a/test/cases/nvidia/manifests/nvidia-driver-capabilities-check.yaml
+++ b/test/cases/nvidia/manifests/nvidia-driver-capabilities-check.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: moderngl-pod
+spec:
+  tolerations:
+  - key: "nvidia.com/gpu"
+    operator: "Exists"
+    effect: "NoSchedule"
+  containers:
+  - name: moderngl-container
+    env:
+    - name: NVIDIA_DRIVER_CAPABILITIES
+      value: "all"
+    image: ubuntu:22.04
+    command: ["/bin/bash"]
+    args:
+      - -c
+      - |
+        set -o errexit
+        set -o pipefail
+
+        apt-get update
+        
+        apt-get install -y \
+          python3 \
+          python3-pip \
+          libgl1-mesa-glx \
+          libegl1-mesa \
+          libgles2-mesa \
+          mesa-utils \
+          xvfb
+        pip3 install moderngl
+        
+        sleep 3600
+    resources:
+      requests:
+        memory: "50Gi"
+        cpu: "15"
+        "nvidia.com/gpu": "1"
+      limits:
+        memory: "50Gi"
+        "nvidia.com/gpu": "1"
+  restartPolicy: Never


### PR DESCRIPTION
*Issue #, if available:*
* This PR is to add e2e test for Nvidia driver capabilities check
* We ever encounter latest released bottlerocket-kernel-kit and bottlerocket-core-kit missing some library like libnvidia-gpucomp. It cause the workloads run with AMI `eks-auto-nvidia-1.32-x86_64-20250531` will failed with lib missing exception when set `NVIDIA_DRIVER_CAPABILITIES=all` env to enable all available driver capabilities.
```
>>> moderngl.create_context()
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/_moderngl.py", line 214, in __init__
    lib = ctypes.CDLL("libEGL.so")
  File "/usr/lib/python3.10/ctypes/__init__.py", line 374, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libEGL.so: cannot open shared object file: No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.10/dist-packages/moderngl/__init__.py", line 2242, in create_context
    ctx = get_context()
  File "/usr/local/lib/python3.10/dist-packages/moderngl/__init__.py", line 2299, in get_context
    init_context()
  File "/usr/local/lib/python3.10/dist-packages/moderngl/__init__.py", line 2281, in init_context
    loader = DefaultLoader()
  File "/usr/local/lib/python3.10/dist-packages/_moderngl.py", line 223, in __init__
    lib = ctypes.CDLL("libGL.so")
  File "/usr/lib/python3.10/ctypes/__init__.py", line 374, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libGL.so: cannot open shared object file: No such file or directory
```

*Test:*
 * Test with auto cluster and latest AMI already have the fix
```
> go test -tags=e2e --test.v ./test/cases/nvidia/... -run TestNvidiaDriverCapabilities --installDevicePlugin=false --nodeType=g5.8xlarge --nvidiaTestImage=nvidia:0
=== RUN   TestNvidiaDriverCapabilities
=== RUN   TestNvidiaDriverCapabilities/nvidia-driver-capabilities-check
2025/07/11 18:47:48 [Setup] Deploy the config map
2025/07/11 18:47:48 [Setup] Applying nvidia driver capabilities check pod manifest.
=== RUN   TestNvidiaDriverCapabilities/nvidia-driver-capabilities-check/Check_Pod_becomes_ready
2025/07/11 18:47:48 [Assess] Waiting up to 5 minute for pod to become Running...
2025/07/11 18:48:33 [Assess] nvidia driver capabilities check succeeded.
=== NAME  TestNvidiaDriverCapabilities/nvidia-driver-capabilities-check
    capabilities_test.go:74: [Teardown] Removing nvidia driver capabilities check pod.
    capabilities_test.go:78: [Teardown] Removing nvidia driver capabilities script config map.
    capabilities_test.go:82: [Teardown] all test resources removed successfully.
--- PASS: TestNvidiaDriverCapabilities (45.10s)
    --- PASS: TestNvidiaDriverCapabilities/nvidia-driver-capabilities-check (45.10s)
        --- PASS: TestNvidiaDriverCapabilities/nvidia-driver-capabilities-check/Check_Pod_becomes_ready (45.01s)
PASS
ok      github.com/aws/aws-k8s-tester/test/cases/nvidia 51.715s
```
  * Pin cluster with bad AMI `eks-auto-nvidia-1.32-x86_64-20250531`, and run test again
```
> go test -tags=e2e --test.v ./test/cases/nvidia/... -run TestNvidiaDriverCapabilities --installDevicePlugin=false --nodeType=g5.8xlarge --nvidiaTestImage=nvidia:0
=== RUN   TestNvidiaDriverCapabilities
=== RUN   TestNvidiaDriverCapabilities/nvidia-driver-capabilities-check
2025/07/11 19:26:18 [Setup] Deploy the config map
2025/07/11 19:26:18 [Setup] Applying nvidia driver capabilities check pod manifest.
=== RUN   TestNvidiaDriverCapabilities/nvidia-driver-capabilities-check/Check_Pod_becomes_ready
2025/07/11 19:26:18 [Assess] Waiting up to 5 minute for pod to become Running...
    capabilities_test.go:62: [Assess] nvidia capabilities pod in Failed status, ModernGL check failed. Could be caused by required library missing
=== NAME  TestNvidiaDriverCapabilities/nvidia-driver-capabilities-check
    capabilities_test.go:70: [Teardown] Removing nvidia driver capabilities check pod.
    capabilities_test.go:74: [Teardown] Removing nvidia driver capabilities script config map.
    capabilities_test.go:78: [Teardown] all test resources removed successfully.
--- FAIL: TestNvidiaDriverCapabilities (50.08s)
    --- FAIL: TestNvidiaDriverCapabilities/nvidia-driver-capabilities-check (50.08s)
        --- FAIL: TestNvidiaDriverCapabilities/nvidia-driver-capabilities-check/Check_Pod_becomes_ready (50.01s)
FAIL
FAIL    github.com/aws/aws-k8s-tester/test/cases/nvidia 61.894s
FAIL
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
