### PR TITLE
Add opt-in deep DCGM diagnostic feature (level 4)

### DIFF
--- a/test/cases/nvidia/dcgm_deadline.go
+++ b/test/cases/nvidia/dcgm_deadline.go
@@ -1,0 +1,40 @@
+package nvidia
+
+import (
+	"fmt"
+	"time"
+)
+
+// dcgmDiagDeadlineSlack is how far inside the wait timeout the Job's own
+// deadline sits. Bounding the Job first means a hung run surfaces as a Job
+// failure with logs attached, rather than as an opaque wait timeout.
+const dcgmDiagDeadlineSlack = time.Minute
+
+// minDcgmDiagTimeoutMinutes is the smallest wait timeout that still yields a
+// positive activeDeadlineSeconds. Kubernetes rejects a Job whose
+// activeDeadlineSeconds is not positive, so anything lower cannot produce a
+// valid Job.
+const minDcgmDiagTimeoutMinutes = 2
+
+// dcgmDiagDeadlineSeconds converts a wait timeout in minutes into the Job's
+// activeDeadlineSeconds, rejecting values that cannot render a valid Job.
+//
+// Validation and arithmetic live together deliberately: keeping them apart
+// invites a bounds check that no longer matches the expression it guards.
+//
+// This file carries no build tag so the logic can be unit tested without the
+// e2e TestMain, which requires a live cluster.
+func dcgmDiagDeadlineSeconds(timeoutMinutes int) (int, error) {
+	if timeoutMinutes < minDcgmDiagTimeoutMinutes {
+		return 0, fmt.Errorf("dcgmDiagTimeoutMinutes must be at least %d, got %d",
+			minDcgmDiagTimeoutMinutes, timeoutMinutes)
+	}
+	deadline := int((time.Duration(timeoutMinutes)*time.Minute - dcgmDiagDeadlineSlack).Seconds())
+	if deadline <= 0 {
+		// Unreachable given the bound above; kept so a change to either the
+		// bound or the slack cannot silently emit an invalid Job.
+		return 0, fmt.Errorf("dcgmDiagTimeoutMinutes=%d yields activeDeadlineSeconds=%d, which Kubernetes rejects",
+			timeoutMinutes, deadline)
+	}
+	return deadline, nil
+}

