### PR TITLE
chore: bump nvbandwidth version to 0.9 and bump timeout to 120m

### DIFF
--- a/test/cases/nvidia/unit_test.go
+++ b/test/cases/nvidia/unit_test.go
@@ -68,7 +68,7 @@ func TestSingleNodeUnitTest(t *testing.T) {
 			}
 			err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
 				wait.WithContext(ctx),
-				wait.WithTimeout(60*time.Minute))
+				wait.WithTimeout(120*time.Minute))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/images/nvidia/Dockerfile
+++ b/test/images/nvidia/Dockerfile
@@ -66,7 +66,7 @@ RUN curl -sL https://efa-installer.amazonaws.com/aws-efa-installer-$EFA_INSTALLE
  && cd && rm -rf /tmp/aws-efa-installer
 
 # Build nvbandwidth
-ARG NVBANDWIDTH_VERSION=v0.8
+ARG NVBANDWIDTH_VERSION=v0.9
 RUN apt install -y libboost-program-options-dev
 RUN git clone https://github.com/NVIDIA/nvbandwidth.git --branch $NVBANDWIDTH_VERSION /tmp/nvbandwidth \
  && cd /tmp/nvbandwidth \

--- a/test/images/nvidia/gpu_unit_tests/unit_test
+++ b/test/images/nvidia/gpu_unit_tests/unit_test
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 TRACE_LOG=trace.log
-TEST_TIMEOUT=3600
+TEST_TIMEOUT=7200
 BASH="/usr/bin/bash"
 CURRENT_DIR=$(pwd)
 SKIP_TESTS_SUBCOMMAND=${SKIP_TESTS_SUBCOMMAND:-""}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Bump the nvbandwidth version used in the nvidia test image from v0.8 to v0.9.
test/images/nvidia/Dockerfile: ARG NVBANDWIDTH_VERSION=v0.8 → v0.9

https://github.com/NVIDIA/nvbandwidth/releases

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
