### PR TITLE
feat(efa): add validation for EFA on single node

### DIFF
--- a/test/cases/efa/commons.go
+++ b/test/cases/efa/commons.go
@@ -79,7 +79,7 @@ func getEfaNodes(ctx context.Context, config *envconf.Config) ([]corev1.Node, er
 		}
 
 		expectedDeviceCount := aws.ToInt(expectedEFADeviceCount)
-		if expectedDeviceCount == 0 {
+		if expectedDeviceCount < 0 {
 			instanceInfo, err := ec2Client.DescribeInstanceType(instanceType)
 			if err != nil {
 				return []corev1.Node{}, err

--- a/test/cases/efa/main_test.go
+++ b/test/cases/efa/main_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 	pingPongIters = flag.Int("pingPongIters", 10000, "number of iterations to use for ping pong")
 	pingPongDeadlineSeconds = flag.Int("pingPongDeadlineSeconds", 120, "maximum run time for a ping pong attempt")
 	nodeType = flag.String("nodeType", "", "instance type to target for tests")
-	expectedEFADeviceCount = flag.Int("expectedEFADeviceCount", 0, "expected number of efa devices for the target nodes")
+	expectedEFADeviceCount = flag.Int("expectedEFADeviceCount", -1, "expected number of efa devices for the target nodes")
 	verbose = flag.Bool("verbose", true, "use verbose mode for tests")
 
 	cfg, err := envconf.NewFromFlags()

--- a/test/images/efa/Dockerfile
+++ b/test/images/efa/Dockerfile
@@ -1,5 +1,7 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
+ARG EFA_BIN_PATH="/opt/amazon/efa/bin"
+
 RUN dnf -y swap gnupg2-minimal gnupg2 && \
     dnf install -y \
     gcc gcc-c++ make \  
@@ -25,7 +27,7 @@ RUN dnf -y swap gnupg2-minimal gnupg2 && \
     tar \
     gnupg2 
 
-ENV PATH="$PATH:/opt/amazon/efa/bin"
+ENV PATH="$PATH:$EFA_BIN_PATH"
 
 RUN cd $HOME \
     && curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz \
@@ -35,6 +37,10 @@ RUN cd $HOME \
     && tar -xf aws-efa-installer-latest.tar.gz \
     && cd aws-efa-installer \
     && ./efa_installer.sh -y -d --skip-kmod --skip-limit-conf --no-verify \
+    # TODO: remove this in favor of letting the efa installer add it if that ever becomes an option.
+    # At the moment, this is only installed if omitting --no-verify, which would require
+    # building in a context with EFA available
+    && install -T -m 0755 efa_test.sh "${EFA_BIN_PATH}/efa_test.sh" \
     && cd $HOME \
     && rm -rf aws-efa-installer
 

--- a/test/images/efa/scripts/unit-test.sh
+++ b/test/images/efa/scripts/unit-test.sh
@@ -41,4 +41,10 @@ else
     echo "Verified at least $EXPECTED_EFA_DEVICE_COUNT RDM endpoint(s) are available (found $RDM_ENDPOINT_COUNT)"
 fi
 
+
+echo "Running single-node efa test"
+
+# Run efa_test.sh, a utility added during the build while installing EFA
+efa_test.sh
+
 echo "Success!"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The EFA installer comes with a utility to validate the installation by ping ponging traffic over EFA on localhost. This adds a step to run that in the unit test.

Sample test output:
```
=== RUN   TestPingPong
=== RUN   TestPingPong/pingpong
    pingpong_test.go:155: need at least 2 nodes with EFA capacity, got 1
--- FAIL: TestPingPong (0.07s)
    --- FAIL: TestPingPong/pingpong (0.07s)
=== RUN   TestUnit
=== RUN   TestUnit/unit
=== RUN   TestUnit/unit/Unit_test_succeeds
=== NAME  TestUnit/unit
    unit_test.go:132: Logs for pod "efa-unit-0"
        Running test on a g5.24xlarge
        provider: efa
            fabric: efa-direct
            domain: rdmap0s26-rdm
            version: 201.0
            type: FI_EP_RDM
            protocol: FI_PROTO_EFA
        provider: efa
            fabric: efa
            domain: rdmap0s26-rdm
            version: 201.0
            type: FI_EP_RDM
            protocol: FI_PROTO_EFA
        provider: efa
            fabric: efa
            domain: rdmap0s26-dgrm
            version: 201.0
            type: FI_EP_DGRAM
            protocol: FI_PROTO_EFA
        Verified at least 1 DGRAM endpoint(s) are available (found 1)
        Verified at least 1 RDM endpoint(s) are available (found 2)
        Running single-node efa test
        Localhost fi_pingpong test: Attempt 1 (max 3)...
        Starting server on port 49220...
        Starting client on port 64270...
        Server Log:
        bytes   #sent   #ack     total       time     MB/sec    usec/xfer   Mxfers/sec
        64      10      =10      1.2k        0.00s      0.87      73.20       0.01
        256     10      =10      5k          0.00s     15.61      16.40       0.06
        1k      10      =10      20k         0.00s     61.50      16.65       0.06
        4k      10      =10      80k         0.00s    227.56      18.00       0.06
        Client Log:
        bytes   #sent   #ack     total       time     MB/sec    usec/xfer   Mxfers/sec
        64      10      =10      1.2k        0.00s      0.88      72.65       0.01
        256     10      =10      5k          0.00s     16.15      15.85       0.06
        1k      10      =10      20k         0.00s     63.80      16.05       0.06
        4k      10      =10      80k         0.00s    235.40      17.40       0.06
        fi_pingpong: SUCCESS!
        Success!
--- PASS: TestUnit (10.15s)
    --- PASS: TestUnit/unit (10.15s)
        --- PASS: TestUnit/unit/Unit_test_succeeds (10.01s)
FAIL
FAIL    github.com/aws/aws-k8s-tester/test/cases/efa    31.243s
FAIL
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
