### PR TITLE
fix: use default maxBytes and ncclBuffSize for p4 running all-to-all

### DIFF
--- a/test/cases/nvidia/mpi_test.go
+++ b/test/cases/nvidia/mpi_test.go
@@ -70,8 +70,13 @@ func multiNode(testName string) features.Feature {
 			ncclBuffSize := "4194304"
 			if slices.Contains(instanceSupportsRdmaRead, *nodeType) {
 				t.Log("Instance supports RDMA")
-				maxBytes = "16G"
-				ncclBuffSize = "8388608"
+				// TODO: revisit this with some kind of per-instance optimizer, or maybe use the defaults for all instance types unless specified
+				if testName == "alltoall_perf" && strings.Contains(*nodeType, "p4") {
+					// Keep default values for P4 running all-to-all
+				} else {
+					maxBytes = "16G"
+					ncclBuffSize = "8388608"
+				}
 			}
 			var err error
 			renderedMpiJobNcclTestMultiNodeManifest, err = fwext.RenderManifests(mpiJobNcclTestMultiNodeManifest, ncclTestManifestTplVars{


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-k8s-tester/issues/690

*Description of changes:*
Use default `maxBytes` and `ncclBuffSize` when running all-to-all test case on P4 instances.


*Test done*
Ran the all-to-all test case on P4 with this change. The test passed:
```
    mpi_test.go:123: Multi node job completed
--- PASS: TestMPIJobPytorchTraining (40.41s)
    --- PASS: TestMPIJobPytorchTraining/multi-node:alltoall_perf (40.41s)
        --- PASS: TestMPIJobPytorchTraining/multi-node:alltoall_perf/MPIJob_succeeds (40.31s)
PASS
ok      github.com/aws/aws-k8s-tester/test/cases/nvidia 52.345s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
