### PR TITLE
fix: move addon from CFN to manager for cloudwatch stack

### DIFF
--- a/internal/deployers/eksapi/deployer.go
+++ b/internal/deployers/eksapi/deployer.go
@@ -209,6 +209,12 @@ func (d *deployer) Up() error {
 	if d.AMI != "" && d.ExpectedAMI == "" {
 		d.ExpectedAMI = d.AMI
 	}
+
+	// TODO: add the pod identity agent addons because it is required for
+	// cloudwatch infrastructure. cloudwatch infra might want to be optional.
+	// this must be prepended to the list in order to respect user overrides.
+	d.deployerOptions.Addons = slices.Insert(d.deployerOptions.Addons, 0, "eks-pod-identity-agent:default")
+
 	if err := d.addonManager.createAddons(d.infra, d.cluster, &d.deployerOptions); err != nil {
 		return err
 	}

--- a/internal/deployers/eksapi/templates/cloudwatch-infra.yaml.template
+++ b/internal/deployers/eksapi/templates/cloudwatch-infra.yaml.template
@@ -36,12 +36,6 @@ Resources:
       Namespace: amazon-cloudwatch
       ServiceAccount: cwagent
       RoleArn: !GetAtt CloudWatchRole.Arn
-  
-  EksPodIdentityAgentAddon:
-    Type: AWS::EKS::Addon
-    Properties:
-      AddonName: eks-pod-identity-agent
-      ClusterName: !Ref ClusterName
 
 Outputs:
   CloudWatchRoleArn:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There's inherent breakage if the pod identity agent is provided as an addon via the flag and also gets deployed with the cloudwatch monitoring stack.

This PR removed the CFN resource and injects an addon string into the deployer arguments so that all addons are managed by the `addonManager`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
