### PR TITLE
CloudWatch  Agent + DCGM Integration for nvidia test

### DIFF
--- a/test/cases/nvidia/mpi_test.go
+++ b/test/cases/nvidia/mpi_test.go
@@ -63,12 +63,12 @@ func multiNode(testName string) features.Feature {
 		WithLabel("hardware", "gpu").
 		WithLabel("hardware", "efa").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			if *nvidiaTestImage == "" {
+			if testConfig.NvidiaTestImage == "" {
 				t.Fatal(fmt.Errorf("nvidiaTestImage must be set to run unit test, use https://github.com/aws/aws-k8s-tester/blob/main/test/images/nvidia/Dockerfile to build the image and -nvidiaTestImage to set the image url"))
 			}
 			maxBytes := "2G"
 			ncclBuffSize := "4194304"
-			if slices.Contains(instanceSupportsRdmaRead, *nodeType) {
+			if slices.Contains(instanceSupportsRdmaRead, testConfig.NodeType) {
 				t.Log("Instance supports RDMA")
 				maxBytes = "16G"
 				ncclBuffSize = "8388608"
@@ -79,7 +79,7 @@ func multiNode(testName string) features.Feature {
 				WorkerNodeCount:     nodeCount,
 				WorkerNodeGpuCount:  nodeCount * gpuPerNode,
 				GpuPerNode:          gpuPerNode,
-				NvidiaTestImage:     *nvidiaTestImage,
+				NvidiaTestImage:     testConfig.NvidiaTestImage,
 				EfaInterfacePerNode: efaPerNode,
 				MaxBytes:            maxBytes,
 				NcclBuffSize:        ncclBuffSize,
@@ -118,10 +118,10 @@ func multiNode(testName string) features.Feature {
 			if !t.Failed() {
 				t.Log("Multi node job completed")
 				// Verify GPU Direct RDMA is used on P4/P5
-				if *efaEnabled && slices.Contains(instanceSupportsRdmaRead, *nodeType) {
+				if testConfig.EfaEnabled && slices.Contains(instanceSupportsRdmaRead, testConfig.NodeType) {
 					pattern := regexp.MustCompile(`\[send\] via NET/.*Libfabric/.*/GDRDMA`)
 					if !pattern.MatchString(log) {
-						t.Errorf("GPU Direct RDMA is not utilized for inter-node communication in NCCL tests on instances that support GDRDMA: %s", *nodeType)
+						t.Errorf("GPU Direct RDMA is not utilized for inter-node communication in NCCL tests on instances that support GDRDMA: %s", testConfig.NodeType)
 					}
 				}
 			}
@@ -149,7 +149,7 @@ func singleNode() features.Feature {
 			renderedSingleNodeManifest, err = fwext.RenderManifests(mpiJobPytorchTrainingSingleNodeManifest, struct {
 				PytorchTestImage string
 			}{
-				PytorchTestImage: *pytorchImage,
+				PytorchTestImage: testConfig.PytorchImage,
 			})
 			if err != nil {
 				t.Fatal(err)

--- a/test/cases/nvidia/unit_test.go
+++ b/test/cases/nvidia/unit_test.go
@@ -42,15 +42,15 @@ func TestSingleNodeUnitTest(t *testing.T) {
 		WithLabel("suite", "nvidia").
 		WithLabel("hardware", "gpu").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			if *nvidiaTestImage == "" {
+			if testConfig.NvidiaTestImage == "" {
 				t.Fatal(fmt.Errorf("nvidiaTestImage must be set to run unit test, use https://github.com/aws/aws-k8s-tester/blob/main/test/images/nvidia/Dockerfile to build the image and -nvidiaTestImage to set the image url"))
 			}
 			var err error
 			renderedJobUnitTestSingleNodeManifest, err = fwext.RenderManifests(jobUnitTestSingleNodeManifest, unitTestManifestTplVars{
-				NvidiaTestImage:    *nvidiaTestImage,
-				SkipTestSubcommand: *skipUnitTestSubcommand,
+				NvidiaTestImage:    testConfig.NvidiaTestImage,
+				SkipTestSubcommand: testConfig.SkipUnitTestSubcommand,
 				GpuPerNode:         gpuPerNode,
-				NodeType:           *nodeType,
+				NodeType:           testConfig.NodeType,
 			})
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
[DO NOT MERGE until [nvidia-training](https://github.com/aws/aws-k8s-tester/pull/649) PR is merged]
This PR contains changes to the `nvidia` test to deploy dcgm and cloudwatch manifests when enabled by `--metricDimensions` flag.
It also has standardization for flag formatting and common functions for daemonset deployment similar to `nvidia-training`.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.