### PR TITLE
fix: extend aws-auth configmap retries

### DIFF
--- a/internal/deployers/eksapi/k8s.go
+++ b/internal/deployers/eksapi/k8s.go
@@ -36,7 +36,7 @@ func init() {
 
 const (
 	requestRetryInterval = 10 * time.Second
-	requestRetryTimeout  = 3 * time.Minute
+	requestRetryTimeout  = 10 * time.Minute
 )
 
 type k8sClient struct {


### PR DESCRIPTION
Even with 3 minutes, still seeing test failures.
Based on DNS caching duration that should be plenty, but maybe there is also a delay between cluster creation completing and DNS update starting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
