### PR TITLE
fix(nvidia): use context for timeout

### DIFF
--- a/test/cases/nvidia/mpi_test.go
+++ b/test/cases/nvidia/mpi_test.go
@@ -100,9 +100,10 @@ func multiNode(testName string) features.Feature {
 		Assess("MPIJob succeeds", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			mpiJob := mpijobs.NewUnstructured(jobName, "default")
 			t.Log("Waiting for multi node job to complete")
+			waitCtx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+			defer cancel()
 			err := wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(mpiJob, mpijobs.MPIJobSucceeded),
-				wait.WithContext(ctx),
-				wait.WithTimeout(20*time.Minute),
+				wait.WithContext(waitCtx),
 			)
 			if err != nil {
 				t.Error(err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`wait.For` is just an api machinery wrapper that only uses the `WithTimeout` value if the context is not provided. 

this PR changes it to just use a timeout with the context.

see: https://github.com/kubernetes-sigs/e2e-framework/blob/deac1548ad2f3f88fd1087bc6492ae65ed04645c/klient/wait/wait.go#L87-L108

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
