### PR TITLE
fix(nvidia): set longer timeout for single node pytorch test

### DIFF
--- a/test/cases/nvidia/mpi_test.go
+++ b/test/cases/nvidia/mpi_test.go
@@ -166,7 +166,9 @@ func singleNode() features.Feature {
 			ctx = context.WithValue(ctx, "mpiJob", mpiJob)
 			t.Log("Waiting for single node job to complete")
 			err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).ResourceMatch(mpiJob, mpijobs.MPIJobSucceeded),
-				wait.WithContext(ctx))
+				wait.WithContext(ctx),
+				wait.WithTimeout(10*time.Minute),
+			)
 			if err != nil {
 				t.Error(err)
 			} else {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

downstream CI sometimes fails to meet 5 minutes default timeout depending on network conditions.

this PR bumps it to 10 minutes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
