### PR TITLE
fix: Add retry to initial kubelet healthz check in TestGracefulReboot

### DIFF
--- a/test/cases/disruptive/graceful_reboot_test.go
+++ b/test/cases/disruptive/graceful_reboot_test.go
@@ -73,10 +73,23 @@ func TestGracefulReboot(t *testing.T) {
 
 			// Do an initial check of the /healthz endpoint reachability to ensure we can rely on it later.
 			// This might fail even if the node is healthy if, for example, the node's security group rules
-			// do not allow ingress traffic from the control plane
-			kubeletResponsive, err := fwext.KubeletIsResponsive(ctx, cfg.Client().RESTConfig(), targetNode.Name)
-			if err != nil || !kubeletResponsive {
-				t.Fatalf("Node %s is not responding to initial /healthz checks: %v", targetNode.Name, err)
+			// do not allow ingress traffic from the control plane.
+			// Retry for up to 1 minute to handle transient TLS errors during cert rotation.
+			var kubeletResponsive bool
+			var err error
+			healthCheckCtx, healthCheckCancel := context.WithTimeout(ctx, 1*time.Minute)
+			defer healthCheckCancel()
+			for {
+				kubeletResponsive, err = fwext.KubeletIsResponsive(healthCheckCtx, cfg.Client().RESTConfig(), targetNode.Name)
+				if err == nil && kubeletResponsive {
+					break
+				}
+				select {
+				case <-healthCheckCtx.Done():
+					t.Fatalf("Node %s is not responding to initial /healthz checks: %v", targetNode.Name, err)
+				case <-time.After(5 * time.Second):
+					t.Logf("Retrying /healthz check for node %s (last error: %v, responsive: %v)", targetNode.Name, err, kubeletResponsive)
+				}
 			}
 
 			providerIDParts := strings.Split(targetNode.Spec.ProviderID, "/")

--- a/test/cases/disruptive/graceful_reboot_test.go
+++ b/test/cases/disruptive/graceful_reboot_test.go
@@ -77,7 +77,7 @@ func TestGracefulReboot(t *testing.T) {
 			// Retry for up to 1 minute to handle transient TLS errors during cert rotation.
 			var kubeletResponsive bool
 			var err error
-			healthCheckCtx, healthCheckCancel := context.WithTimeout(ctx, 1*time.Minute)
+			healthCheckCtx, healthCheckCancel := context.WithTimeout(ctx, 5*time.Minute)
 			defer healthCheckCancel()
 			for {
 				kubeletResponsive, err = fwext.KubeletIsResponsive(healthCheckCtx, cfg.Client().RESTConfig(), targetNode.Name)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The TestGracefulReboot test was failing because the initial /healthz
check encountered a transient TLS error ("tls: internal error") from
the kubelet, causing an immediate test failure before the reboot was
even attempted.

This can happen when kubelet's serving certificate is being rotated
shortly after the node becomes schedulable. The scheduler considers
the node ready (and places the canary pod), but the kubelet healthz
endpoint briefly returns TLS errors.

This change replaces the single-shot healthz check with a retry loop
that polls every 5 seconds for up to 1 minute, giving the kubelet
time to stabilize its TLS state before we rely on the endpoint for
reboot detection.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
