### PR TITLE
Use the Go module proxy when building the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN  wget -O go.tar.gz https://go.dev/dl/$(cat go-version.txt).${TARGETOS}-${TAR
     tar -C /usr/local -xzf go.tar.gz
 ENV GOPATH=/usr/local/go
 ENV PATH=$PATH:$GOPATH/bin
-ENV GOPROXY=direct
+ARG GOPROXY="https://proxy.golang.org|direct"
+ENV GOPROXY=${GOPROXY}
 
 WORKDIR $GOPATH/src/github.com/aws/aws-k8s-tester
 COPY . .


### PR DESCRIPTION
go install ./... fetches every module from its origin because GOPROXY is pinned to direct, which makes the build depend on the availability of every host in the module graph. sigs.k8s.io/bom, an indirect dependency reached via internal/testers/ginkgov1 -> sigs.k8s.io/kubetest2/pkg/build, imports gitlab.alpinelinux.org/alpine/go, and that host now answers 418 to GitHub Actions runners:

  sigs.k8s.io/bom@v0.7.1/pkg/osinfo/scanner_alpine.go:26:2: unrecognized
  import path "gitlab.alpinelinux.org/alpine/go": reading
  https://gitlab.alpinelinux.org/alpine/go?go-get=1: 418 I'm a teapot

This has failed build-image on every pull request since, with no change to this repository; a no-op commit on top of main reproduces it. The build and build-test jobs pass on the same commit because nothing overrides GOPROXY for them, so they already resolve these modules through the default proxy.

The separator is "|" rather than ",". Go advances past a comma-separated proxy only on HTTP 404 or 410, so a proxy that is unreachable rather than merely missing a module fails the build outright; with "|" any error falls through to the next entry. This matters on networks that block or TLS-intercept proxy.golang.org, where the comma form fails immediately while this form falls back to direct. Verified both ways: the image builds on such a network, and build-image passes on GitHub Actions.

GOPROXY remains overridable, as it was before it became a hardcoded ENV, so --build-arg GOPROXY=direct restores the previous behaviour.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