--- a/test/cases/nvidia/dcgm_deadline_test.go
+++ b/test/cases/nvidia/dcgm_deadline_test.go
@@ -1,0 +1,49 @@
+package nvidia
+
+import "testing"
+
+func TestDcgmDiagDeadlineSeconds(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		minutes int
+		want    int
+		wantErr bool
+	}{
+		{name: "zero is rejected", minutes: 0, wantErr: true},
+		{name: "negative is rejected", minutes: -5, wantErr: true},
+		{name: "one minute would render zero, so is rejected", minutes: 1, wantErr: true},
+		{name: "two minutes is the smallest accepted", minutes: 2, want: 60},
+		{name: "the default", minutes: 180, want: 10740},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := dcgmDiagDeadlineSeconds(tc.minutes)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("dcgmDiagDeadlineSeconds(%d) = %d, want an error", tc.minutes, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("dcgmDiagDeadlineSeconds(%d) returned unexpected error: %v", tc.minutes, err)
+			}
+			if got != tc.want {
+				t.Errorf("dcgmDiagDeadlineSeconds(%d) = %d, want %d", tc.minutes, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDcgmDiagDeadlineAlwaysPositive asserts the property the Job depends on
+// across the whole accepted range, rather than only at the values enumerated
+// above: anything the bound admits must render a deadline Kubernetes accepts.
+func TestDcgmDiagDeadlineAlwaysPositive(t *testing.T) {
+	for m := minDcgmDiagTimeoutMinutes; m <= 600; m++ {
+		got, err := dcgmDiagDeadlineSeconds(m)
+		if err != nil {
+			t.Fatalf("dcgmDiagDeadlineSeconds(%d) rejected a value inside the accepted range: %v", m, err)
+		}
+		if got <= 0 {
+			t.Fatalf("dcgmDiagDeadlineSeconds(%d) = %d, must be positive", m, got)
+		}
+	}
+}

--- a/test/cases/nvidia/dcgm_test.go
+++ b/test/cases/nvidia/dcgm_test.go
@@ -1,0 +1,242 @@
+//go:build e2e
+
+package nvidia
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	//go:embed manifests/job-dcgm-diag.yaml
+	jobDcgmDiagManifest         []byte
+	renderedJobDcgmDiagManifest []byte
+)
+
+const dcgmDiagJobName = "dcgm-diag-job"
+
+type dcgmDiagManifestTplVars struct {
+	NvidiaTestImage       string
+	NodeType              string
+	GpuPerNode            int
+	DiagLevel             int
+	ActiveDeadlineSeconds int
+}
+
+// dcgmDiagProgressInterval is how often the waiting side polls the runner Job
+// for new output. Short enough to notice a stall, long enough not to spam the
+// API server across a multi-hour run.
+const dcgmDiagProgressInterval = 2 * time.Minute
+
+// deleteStaleJob removes a Job left behind by an earlier run and waits for it to
+// disappear, so a fresh Job of the same name can be created. A missing Job is
+// the expected case and is not an error.
+func deleteStaleJob(ctx context.Context, cfg *envconf.Config, name string) error {
+	res := cfg.Client().Resources()
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
+	if err := res.Get(ctx, name, "default", job); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	log.Printf("[dcgm-diag] found a pre-existing %s from an earlier run; deleting it", name)
+	// Propagate deletion so the Job's Pods go too, otherwise a finished Pod can
+	// keep reporting logs for a Job that no longer exists.
+	policy := metav1.DeletePropagationForeground
+	if err := res.Delete(ctx, job, func(o *metav1.DeleteOptions) { o.PropagationPolicy = &policy }); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return wait.For(conditions.New(res).ResourceDeleted(job),
+		wait.WithContext(ctx), wait.WithTimeout(2*time.Minute))
+}
+
+// requireJobExists verifies the Job is present after apply. ApplyManifests can
+// return nil even when the underlying Create failed, so without this a
+// swallowed error would surface much later as an opaque wait timeout.
+func requireJobExists(ctx context.Context, cfg *envconf.Config, name string) error {
+	job := &batchv1.Job{}
+	return cfg.Client().Resources().Get(ctx, name, "default", job)
+}
+
+// followJobProgress polls a Job's logs and prints whatever is new, so a
+// long-running run reports progress instead of going silent until it finishes.
+// The returned function stops the poller.
+func followJobProgress(ctx context.Context, cfg *envconf.Config, jobName string) func() {
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(dcgmDiagProgressInterval)
+		defer ticker.Stop()
+
+		started := time.Now()
+		var seen int
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				elapsed := time.Since(started).Round(time.Second)
+				out, err := fwext.GetJobLogs(cfg.Client().RESTConfig(), &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: "default"},
+				})
+				if err != nil {
+					// Expected early on, before the Pod is scheduled.
+					log.Printf("[dcgm-diag +%s] no logs yet (%v)", elapsed, err)
+					continue
+				}
+				if len(out) > seen {
+					log.Printf("[dcgm-diag +%s] new output:\n%s", elapsed, out[seen:])
+					seen = len(out)
+				} else {
+					log.Printf("[dcgm-diag +%s] no new output since last check", elapsed)
+				}
+			}
+		}
+	}()
+
+	return func() {
+		cancel()
+		<-done
+	}
+}
+
+// TestDcgmDiagnostics runs a deep DCGM diagnostic (level 4 by default) as a
+// standalone feature.
+//
+// This is deliberately separate from the unit-test feature, which runs
+// `dcgmi diag -r 2` as one of many quick checks. Levels 3 and 4 are invasive
+// and slow: level 4 (`xlong`) adds memtest and pulse on top of level 3, and
+// NVIDIA's guidance allows up to 2.25 hours on an eight-GPU node.
+//
+// Runtime grows with the number of GPUs on the node, though sub-linearly.
+// Measured with DCGM 4.6.1 and driver 580: about 32 minutes on a single-GPU
+// instance and about 80 minutes on an eight-GPU instance. Total HBM has
+// little effect, so budget by GPU count.
+//
+// It therefore cannot be a per-build gate and belongs in a periodic or
+// on-demand tier.
+//
+// IMPORTANT — this feature is opt-in and MUST stay that way. Some harnesses
+// invoke this binary without -test.run (they pass only --skip-features), so any
+// new Test function here runs by default in those pipelines. The
+// --dcgmDiagEnabled gate is what prevents an hours-long GPU stress from
+// silently attaching itself to a per-build path. Do not default it to true,
+// and do not rely on --skip-features to hold it back: a harness that forgets
+// the skip would inherit the whole run.
+func TestDcgmDiagnostics(t *testing.T) {
+	if !testConfig.DcgmDiagEnabled {
+		t.Skip("skipping deep DCGM diagnostics; set --dcgmDiagEnabled to run (long-running, not suitable for a per-build gate)")
+	}
+
+	timeout := time.Duration(testConfig.DcgmDiagTimeoutMinutes) * time.Minute
+
+	feat := features.New("dcgm-diag").
+		WithLabel("suite", "nvidia").
+		WithLabel("hardware", "gpu").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			if testConfig.NvidiaTestImage == "" {
+				t.Fatal(fmt.Errorf("nvidiaTestImage must be set to run dcgm-diag, use https://github.com/aws/aws-k8s-tester/blob/main/test/images/nvidia/Dockerfile to build the image and -nvidiaTestImage to set the image url"))
+			}
+			if testConfig.DcgmDiagLevel < 1 || testConfig.DcgmDiagLevel > 4 {
+				t.Fatalf("dcgmDiagLevel must be 1-4, got %d", testConfig.DcgmDiagLevel)
+			}
+			deadlineSeconds, err := dcgmDiagDeadlineSeconds(testConfig.DcgmDiagTimeoutMinutes)
+			if err != nil {
+				t.Fatal(err)
+			}
+			renderedJobDcgmDiagManifest, err = fwext.RenderManifests(jobDcgmDiagManifest, dcgmDiagManifestTplVars{
+				NvidiaTestImage:       testConfig.NvidiaTestImage,
+				NodeType:              testConfig.NodeType,
+				GpuPerNode:            gpuPerNode,
+				DiagLevel:             testConfig.DcgmDiagLevel,
+				ActiveDeadlineSeconds: deadlineSeconds,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The Job name is fixed, so a leftover Job from an interrupted run on
+			// a reused cluster would make the wait below observe that Job's
+			// terminal state and report success without running anything. Clear
+			// any such Job first. fwext.ApplyManifests cannot be relied on to
+			// surface the resulting AlreadyExists error, because processObjects
+			// discards the per-object Create error (internal/e2e/client.go).
+			if err := deleteStaleJob(ctx, cfg, dcgmDiagJobName); err != nil {
+				t.Fatalf("failed to clear a pre-existing %s: %v", dcgmDiagJobName, err)
+			}
+			if err := fwext.ApplyManifests(cfg.Client().RESTConfig(), renderedJobDcgmDiagManifest); err != nil {
+				t.Fatal(err)
+			}
+			// Confirm the Job actually exists, since a swallowed Create error
+			// would otherwise leave the wait below polling a Job that is not
+			// there.
+			if err := requireJobExists(ctx, cfg, dcgmDiagJobName); err != nil {
+				t.Fatalf("%s was not created: %v", dcgmDiagJobName, err)
+			}
+			return ctx
+		}).
+		// The verdict is dcgmi's exit code, so subtests that DCGM reports as
+		// Skip do not fail this feature. That is intentional: NVIDIA enables
+		// several plugins per GPU SKU in nvvs's built-in config and skips them
+		// silently elsewhere, so which subtests actually run is a property of
+		// the hardware, not of our setup. Read the result table in the Job log
+		// to see what was exercised on a given instance type.
+		Assess(fmt.Sprintf("DCGM level-%d diagnostic passes", testConfig.DcgmDiagLevel), func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: dcgmDiagJobName, Namespace: "default"},
+			}
+
+			// This run can take over an hour. Stream the Job's output while we
+			// wait rather than only dumping it in Teardown, so a watcher can
+			// tell a slow run from a stuck one without kubectl access. Use
+			// log.Printf, not t.Logf: the stdlib logger writes to stderr
+			// immediately, whereas t.Logf output is held until the test ends.
+			stopProgress := followJobProgress(ctx, cfg, dcgmDiagJobName)
+			defer stopProgress()
+
+			log.Printf("[dcgm-diag] waiting up to %s for level %d on %d GPU(s)", timeout, testConfig.DcgmDiagLevel, gpuPerNode)
+			err := wait.For(fwext.NewConditionExtension(cfg.Client().Resources()).JobSucceeded(job),
+				wait.WithContext(ctx),
+				wait.WithTimeout(timeout))
+			if err != nil {
+				// Report rather than Fatal so Teardown still dumps the DCGM
+				// output, which is the only place the failing subtest is named.
+				t.Errorf("dcgm level-%d diagnostic did not succeed: %v", testConfig.DcgmDiagLevel, err)
+			}
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			log, err := fwext.GetJobLogs(cfg.Client().RESTConfig(), &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: dcgmDiagJobName, Namespace: "default"},
+			})
+			if err != nil {
+				t.Errorf("failed to get logs for %s: %v", dcgmDiagJobName, err)
+			} else {
+				t.Logf("Test log for %s:", dcgmDiagJobName)
+				t.Log(log)
+			}
+			if err := fwext.DeleteManifests(cfg.Client().RESTConfig(), renderedJobDcgmDiagManifest); err != nil {
+				t.Error(err)
+			}
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}

