### PR TITLE
fix(nvidia): make nvidia unit tests bubble error

### DIFF
--- a/test/images/nvidia/gpu_unit_tests/unit_test
+++ b/test/images/nvidia/gpu_unit_tests/unit_test
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 TRACE_LOG=trace.log
 TEST_TIMEOUT=1800
 BASH="/usr/bin/bash"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The failures in the unit test are not being bubbled up from the entrypoint without `errexit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
