### PR TITLE
fix: Render CloudWatch Manifest Placement

### DIFF
--- a/test/cases/nvidia-training/main_test.go
+++ b/test/cases/nvidia-training/main_test.go
@@ -40,12 +40,6 @@ func TestMain(m *testing.M) {
 	defer cancel()
 	testenv = env.NewWithConfig(cfg).WithContext(ctx)
 
-	// Render CloudWatch Agent manifest with dynamic dimensions
-	renderedCloudWatchAgentManifest, err := manifests.RenderCloudWatchAgentManifest(testConfig.MetricDimensions)
-	if err != nil {
-		log.Printf("Warning: failed to render CloudWatch Agent manifest: %v", err)
-	}
-
 	manifestsList := [][]byte{
 		manifests.NvidiaDevicePluginManifest,
 		manifests.MpiOperatorManifest,
@@ -53,6 +47,11 @@ func TestMain(m *testing.M) {
 	}
 
 	if len(testConfig.MetricDimensions) > 0 {
+		// Render CloudWatch Agent manifest with dynamic dimensions
+		renderedCloudWatchAgentManifest, err := manifests.RenderCloudWatchAgentManifest(testConfig.MetricDimensions)
+		if err != nil {
+			log.Printf("Warning: failed to render CloudWatch Agent manifest: %v", err)
+		}
 		manifestsList = append(manifestsList, manifests.DCGMExporterManifest, renderedCloudWatchAgentManifest)
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Small change from preemptively rendering CloudWatch manifest to only Render CloudWatch Manifest if `metricDimensions ` was populated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