--- a/test/cases/nvidia/main_test.go
+++ b/test/cases/nvidia/main_test.go
@@ -33,6 +33,12 @@ type Config struct {
 	NvidiaTestImage        string `flag:"nvidiaTestImage" desc:"nccl test image for nccl tests"`
 	PytorchImage           string `flag:"pytorchImage" desc:"pytorch cuda image for single node tests"`
 	SkipUnitTestSubcommand string `flag:"skipUnitTestSubcommand" desc:"optional command to skip specified unit test"`
+	// Deep DCGM diagnostics are opt-in: this binary is invoked without
+	// -test.run by several harnesses, so a new test function would otherwise
+	// run everywhere by default. See dcgm_test.go.
+	DcgmDiagEnabled        bool `flag:"dcgmDiagEnabled" desc:"run the deep DCGM diagnostic feature (long-running; not for per-build gates)"`
+	DcgmDiagLevel          int  `flag:"dcgmDiagLevel" desc:"dcgmi diag run level 1-4 (4 adds memtest+pulse and can exceed an hour)"`
+	DcgmDiagTimeoutMinutes int  `flag:"dcgmDiagTimeoutMinutes" desc:"wait timeout for the deep DCGM diagnostic Job, in minutes"`
 }
 
 var (
@@ -99,6 +105,12 @@ func TestMain(m *testing.M) {
 	testConfig = Config{
 		InstallDevicePlugin: true,
 		PytorchImage:        "763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:2.1.0-gpu-py310-cu121-ubuntu20.04-ec2",
+		// Off by default on purpose (see dcgm_test.go). The 3-hour budget gives
+		// headroom over the ~80 minutes level 4 takes on an eight-GPU instance;
+		// NVIDIA allows up to 2.25h there.
+		DcgmDiagEnabled:        false,
+		DcgmDiagLevel:          4,
+		DcgmDiagTimeoutMinutes: 180,
 	}
 
 	_, err := common.ParseFlags(&testConfig)

--- a/test/cases/nvidia/manifests/job-dcgm-diag.yaml
+++ b/test/cases/nvidia/manifests/job-dcgm-diag.yaml
@@ -1,0 +1,38 @@
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: dcgm-diag-job
+  labels:
+    app: dcgm-diag-job
+spec:
+  # DCGM level 3/4 is a long, invasive GPU stress. A retry would repeat the
+  # entire run, so fail once and report rather than re-burning the GPUs.
+  backoffLimit: 0
+  activeDeadlineSeconds: {{.ActiveDeadlineSeconds}}
+  template:
+    metadata:
+      labels:
+        app: dcgm-diag-job
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: dcgm-diag-container
+        image: {{.NvidiaTestImage}}
+        imagePullPolicy: Always
+        env:
+          - name: EC2_INSTANCE_TYPE
+            value: {{.NodeType}}
+          - name: DCGM_DIAG_LEVEL
+            value: "{{.DiagLevel}}"
+        # Script is baked into the image; see test/images/nvidia/gpu_unit_tests.
+        command:
+        - bash
+        - /app/gpu_unit_tests/dcgm-diag.sh
+        resources:
+          # Request every GPU on the node so the scheduler guarantees the
+          # exclusivity the script's preflight check asserts.
+          limits:
+            nvidia.com/gpu: {{.GpuPerNode}}
+          requests:
+            cpu: "1"
+            memory: 1Gi

--- a/test/images/nvidia/Dockerfile
+++ b/test/images/nvidia/Dockerfile
@@ -119,4 +119,4 @@ RUN rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 COPY test/images/nvidia/gpu_unit_tests ./gpu_unit_tests
-RUN chmod +x ./gpu_unit_tests/unit_test
+RUN chmod +x ./gpu_unit_tests/unit_test ./gpu_unit_tests/dcgm-diag.sh

--- a/test/images/nvidia/gpu_unit_tests/dcgm-diag.sh
+++ b/test/images/nvidia/gpu_unit_tests/dcgm-diag.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Runs a DCGM diagnostic at the level given by DCGM_DIAG_LEVEL. Baked into the
+# nvidia test image and invoked directly as the dcgm-diag-job Job body by the
+# dcgm-diag feature (test/cases/nvidia/dcgm_test.go).
+#
+# Expects in the environment:
+#   DCGM_DIAG_LEVEL   dcgmi diag run level (1-4)
+#   EC2_INSTANCE_TYPE instance type, for logging only
+
+set -o pipefail
+
+echo "=== instance: ${EC2_INSTANCE_TYPE:-unknown} ==="
+nvidia-smi --query-gpu=index,name,pci.bus_id --format=csv || true
+
+# dcgmi diag drives every GPU on the node. Another process holding a
+# GPU makes the run either fail or report misleading results, so
+# assert exclusivity before spending an hour on it.
+busy=$(nvidia-smi --query-compute-apps=pid,name,used_memory --format=csv,noheader)
+if [ -n "$busy" ]; then
+  echo "FAIL: other processes hold a GPU; dcgmi diag needs exclusive access:"
+  echo "$busy"
+  exit 1
+fi
+
+# Reuse the per-GPU-model overrides the level-2 run already relies on
+# (e.g. L4 wired to PCIe x8 on single-GPU g6 sizes). Resolved relative to this
+# script so it works wherever the image places gpu_unit_tests.
+config="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/tests/dcgm-diag.yaml"
+if [ ! -f "$config" ]; then
+  echo "FAIL: expected DCGM config at $config"
+  exit 1
+fi
+
+echo "=== dcgmi diag -r ${DCGM_DIAG_LEVEL} ==="
+echo "measured level-4 durations: ~32 min on a 1-GPU instance,"
+echo "~80 min on an 8-GPU instance. Scales with GPU count,"
+echo "sub-linearly; total HBM has little effect."
+echo
+echo "note: a 'Skip' in the result table below is usually NVIDIA"
+echo "policy rather than a packaging problem with this image. Some"
+echo "plugins are enabled per GPU SKU in nvvs's built-in config and"
+echo "skip silently where the SKU is not listed. Confirm the SKU is"
+echo "actually permitted before suspecting missing plugins."
+started=$(date +%s)
+echo "start: $(date -Is)"
+
+# dcgmi can go quiet for tens of minutes inside a single subtest, so
+# emit a heartbeat carrying GPU telemetry. Utilisation and power are
+# what distinguish "still working" from "hung": a stuck run shows 0%
+# utilisation and idle power draw while the process stays alive.
+(
+  while :; do
+    sleep 60
+    echo "--- heartbeat +$(( $(date +%s) - started ))s ---"
+    nvidia-smi --query-gpu=index,utilization.gpu,memory.used,power.draw,temperature.gpu,clocks_throttle_reasons.active \
+      --format=csv,noheader 2>&1 || echo "  (nvidia-smi query failed)"
+  done
+) &
+heartbeat=$!
+# disown so bash does not print a job-termination notice (which dumps
+# the whole subshell body) when the heartbeat is killed below.
+disown "$heartbeat" 2>/dev/null || true
+trap 'kill "$heartbeat" 2>/dev/null || true' EXIT
+
+# stdbuf forces line buffering so dcgmi's per-test progress reaches
+# the log as it happens instead of sitting in a pipe buffer.
+stdbuf -oL -eL dcgmi diag -r "${DCGM_DIAG_LEVEL}" -c "$config"
+rc=$?
+
+kill "$heartbeat" 2>/dev/null || true
+echo "end: $(date -Is) (elapsed $(( $(date +%s) - started ))s, exit $rc)"
+exit $rc


### PR DESCRIPTION
Adds a standalone `dcgm-diag` feature running `dcgmi diag -r 4`, separate from the level-2 pass the unit-test feature already performs. Level 4 (`xlong`) adds `memtest` and `pulse_test` on top of level 3.

Runtime grows with GPU count, though sub-linearly: measured with DCGM 4.6.1 and driver 580, about 32 minutes on a single-GPU instance and about 80 minutes on an eight-GPU instance. Total HBM has little effect, so budget by GPU count. NVIDIA's guidance allows up to 2.25 hours on eight GPUs.

The feature is opt-in via `--dcgmDiagEnabled` and defaults to off. This is load-bearing rather than conservative: some harnesses invoke this binary without `-test.run`, passing only `--skip-features`, so any new Test function here runs by default in those pipelines. Relying on `--skip-features` to hold it back would mean a harness that forgets an entry silently inherits an hours-long GPU stress. Failing closed puts the consequence of a mistake on the side of not running.

The Job body is a shell script baked into the nvidia test image next to `unit_test`, rather than inlined in the manifest, so it can be read and linted as shell. It resolves its DCGM config relative to its own location, so it picks up the same per-GPU-model overrides the level-2 run already relies on.

Two guards are worth calling out.

The Job name is fixed, so a Job left behind by an interrupted run on a reused cluster would let the wait observe that Job's terminal state and report success without running anything. Setup therefore deletes any pre-existing Job and waits for it to go before creating a new one, then confirms the new Job exists. Both are necessary because `fwext.ApplyManifests` can return nil even when the underlying Create failed: `processObjects` discards the per-object error (`internal/e2e/client.go`). That discard is a pre-existing repo-wide issue and is left for a separate change.

The Job's `activeDeadlineSeconds` is derived from the wait timeout, and Kubernetes rejects a Job whose `activeDeadlineSeconds` is not positive. `dcgmDiagDeadlineSeconds` keeps that bound and the arithmetic together so they cannot drift, and lives in an untagged file so it can be unit tested without the e2e TestMain, which needs a live cluster.

The datacenter-gpu-manager-4-cuda12/13 packages already in that image carry the plugins level 4 needs, so no packaging change is required.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
