### PR TITLE
feat: add disruptive reboot test case

### DIFF
--- a/test/cases/disruptive/graceful_reboot_test.go
+++ b/test/cases/disruptive/graceful_reboot_test.go
@@ -1,0 +1,161 @@
+//go:build e2e
+
+package disruptive
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+
+	"github.com/aws/aws-k8s-tester/internal/awssdk"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/exec"
+
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func getSleepPodTemplate(name string, targetNodeName string, duration string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    name,
+					Image:   "public.ecr.aws/amazonlinux/amazonlinux:2023",
+					Command: []string{"sleep", duration},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+			NodeName:      targetNodeName,
+			Resources: &corev1.ResourceRequirements{
+				// set high pod limits to make sure the pod does not get
+				// OOMKilled, and make requests equal to qualify the pod
+				// for the Guaranteed Quality of Service class
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("250m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("250m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
+				},
+			},
+		},
+	}
+}
+
+func TestGracefulReboot(t *testing.T) {
+	terminationCanaryPodName := fmt.Sprintf("termination-canary-%d", time.Now().Unix())
+	canaryPod := getSleepPodTemplate(terminationCanaryPodName, "", "infinity")
+	bootIndicatorPodName := fmt.Sprintf("boot-detection-%d", time.Now().Unix())
+	bootIndicatorPod := getSleepPodTemplate(bootIndicatorPodName, "", "infinity")
+
+	feat := features.New("graceful-reboot").
+		WithLabel("suite", "disruptive").
+		Assess("Node gracefully reboots", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			if err := cfg.Client().Resources().Create(ctx, &canaryPod); err != nil {
+				t.Fatalf("Failed to create heartbeat pod: %v", err)
+			}
+
+			if err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).PodRunning(&canaryPod),
+				wait.WithContext(ctx),
+				wait.WithTimeout(5*time.Minute),
+			); err != nil {
+				t.Fatalf("Failed to wait for pod to go into running status %s: %v", terminationCanaryPodName, err)
+			}
+
+			var targetNode corev1.Node
+			if err := cfg.Client().Resources().Get(ctx, canaryPod.Spec.NodeName, "", &targetNode); err != nil {
+				t.Fatalf("failed to get node %s: %v", canaryPod.Spec.NodeName, err)
+			}
+
+			providerIDParts := strings.Split(targetNode.Spec.ProviderID, "/")
+			instanceID := providerIDParts[len(providerIDParts)-1]
+			t.Logf("Node %s corresponds to EC2 instance: %s", targetNode.Name, instanceID)
+
+			ec2Client := ec2.NewFromConfig(awssdk.NewConfig())
+
+			// TODO: make sure the exec starts before the reboot to promote better determinism
+			t.Logf("Rebooting instance %s to test graceful reboot...", instanceID)
+			_, err := ec2Client.RebootInstances(ctx, &ec2.RebootInstancesInput{
+				InstanceIds: []string{instanceID},
+			})
+			if err != nil {
+				t.Fatalf("Failed to reboot EC2 instance %s: %v", instanceID, err)
+			}
+			t.Logf("Successfully initiated reboot of instance %s, waiting for pod %s to terminate...", instanceID, canaryPod.Name)
+
+			t.Logf("Started exec into pod %s", terminationCanaryPodName)
+			// Attempt to execute a blocking command in the pod until we get a 143, which would indicate a SIGTERM.
+			// This a reliable way to check termination since it requires direct response from Kubelet
+			var execOut, execErr bytes.Buffer
+			err = cfg.Client().Resources().ExecInPod(ctx, "default", terminationCanaryPodName, terminationCanaryPodName, []string{"sleep", "infinity"}, &execOut, &execErr)
+			if err != nil {
+				if execErr, ok := err.(exec.CodeExitError); ok && execErr.Code == 143 {
+					t.Logf("Pod %s was terminated", terminationCanaryPodName)
+				} else {
+					t.Fatalf("Got unexpected error terminating pod: %v", err)
+				}
+			}
+
+			t.Logf("Waiting up to 10 minutes for node %s to become schedulable again", targetNode.Name)
+
+			// Create a second pod, under the assumption that a new pod cannot be scheduled by a shutting down kubelet
+			// that has already evicted other pods, so this one should only schedule with a new kubelet after boot
+			bootIndicatorPod.Spec.NodeName = targetNode.Name
+			if err := cfg.Client().Resources().Create(ctx, &bootIndicatorPod); err != nil {
+				t.Fatalf("Failed to create boot indicator pod: %v", err)
+			}
+
+			if err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).PodRunning(&bootIndicatorPod),
+				wait.WithContext(ctx),
+				wait.WithTimeout(10*time.Minute), // TODO: bring down this value after collecting some more data
+			); err != nil {
+				t.Fatalf("Failed to wait for pod to go into running status %s: %v", bootIndicatorPodName, err)
+			}
+
+			t.Logf("Node %s became ready and schedulable within %v!", targetNode.Name, time.Since(bootIndicatorPod.CreationTimestamp.Time))
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			if err := cfg.Client().Resources().Delete(ctx, &canaryPod); err != nil {
+				t.Logf("Failed to delete pod %s: %v", terminationCanaryPodName, err)
+			} else {
+				t.Logf("Successfully cleaned up pod %s", terminationCanaryPodName)
+			}
+
+			if err := cfg.Client().Resources().Delete(ctx, &bootIndicatorPod); err != nil {
+				t.Logf("Failed to delete pod %s: %v", bootIndicatorPodName, err)
+			} else {
+				t.Logf("Successfully cleaned up pod %s", bootIndicatorPodName)
+			}
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a new test case that reboots the instance, intended to help sanity check that reboots are graceful. It's quite difficult from AWS APIs alone to determine the status of an instance after reboot (the `RebootInstance` API itself is asynchronous, EC2 status checks and SSM agent connectivity status are reconciled sparsely so they some times miss state changes). Ultimately, something must be executed on the node to determine whether or not it's running, this uses a pod to do so to keep it more as Kubernetes-oriented as possible. 

