### PR TITLE
chore(images,nvidia): start with latest packages

### DIFF
--- a/test/images/nvidia/Dockerfile
+++ b/test/images/nvidia/Dockerfile
@@ -11,6 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install necessary dependencies
 RUN apt update -y \
+ && apt upgrade -y \
  && apt remove -y --allow-change-held-packages \
       libmlx5-1 \
       ibverbs-utils \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

All images except the `nvidia` one start with an `apt upgrade`, making the same change here so that it'll be consistent across the board.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
