### PR TITLE
fix: ensure neuron test teardown completes

### DIFF
--- a/test/cases/neuron/main_test.go
+++ b/test/cases/neuron/main_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"slices"
 	"testing"
 	"time"
@@ -158,7 +159,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("failed to initialize test environment: %v", err)
 	}
 	testenv = env.NewWithConfig(cfg)
-	ctx, cancel := context.WithTimeout(context.Background(), 55*time.Minute)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 	testenv = testenv.WithContext(ctx)
 

--- a/test/cases/neuron/neuron_test.go
+++ b/test/cases/neuron/neuron_test.go
@@ -84,13 +84,14 @@ func TestNeuronNodes(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "neuronx-single-node", Namespace: "default"},
 			})
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+			} else {
+				t.Log("Test log for neuronx-single-node:")
+				t.Log(log)
 			}
-			t.Log("Test log for neuronx-single-node:")
-			t.Log(log)
 			err = fwext.DeleteManifests(cfg.Client().RESTConfig(), renderedNeuronSingleNodeManifest)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 			return ctx
 		}).

--- a/test/cases/nvidia/mpi_test.go
+++ b/test/cases/nvidia/mpi_test.go
@@ -100,9 +100,9 @@ func multiNode(testName string) features.Feature {
 		Assess("MPIJob succeeds", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			mpiJob := mpijobs.NewUnstructured(jobName, "default")
 			t.Log("Waiting for multi node job to complete")
-			ctxJobSucceed, _ := context.WithTimeout(ctx, 20*time.Minute)
 			err := wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(mpiJob, mpijobs.MPIJobSucceeded),
-				wait.WithContext(ctxJobSucceed),
+				wait.WithContext(ctx),
+				wait.WithTimeout(20*time.Minute),
 			)
 			if err != nil {
 				t.Error(err)

--- a/test/manifests/raw.go
+++ b/test/manifests/raw.go
@@ -20,5 +20,4 @@ var (
 
 	//go:embed assets/dcgm-exporter.yaml
 	DCGMExporterManifest []byte
-
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR changes several `t.Fatal` calls to `t.Error` so that teardown does not partially execute. it also makes the `main_test.go` context cancellable via `SIGINT`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
