### PR TITLE
chore: revert to go 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 RUN yum install -y git tar gzip make unzip gcc rsync wget jq curl
-ARG GO_MINOR_VERSION=1.25
+ARG GO_MINOR_VERSION=1.24
 RUN curl https://go.dev/dl/?mode=json | jq -r .[].version | grep "^go${GO_MINOR_VERSION}" | head -n1 > go-version.txt
 RUN  wget -O go.tar.gz https://go.dev/dl/$(cat go-version.txt).${TARGETOS}-${TARGETARCH}.tar.gz && \
     rm -rf /usr/local/go && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/aws-k8s-tester
 
-go 1.25.0
+go 1.24.4
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

reverting since downstream CI is not yet ready for go 1.25

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
