### PR TITLE
feat(e2e): Add consistent timeout message for test workload timeouts

### DIFF
--- a/internal/e2e/wait.go
+++ b/internal/e2e/wait.go
@@ -1,0 +1,26 @@
+package e2e
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/klient/wait"
+)
+
+// WaitForTimeoutMessage is a consistent message logged when wait.For times out.
+const WaitForTimeoutMessage = "TIMEOUT: timed out waiting for test workload to complete"
+
+// WaitForWithTimeout wraps wait.For and logs a consistent timeout message on context deadline exceeded.
+func WaitForWithTimeout(t *testing.T, description string, fn func(ctx context.Context) (bool, error), opts ...wait.Option) error {
+	err := wait.For(fn, opts...)
+	if err != nil && IsTimeoutError(err) {
+		log.Printf("%s: %s", WaitForTimeoutMessage, description)
+	}
+	return err
+}
+
+// IsTimeoutError checks if an error is a context deadline exceeded error.
+func IsTimeoutError(err error) bool {
+	return err != nil && err.Error() == context.DeadlineExceeded.Error()
+}

--- a/test/cases/neuron-inference/bert_inference_test.go
+++ b/test/cases/neuron-inference/bert_inference_test.go
@@ -67,7 +67,7 @@ func TestNeuronInference(t *testing.T) {
 			job := &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "neuron-inference", Namespace: "default"},
 			}
-			if err := wait.For(
+			if err := fwext.WaitForWithTimeout(t, "Job neuron-inference",
 				fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
 				wait.WithTimeout(60*time.Minute),
 			); err != nil {

--- a/test/cases/neuron-training/bert_training_test.go
+++ b/test/cases/neuron-training/bert_training_test.go
@@ -214,10 +214,14 @@ func waitForJobCreation(cfg *envconf.Config) (*batchv1.Job, error) {
 
 func waitForJobCompletion(job *batchv1.Job, cfg *envconf.Config) error {
 	log.Println("Waiting for 'bert-training' Job to succeed...")
-	return wait.For(
+	err := wait.For(
 		fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
 		wait.WithTimeout(30*time.Minute),
 	)
+	if err != nil && fwext.IsTimeoutError(err) {
+		log.Printf("%s: Job bert-training", fwext.WaitForTimeoutMessage)
+	}
+	return err
 }
 
 func processJobLogs(ctx context.Context, cfg *envconf.Config) error {

--- a/test/cases/neuron/neuron_test.go
+++ b/test/cases/neuron/neuron_test.go
@@ -70,7 +70,8 @@ func TestNeuronNodes(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "neuronx-single-node", Namespace: "default"},
 			}
 			t.Log("Waiting for single node job to complete")
-			err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
+			err := fwext.WaitForWithTimeout(t, "Job neuronx-single-node",
+				fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
 				wait.WithContext(ctx),
 				wait.WithTimeout(time.Minute*20),
 			)
@@ -129,7 +130,8 @@ func TestNeuronNodes(t *testing.T) {
 			mpiJob := mpijobs.NewUnstructured("multi-node-nccom-test", "default")
 			ctx = context.WithValue(ctx, "mpiJob", mpiJob)
 			t.Log("Waiting for MPIJob to complete")
-			err := wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(mpiJob, mpijobs.MPIJobSucceeded),
+			err := fwext.WaitForWithTimeout(t, "MPIJob multi-node-nccom-test",
+				conditions.New(cfg.Client().Resources()).ResourceMatch(mpiJob, mpijobs.MPIJobSucceeded),
 				wait.WithContext(ctx),
 				wait.WithTimeout(time.Minute*30),
 			)

--- a/test/cases/nvidia-inference/bert_inference_test.go
+++ b/test/cases/nvidia-inference/bert_inference_test.go
@@ -71,7 +71,7 @@ func TestBertInference(t *testing.T) {
 			job := &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "bert-inference", Namespace: "default"},
 			}
-			if err := wait.For(
+			if err := fwext.WaitForWithTimeout(t, "Job bert-inference",
 				fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
 				wait.WithTimeout(20*time.Minute),
 			); err != nil {

--- a/test/cases/nvidia-training/bert_training_test.go
+++ b/test/cases/nvidia-training/bert_training_test.go
@@ -68,7 +68,8 @@ func TestBertTraining(t *testing.T) {
 			job := &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "bert-training-launcher", Namespace: "default"},
 			}
-			if err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
+			if err := fwext.WaitForWithTimeout(t, "Job bert-training-launcher",
+				fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
 				wait.WithTimeout(time.Minute*20),
 				wait.WithContext(ctx),
 			); err != nil {

--- a/test/cases/nvidia/mpi_test.go
+++ b/test/cases/nvidia/mpi_test.go
@@ -105,7 +105,8 @@ func multiNode(testName string) features.Feature {
 		Assess("MPIJob succeeds", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			mpiJob := mpijobs.NewUnstructured(jobName, "default")
 			t.Log("Waiting for multi node job to complete")
-			err := wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(mpiJob, mpijobs.MPIJobSucceeded),
+			err := fwext.WaitForWithTimeout(t, "MPIJob "+jobName,
+				conditions.New(cfg.Client().Resources()).ResourceMatch(mpiJob, mpijobs.MPIJobSucceeded),
 				wait.WithContext(ctx),
 				wait.WithTimeout(60*time.Minute),
 			)
@@ -170,7 +171,8 @@ func singleNode() features.Feature {
 			mpiJob := mpijobs.NewUnstructured("pytorch-training-single-node", "default")
 			ctx = context.WithValue(ctx, "mpiJob", mpiJob)
 			t.Log("Waiting for single node job to complete")
-			err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).ResourceMatch(mpiJob, mpijobs.MPIJobSucceeded),
+			err := fwext.WaitForWithTimeout(t, "MPIJob pytorch-training-single-node",
+				fwext.NewConditionExtension(cfg.Client().Resources()).ResourceMatch(mpiJob, mpijobs.MPIJobSucceeded),
 				wait.WithContext(ctx),
 				wait.WithTimeout(30*time.Minute),
 			)

--- a/test/cases/nvidia/unit_test.go
+++ b/test/cases/nvidia/unit_test.go
@@ -66,7 +66,8 @@ func TestSingleNodeUnitTest(t *testing.T) {
 			job := &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "unit-test-job", Namespace: "default"},
 			}
-			err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
+			err := fwext.WaitForWithTimeout(t, "Job unit-test-job",
+				fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
 				wait.WithContext(ctx),
 				wait.WithTimeout(60*time.Minute))
 			if err != nil {


### PR DESCRIPTION
Add `WaitForWithTimeout` helper in `internal/e2e` that wraps `wait.For` and logs a consistent TIMEOUT message when context deadline is exceeded. Update test files to use the helper so that transient test timeouts can be identified in task logs.