The test is based on the assumption that the pod `Exec` require kubelet responsiveness, and therefore a `143` to a command execution within a pod will decisively indicate that the node is shutting down. This is a bit of a simplification since any `SIGTERM` would lead to this state, but given the timing and the presumed clean state of the instance, it's taken to mean the reboot is starting. After this, a second pod is created, and it follows from the prior state that this pod should not start running until after the boot, since kubelet was already non-responsive or evicting existing pods.  

Sample happy path output:
```
2025/09/26 23:36:11 Starting quick test suite...
=== RUN   TestGracefulReboot
=== RUN   TestGracefulReboot/graceful-reboot
=== RUN   TestGracefulReboot/graceful-reboot/Node_gracefully_reboots
    graceful_reboot_test.go:98: Node ip-172-31-42-36.us-west-2.compute.internal corresponds to EC2 instance: i-079f0dd190956bc92
    graceful_reboot_test.go:116: Started exec into pod termination-canary-1758929771
    graceful_reboot_test.go:106: Rebooting instance i-079f0dd190956bc92 to test graceful reboot...
    graceful_reboot_test.go:113: Successfully initiated reboot of instance i-079f0dd190956bc92, waiting for pod termination-canary-1758929771 to terminate...
    graceful_reboot_test.go:123: Pod termination-canary-1758929771 was terminated
    graceful_reboot_test.go:129: Waiting up to 5 minutes for node ip-172-31-42-36.us-west-2.compute.internal to become schedulable again
    graceful_reboot_test.go:146: Node ip-172-31-42-36.us-west-2.compute.internal became ready and schedulable within 2m5.597110799s!
=== NAME  TestGracefulReboot/graceful-reboot
    graceful_reboot_test.go:153: Successfully cleaned up pod termination-canary-1758929771
    graceful_reboot_test.go:159: Successfully cleaned up pod boot-detection-1758929771
--- PASS: TestGracefulReboot (132.70s)
    --- PASS: TestGracefulReboot/graceful-reboot (132.70s)
        --- PASS: TestGracefulReboot/graceful-reboot/Node_gracefully_reboots (132.64s)
PASS
ok      github.com/aws/aws-k8s-tester/test/cases/disruptive     132.725s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
