### PR TITLE
Update dranet filter to positive EFA-only match

### DIFF
--- a/test/manifests/assets/dranet.yaml
+++ b/test/manifests/assets/dranet.yaml
@@ -118,7 +118,7 @@ spec:
         - --hostname-override=$(NODE_NAME)
         - "--bind-address=:9177"
         - --cloud-provider-hint=AWS
-        - --filter=(!("dra.net/type" in attributes) || attributes["dra.net/type"].StringValue != "veth") && (!("dra.net/pciDevice" in attributes) || attributes["dra.net/pciDevice"].StringValue != "Elastic Network Adapter (ENA)")
+        - --filter="dra.net/pciDevice" in attributes && attributes["dra.net/pciDevice"].StringValue == "Elastic Fabric Adapter (EFA)"
         image: {{.RdmaDeviceDraDriverImage}}
         imagePullPolicy: IfNotPresent
         env:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change the dranet --filter from a negative filter (exclude veth and ENA) to a positive filter (include only EFA devices). The negative filter allowed non-PCI devices like pod-id-link0 to be published, which caused CEL runtime errors in the DeviceClass selector:
  'no such key: pciDevice'

The positive filter ensures only devices with pciDevice attribute set to 'Elastic Fabric Adapter (EFA)' are published in ResourceSlices.


*Testing: *
Deployed the test on a trn1 cluster and verified the fix.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
