### PR TITLE
Renaming CloudWatch Stack Name

### DIFF
--- a/internal/deployers/eksapi/infra.go
+++ b/internal/deployers/eksapi/infra.go
@@ -479,7 +479,7 @@ func (m *InfrastructureManager) getAZsWithCapacity(opts *deployerOptions) ([]str
 
 func getCloudWatchStackName(resourceID string) (string, string) {
 	clusterUUID := strings.TrimPrefix(resourceID, ResourcePrefix+"-")
-	return fmt.Sprintf("cloudwatch-%s", clusterUUID), clusterUUID
+	return fmt.Sprintf("%s-cw", resourceID), clusterUUID
 }
 
 func (m *InfrastructureManager) createCloudWatchInfrastructureStack(clusterName string) (string, error) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change CloudWatch stack name from `'cloudwatch-{UUID}' `to `'kubetest2-eksapi-{UUID}-cw'` so janitor can find and clean it up


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
