### PR TITLE
feat(efa): add --installDevicePlugin flag to EFA test suite

### DIFF
--- a/test/cases/efa/commons.go
+++ b/test/cases/efa/commons.go
@@ -32,7 +32,8 @@ var (
 	nodeType               *string
 	expectedEFADeviceCount *int
 
-	verbose *bool
+	verbose             *bool
+	installDevicePlugin *bool
 )
 
 const (

--- a/test/cases/efa/main_test.go
+++ b/test/cases/efa/main_test.go
@@ -57,6 +57,7 @@ func TestMain(m *testing.M) {
 	nodeType = flag.String("nodeType", "", "instance type to target for tests")
 	expectedEFADeviceCount = flag.Int("expectedEFADeviceCount", -1, "expected number of efa devices for the target nodes")
 	verbose = flag.Bool("verbose", true, "use verbose mode for tests")
+	installDevicePlugin = flag.Bool("installDevicePlugin", true, "install EFA device plugin")
 
 	cfg, err := envconf.NewFromFlags()
 	if err != nil {
@@ -77,8 +78,13 @@ func TestMain(m *testing.M) {
 
 	ec2Client = e2e.NewEC2Client()
 
-	testenv.Setup(
-		deployEFAPlugin,
+	setUpFunctions := []env.Func{}
+	if *installDevicePlugin {
+		setUpFunctions = append(setUpFunctions, deployEFAPlugin)
+	} else {
+		log.Println("skipping EFA device plugin installation (--installDevicePlugin=false)")
+	}
+	setUpFunctions = append(setUpFunctions,
 		func(ctx context.Context, config *envconf.Config) (context.Context, error) {
 			select {
 			case <-ctx.Done():
@@ -89,13 +95,16 @@ func TestMain(m *testing.M) {
 			return ctx, cfg.Client().Resources().Create(ctx, getTestNamespace())
 		},
 	)
+	testenv.Setup(setUpFunctions...)
 
 	testenv.Finish(
 		func(ctx context.Context, config *envconf.Config) (context.Context, error) {
 			cfg.Client().Resources().Delete(context.TODO(), getTestNamespace())
-			err := e2e.DeleteManifests(cfg.Client().RESTConfig(), manifests.EfaDevicePluginManifest)
-			if err != nil {
-				return ctx, err
+			if *installDevicePlugin {
+				err := e2e.DeleteManifests(cfg.Client().RESTConfig(), manifests.EfaDevicePluginManifest)
+				if err != nil {
+					return ctx, err
+				}
 			}
 			return ctx, nil
 		},


### PR DESCRIPTION
**Summary**
Adds a --installDevicePlugin flag (default true) to the EFA test suite (test/cases/efa/), mirroring the existing pattern already used in the nvidia and neuron test suites. When set to false, the test skips the deployEFAPlugin setup step (and its corresponding teardown), allowing the test to run in environments where the EFA device plugin is already present.

**Testing**
Validated using an EKS Auto Mode cluster (us-west-2, c5n.9xlarge) via go test -tags e2e:

Test with `--installDevicePlugin=false`
Output: deployEFAPlugin was skipped cleanly and proceeded to namespace creation with no DaemonSet conflict.
```
2026/07/21 18:15:36 skipping EFA device plugin installation (--installDevicePlugin=false)
=== RUN   TestPingPong
=== RUN   TestPingPong/pingpong
```

Test with `--installDevicePlugin=true` (default)
Output: Deploy path executed unchanged: the DaemonSet was applied and the readiness wait ran (it timed out at 300s)
```
E0721 18:21:32.581153    1582 env.go:418] Setup failure: client rate limiter Wait returned an error: context deadline exceeded
FAIL    github.com/aws/aws-k8s-tester/test/cases/efa    300.784s
FAIL
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.