### PR TITLE
chore: update Dockerfile go version to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 RUN yum install -y git tar gzip make unzip gcc rsync wget jq curl
-ARG GO_MINOR_VERSION="1.23"
+ARG GO_MINOR_VERSION="1.25"
 RUN curl https://go.dev/dl/?mode=json | jq -r .[].version | grep "^go${GO_MINOR_VERSION}" | head -n1 > go-version.txt
 RUN  wget -O go.tar.gz https://go.dev/dl/$(cat go-version.txt).${TARGETOS}-${TARGETARCH}.tar.gz && \
     rm -rf /usr/local/go && \

--- a/test/cases/efa/main_test.go
+++ b/test/cases/efa/main_test.go
@@ -68,7 +68,8 @@ func TestMain(m *testing.M) {
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-	timedCtx, _ := context.WithTimeout(ctx, 55*time.Minute)
+	defer cancel()
+	timedCtx, cancel := context.WithTimeout(ctx, 55*time.Minute)
 	defer cancel()
 
 	testenv = env.NewWithConfig(cfg)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

bump the go version download to `go1.25` since 1.25 has been released and 1.23 was kicked off of hosting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
