### PR TITLE
fix: remove stale NCCL preload entry to silence ld.so warning

### DIFF
--- a/test/images/nvidia/Dockerfile
+++ b/test/images/nvidia/Dockerfile
@@ -109,6 +109,8 @@ RUN git clone https://github.com/NVIDIA/nccl-tests /tmp/nccl-tests \
 
 # Set a default command for debugging or modify as per requirements
 ENV NCCL_PROTO simple
+# see https://linux.die.net/man/8/ld.so for usage. replaces LD_PRELOAD env.
+RUN echo "/usr/local/lib/libnccl.so" >> /etc/ld.so.preload
 
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The nvidia-unit test images spams the stdout with a lot of unrelated errors like so:
```
ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libnccl.so' from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.
ls: cannot access '/usr/lib/x86_64-linux-gnu/libnccl.so*': No such file or directory
```

After we moved to building NCCL images from source [in this commit](https://github.com/aws/aws-k8s-tester/commit/14087f38fa2a3f41a4aaff3d71bb341ce911499c#diff-c8619414d5f991e60ebbce04169b8ea2fe998364dfa172a6a0aead792b4c029e), the libnccl.so files were now moved to `/usr/local/lib/`:
```
root@nvidia-debug-5b68bbc95-t5w94:/app# find /usr/local -name 'libnccl.so*' 2>/dev/null
/usr/local/lib/libnccl.so
/usr/local/lib/libnccl.so.2
/usr/local/lib/libnccl.so.2.27.5
```

This is already discoverable via the `LD_LIBRARY_PATH` env in the Dockerfile and other conf file also include this path. For ex:
```
root@nvidia-debug-5b68bbc95-gdvzk:/app# cat /etc/ld.so.conf.d/libc.conf 
ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libnccl.so' from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.
# libc default configuration
/usr/local/lib
```

Testing:
Rebuilt the image and re-ran the unit test to confirm no error logs for `ld.so` and confirmed that nccl tests pass:
```
go test -v \
-tags=e2e \
./test/cases/nvidia/... -timeout=0 \
-args \
--test.timeout=60m \
--test.v \
--test.run=^TestMPIJobPytorchTraining$/multi-node \
--efaEnabled=true \
--nvidiaTestImage=${AWS_ECR_PREFIX}/aws-k8s-tester/nvidia-test:latest \
--nodeType=g5.12xlarge

... <long output skipped> ...
        
--- PASS: TestMPIJobPytorchTraining (110.13s)
    --- PASS: TestMPIJobPytorchTraining/multi-node (110.13s)
        --- PASS: TestMPIJobPytorchTraining/multi-node/MPIJob_succeeds (110.04s)
PASS
ok      github.com/aws/aws-k8s-tester/test/cases/nvidia 127.362s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
