### PR TITLE
fix: allow reduced PCIe width in DCGM diagnostics

### DIFF
--- a/test/images/nvidia/gpu_unit_tests/tests/dcgm-diag.yaml
+++ b/test/images/nvidia/gpu_unit_tests/tests/dcgm-diag.yaml
@@ -1,0 +1,17 @@
+# Per-GPU-model DCGM diagnostics overrides for gpu_unit_tests.
+# Lists only GPU models provisioned with reduced PCIe lanes on AWS; unlisted
+# models keep DCGM's strict defaults. version tracks the DCGM in the Dockerfile.
+version: "4.6.0"
+spec: dcgm-diag-v1
+skus:
+  # NVIDIA L4: g6.*/gr6.* single-GPU sizes wire the L4 to a PCIe x8 slot.
+  - name: NVIDIA L4
+    id: 27b8
+    pcie:
+      is_allowed: true
+      h2d_d2h_single_pinned:
+        min_pci_generation: 1.0
+        min_pci_width: 8.0
+      h2d_d2h_single_unpinned:
+        min_pci_generation: 1.0
+        min_pci_width: 8.0

--- a/test/images/nvidia/gpu_unit_tests/tests/test_basic.sh
+++ b/test/images/nvidia/gpu_unit_tests/tests/test_basic.sh
@@ -36,6 +36,9 @@ test_04_dcgm_diagnostics()
         skip "This test does not apply to vGPU instances (g6f.*, gr6f.*)"
     fi
 
-    # https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/dcgm-diagnostics.html#run-levels-and-tests
-    assert_status_code 0 "dcgmi diag -r 2"
+    # Use per-GPU-model PCIe width overrides via -c;
+    # min_pci_width is sub-test-scoped and cannot be set with -p.
+    local test_dir
+    test_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    assert_status_code 0 "dcgmi diag -r 2 -c ${test_dir}/dcgm-diag.yaml"
 }


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
test_04_dcgm_diagnostics fails on instance sizes that connect the GPU to fewer PCIe lanes than the card supports. DCGM's pcie diagnostic defaults to requiring an x16 link (min_pci_width=16), which suits instances with full x16 slots. Some single-GPU sizes provision fewer lanes by design, so the link comes up below x16 and the sub-test fails with DCGM_FR_PCIE_WIDTH (error 46) even though the GPU is healthy.

min_pci_width is a sub-test-scoped parameter (under h2d_d2h_single_pinned / h2d_d2h_single_unpinned), so it cannot be set via dcgmi diag -p (that flag only reaches plugin-level parameters), and error 46 is not maskable via --ignoreErrorCodes. The supported way to override it is a DCGM config file (dcgm-diag-v1) applied with -c.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
