### PR TITLE
launch efa node for Auto when --efa passed

### DIFF
--- a/internal/deployers/eksapi/node.go
+++ b/internal/deployers/eksapi/node.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/smithy-go"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"log/slog"
@@ -328,6 +329,20 @@ func (m *nodeManager) createPlaceholderDeployment(opts *deployerOptions, k8sClie
 							Name:    "main",
 							Image:   "public.ecr.aws/amazonlinux/amazonlinux:2023",
 							Command: []string{"sleep", "infinity"},
+							Resources: func() corev1.ResourceRequirements {
+								// Auto mode will launch node with efa interface attached only when efa request exist in pod spec
+								if opts.EFA {
+									return corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"vpc.amazonaws.com/efa": resource.MustParse("1"),
+										},
+										Limits: corev1.ResourceList{
+											"vpc.amazonaws.com/efa": resource.MustParse("1"),
+										},
+									}
+								}
+								return corev1.ResourceRequirements{}
+							}(),
 						},
 					},
 				},


### PR DESCRIPTION
*Issue #, if available:*
* karpenter only attach efa interface to node when efa request exist in pod spec

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
