### PR TITLE
Adding additional nvidia test suites for supporting multi nvidia drivers

### DIFF
--- a/test/cases/nvidia-cuda-compute/cuda_compute_test.go
+++ b/test/cases/nvidia-cuda-compute/cuda_compute_test.go
@@ -1,0 +1,77 @@
+//go:build e2e
+
+package nvidia_cuda_compute
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2ewait "sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	podName      = "nvidia-cuda-compute-check"
+	podNamespace = "default"
+)
+
+// TestCUDACompute runs the 9 CUDA compute samples in a single pod. See
+// pod-cuda-compute-check.yaml for the run_sample helper that gates
+// compute-cap-dependent samples and fails with exit 20 if a required
+// binary is missing from the image.
+func TestCUDACompute(t *testing.T) {
+	feat := features.New("nvidia-cuda-compute").
+		WithLabel("suite", "nvidia").
+		WithLabel("hardware", "gpu").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rendered, err := fwext.RenderManifests(podCUDAComputeCheckManifest, PodManifestTplVars{
+				NvidiaTestImage: testConfig.NvidiaTestImage,
+			})
+			if err != nil {
+				t.Fatalf("render manifest: %v", err)
+			}
+			if err := fwext.ApplyManifests(cfg.Client().RESTConfig(), rendered); err != nil {
+				t.Fatalf("apply manifest: %v", err)
+			}
+			ctx = context.WithValue(ctx, renderedManifestKey{}, rendered)
+			return ctx
+		}).
+		Assess("pod reaches Succeeded", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: podNamespace}}
+			// Timeout is generous -- some samples (UnifiedMemoryPerf,
+			// immaTensorCoreGemm) are minutes-long on their own.
+			err := e2ewait.For(
+				fwext.NewConditionExtension(cfg.Client().Resources()).PodSucceeded(pod),
+				e2ewait.WithTimeout(15*time.Minute),
+			)
+			if err != nil {
+				if err == wait.ErrWaitTimeout {
+					t.Fatalf("cuda-compute pod did not complete within 15 minutes: %v", err)
+				}
+				t.Fatalf("cuda-compute pod ended in Failed phase: %v (exit 20=binary missing from image, exit 21=sample self-check failed)", err)
+			}
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rendered, _ := ctx.Value(renderedManifestKey{}).([]byte)
+			if len(rendered) == 0 {
+				return ctx
+			}
+			if err := fwext.DeleteManifests(cfg.Client().RESTConfig(), rendered); err != nil {
+				t.Errorf("delete pod: %v", err)
+			}
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}
+
+type renderedManifestKey struct{}

--- a/test/cases/nvidia-cuda-compute/main_test.go
+++ b/test/cases/nvidia-cuda-compute/main_test.go
@@ -1,0 +1,101 @@
+//go:build e2e
+
+// Package nvidia_cuda_compute runs the CUDA sample binaries baked into
+// the nvidia test image and asserts each exits 0.
+// (excludes deviceQuery and vectorAdd which
+// are already asserted by upstream's nvidia.test).
+package nvidia_cuda_compute
+
+import (
+	"context"
+	_ "embed"
+	"log"
+	"os"
+	"os/signal"
+	"slices"
+	"testing"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+	"github.com/aws/aws-k8s-tester/test/common"
+	"github.com/aws/aws-k8s-tester/test/manifests"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+//go:embed manifests/pod-cuda-compute-check.yaml
+var podCUDAComputeCheckManifest []byte
+
+type Config struct {
+	NvidiaTestImage     string `flag:"nvidiaTestImage" desc:"URL of the nvidia test image with the extended CUDA samples baked in -- required"`
+	InstallDevicePlugin bool   `flag:"installDevicePlugin" desc:"install the NVIDIA k8s device plugin before the test and delete it after (default true)"`
+	EfaEnabled          bool   `flag:"efaEnabled" desc:"also install the aws-efa-k8s device plugin (default false)"`
+}
+
+var (
+	testenv    env.Environment
+	testConfig Config
+)
+
+func TestMain(m *testing.M) {
+	testConfig = Config{InstallDevicePlugin: true}
+
+	if _, err := common.ParseFlags(&testConfig); err != nil {
+		log.Fatalf("failed to parse flags: %v", err)
+	}
+	cfg, err := envconf.NewFromFlags()
+	if err != nil {
+		log.Fatalf("failed to initialize test environment: %v", err)
+	}
+	if testConfig.NvidiaTestImage == "" {
+		log.Fatalf("-nvidiaTestImage is required")
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	testenv = env.NewWithConfig(cfg).WithContext(ctx)
+
+	var pluginManifests [][]byte
+	var setUp []env.Func
+	if testConfig.InstallDevicePlugin {
+		pluginManifests = append(pluginManifests, manifests.NvidiaDevicePluginManifest)
+		setUp = append(setUp,
+			func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+				if err := fwext.ApplyManifests(config.Client().RESTConfig(), manifests.NvidiaDevicePluginManifest); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			},
+			common.DeployDaemonSet("nvidia-device-plugin-daemonset", "kube-system"),
+		)
+	}
+	if testConfig.EfaEnabled {
+		pluginManifests = append(pluginManifests, manifests.EfaDevicePluginManifest)
+		setUp = append(setUp,
+			func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+				if err := fwext.ApplyManifests(config.Client().RESTConfig(), manifests.EfaDevicePluginManifest); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			},
+			common.DeployDaemonSet("aws-efa-k8s-device-plugin-daemonset", "kube-system"),
+		)
+	}
+	if len(setUp) > 0 {
+		testenv.Setup(setUp...)
+	}
+	if len(pluginManifests) > 0 {
+		testenv.Finish(func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+			slices.Reverse(pluginManifests)
+			if err := fwext.DeleteManifests(config.Client().RESTConfig(), pluginManifests...); err != nil {
+				return ctx, err
+			}
+			return ctx, nil
+		})
+	}
+
+	os.Exit(testenv.Run(m))
+}
+
+type PodManifestTplVars struct {
+	NvidiaTestImage string
+}

--- a/test/cases/nvidia-cuda-compute/manifests/pod-cuda-compute-check.yaml
+++ b/test/cases/nvidia-cuda-compute/manifests/pod-cuda-compute-check.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nvidia-cuda-compute-check
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: "nvidia.com/gpu"
+    operator: "Exists"
+    effect: "NoSchedule"
+  containers:
+  - name: cuda-compute-check
+    image: {{.NvidiaTestImage}}
+    env:
+    - name: NVIDIA_DRIVER_CAPABILITIES
+      value: "compute,utility"
+    - name: DEMO_SUITE_DIR
+      value: "/usr/bin"
+    command:
+    - /bin/bash
+    - -c
+    - |
+      set -eu
+      set -o pipefail
+
+      # CUDA compute sub-tests (excludes deviceQuery and
+      # vectorAdd -- already covered upstream in nvidia.test).
+      # The sample binaries are built into the container image by
+      # upstream's test/images/nvidia/Dockerfile. If a binary is missing
+      # we fail explicitly with a note about the image tag needed.
+      #
+      # Two tests are compute-cap gated:
+      #   * immaTensorCoreGemm     SM >= 7.5 (INT8 tensor cores, Turing+)
+      #   * globalToShmemAsyncCopy SM >= 8.0 (cp.async, Ampere+)
+      # Below the gate they skip cleanly rather than failing.
+
+      compute_cap_int=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d ' .' | head -c 3)
+      : "${compute_cap_int:=0}"
+      echo "compute capability (as int): $compute_cap_int"
+
+      run_sample() {
+        local name="$1"
+        local min_cc="${2:-0}"
+        if [ "$compute_cap_int" -lt "$min_cc" ]; then
+          echo "SKIP ${name}: requires compute capability >= ${min_cc}, current is ${compute_cap_int}"
+          return 0
+        fi
+        if [ ! -x "$DEMO_SUITE_DIR/${name}" ]; then
+          echo "FAIL ${name}: binary $DEMO_SUITE_DIR/${name} is missing from the image."
+          echo "  This image was not built with the extended CUDA-samples list."
+          echo "  See upstream test/images/nvidia/Dockerfile for the required builds."
+          exit 20
+        fi
+        echo "=== running ${name} ==="
+        if ! "$DEMO_SUITE_DIR/${name}"; then
+          echo "FAIL ${name}: sample self-check reported failure (non-zero exit)"
+          exit 21
+        fi
+      }
+
+      # 2.11 -- Unified Memory page migration
+      run_sample UnifiedMemoryPerf
+      # 2.3  -- INT8 tensor-core MMA (Turing+)
+      run_sample immaTensorCoreGemm 75
+      # 2.5  -- Cooperative Groups grid-wide barrier
+      run_sample reductionMultiBlockCG
+      # 2.6  -- Warp shuffle intrinsics
+      run_sample shfl_scan
+      # 2.4  -- Async arrive/wait barrier (cp.async on Ampere+, sw fallback below)
+      run_sample simpleAWBarrier
+      # 2.7  -- Atomic intrinsics correctness under contention
+      run_sample simpleAtomicIntrinsics
+      # 2.8  -- Warp-vote intrinsics
+      run_sample simpleVoteIntrinsics
+      # 2.9  -- Warp-aggregated atomic add
+      run_sample warpAggregatedAtomicsCG
+      # 2.10 -- cp.async global->shmem (Ampere+)
+      run_sample globalToShmemAsyncCopy 80
+
+      echo "=== all CUDA-compute samples passed (or skipped where compute-cap gated) ==="
+    resources:
+      requests:
+        nvidia.com/gpu: "1"
+      limits:
+        nvidia.com/gpu: "1"

--- a/test/cases/nvidia-driver-liveness/driver_liveness_test.go
+++ b/test/cases/nvidia-driver-liveness/driver_liveness_test.go
@@ -1,0 +1,73 @@
+//go:build e2e
+
+package nvidia_driver_liveness
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2ewait "sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	podName      = "nvidia-driver-liveness-check"
+	podNamespace = "default"
+)
+
+// TestDriverLiveness runs nvidia-smi -L, driver version match,
+// and GPU model matches instance type in one pod. The pod's script
+// exits non-zero with a specific code on the first failing assertion --
+// see pod-driver-liveness-check.yaml for the exit-code catalog.
+func TestDriverLiveness(t *testing.T) {
+	feat := features.New("nvidia-driver-liveness").
+		WithLabel("suite", "nvidia").
+		WithLabel("hardware", "gpu").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rendered, err := fwext.RenderManifests(podDriverLivenessCheckManifest, tplVars())
+			if err != nil {
+				t.Fatalf("render manifest: %v", err)
+			}
+			if err := fwext.ApplyManifests(cfg.Client().RESTConfig(), rendered); err != nil {
+				t.Fatalf("apply manifest: %v", err)
+			}
+			ctx = context.WithValue(ctx, renderedManifestKey{}, rendered)
+			return ctx
+		}).
+		Assess("pod reaches Succeeded", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: podNamespace}}
+			err := e2ewait.For(
+				fwext.NewConditionExtension(cfg.Client().Resources()).PodSucceeded(pod),
+				e2ewait.WithTimeout(5*time.Minute),
+			)
+			if err != nil {
+				if err == wait.ErrWaitTimeout {
+					t.Fatalf("driver-liveness pod did not complete within 5 minutes: %v", err)
+				}
+				t.Fatalf("driver-liveness pod ended in Failed phase: %v (see pod logs; exit 10=smi, 11=version, 12=model)", err)
+			}
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rendered, _ := ctx.Value(renderedManifestKey{}).([]byte)
+			if len(rendered) == 0 {
+				return ctx
+			}
+			if err := fwext.DeleteManifests(cfg.Client().RESTConfig(), rendered); err != nil {
+				t.Errorf("delete pod: %v", err)
+			}
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}
+
+type renderedManifestKey struct{}

--- a/test/cases/nvidia-driver-liveness/main_test.go
+++ b/test/cases/nvidia-driver-liveness/main_test.go
@@ -1,0 +1,127 @@
+//go:build e2e
+
+// Package nvidia_driver_liveness is an e2e test that asserts the NVIDIA
+// driver is alive and reports the versions/models expected of the AMI
+// under test. Covers three capability #1 sub-tests: nvidia-smi runs,
+// driver version matches the -expectedDriverVersion flag, GPU
+// model matches the instance type. Runs as one pod that performs all
+// three assertions in a single bash script; the pod exits non-zero on
+// any failure with a specific code (10=smi, 11=version, 12=model).
+//
+// Excludes tests already covered upstream in nvidia.test / test_sysinfo.sh:
+// test_nvidia_gpu_count, test_nvidia_gpu_unused, test_nvidia_gpu_throttled.
+package nvidia_driver_liveness
+
+import (
+	"context"
+	_ "embed"
+	"log"
+	"os"
+	"os/signal"
+	"slices"
+	"testing"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+	"github.com/aws/aws-k8s-tester/test/common"
+	"github.com/aws/aws-k8s-tester/test/manifests"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+//go:embed manifests/pod-driver-liveness-check.yaml
+var podDriverLivenessCheckManifest []byte
+
+// Config is the flag surface for this test binary. Field tags become
+// `-<flag>` on the command line (parsed via common.ParseFlags).
+type Config struct {
+	NvidiaTestImage       string `flag:"nvidiaTestImage" desc:"URL of the nvidia test image (built from upstream test/images/nvidia/Dockerfile) -- required"`
+	ExpectedDriverVersion string `flag:"expectedDriverVersion" desc:"expected NVIDIA driver version (e.g. 570.86.15); when empty the 1.5 assertion is skipped"`
+	NodeType              string `flag:"nodeType" desc:"EC2 instance type under qualification (e.g. p5.48xlarge) -- required for 1.8 GPU-model regex"`
+	InstallDevicePlugin   bool   `flag:"installDevicePlugin" desc:"install the NVIDIA k8s device plugin before the test and delete it after (default true)"`
+	EfaEnabled            bool   `flag:"efaEnabled" desc:"also install the aws-efa-k8s device plugin (default false)"`
+}
+
+var (
+	testenv    env.Environment
+	testConfig Config
+)
+
+func TestMain(m *testing.M) {
+	testConfig = Config{InstallDevicePlugin: true}
+
+	if _, err := common.ParseFlags(&testConfig); err != nil {
+		log.Fatalf("failed to parse flags: %v", err)
+	}
+	cfg, err := envconf.NewFromFlags()
+	if err != nil {
+		log.Fatalf("failed to initialize test environment: %v", err)
+	}
+	if testConfig.NvidiaTestImage == "" {
+		log.Fatalf("-nvidiaTestImage is required")
+	}
+	if testConfig.NodeType == "" {
+		log.Fatalf("-nodeType is required")
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	testenv = env.NewWithConfig(cfg).WithContext(ctx)
+
+	// Device-plugin manifests are applied in Setup and deleted (reversed)
+	// in Finish so the cluster ends the run in the state it started in.
+	var pluginManifests [][]byte
+	var setUp []env.Func
+	if testConfig.InstallDevicePlugin {
+		pluginManifests = append(pluginManifests, manifests.NvidiaDevicePluginManifest)
+		setUp = append(setUp,
+			func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+				if err := fwext.ApplyManifests(config.Client().RESTConfig(), manifests.NvidiaDevicePluginManifest); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			},
+			common.DeployDaemonSet("nvidia-device-plugin-daemonset", "kube-system"),
+		)
+	}
+	if testConfig.EfaEnabled {
+		pluginManifests = append(pluginManifests, manifests.EfaDevicePluginManifest)
+		setUp = append(setUp,
+			func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+				if err := fwext.ApplyManifests(config.Client().RESTConfig(), manifests.EfaDevicePluginManifest); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			},
+			common.DeployDaemonSet("aws-efa-k8s-device-plugin-daemonset", "kube-system"),
+		)
+	}
+	if len(setUp) > 0 {
+		testenv.Setup(setUp...)
+	}
+	if len(pluginManifests) > 0 {
+		testenv.Finish(func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+			slices.Reverse(pluginManifests)
+			if err := fwext.DeleteManifests(config.Client().RESTConfig(), pluginManifests...); err != nil {
+				return ctx, err
+			}
+			return ctx, nil
+		})
+	}
+
+	os.Exit(testenv.Run(m))
+}
+
+// PodManifestTplVars is the template-variable set for the pod manifest.
+type PodManifestTplVars struct {
+	NvidiaTestImage       string
+	ExpectedDriverVersion string
+	NodeType              string
+}
+
+func tplVars() PodManifestTplVars {
+	return PodManifestTplVars{
+		NvidiaTestImage:       testConfig.NvidiaTestImage,
+		ExpectedDriverVersion: testConfig.ExpectedDriverVersion,
+		NodeType:              testConfig.NodeType,
+	}
+}

--- a/test/cases/nvidia-driver-liveness/manifests/pod-driver-liveness-check.yaml
+++ b/test/cases/nvidia-driver-liveness/manifests/pod-driver-liveness-check.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nvidia-driver-liveness-check
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: "nvidia.com/gpu"
+    operator: "Exists"
+    effect: "NoSchedule"
+  containers:
+  - name: driver-liveness-check
+    image: {{.NvidiaTestImage}}
+    env:
+    - name: NVIDIA_DRIVER_CAPABILITIES
+      value: "compute,utility"
+    - name: EXPECTED_DRIVER_VERSION
+      value: "{{.ExpectedDriverVersion}}"
+    - name: EC2_INSTANCE_TYPE
+      value: "{{.NodeType}}"
+    command:
+    - /bin/bash
+    - -c
+    - |
+      set -eu
+      set -o pipefail
+
+      # ------------------------------------------------------------------
+      # 1.1  test_nvidia_smi_runs -- cheapest liveness probe.
+      # `nvidia-smi -L` exits 0 iff NVML initialised, kernel module
+      # answered, and the management path is intact. The classic
+      # "Driver/library version mismatch" failure after a bad re-point
+      # exits non-zero here.
+      # ------------------------------------------------------------------
+      echo "=== 1.1 nvidia-smi -L ==="
+      if ! nvidia-smi -L; then
+        echo "FAIL 1.1: nvidia-smi -L returned non-zero. NVML failed to"
+        echo "  initialise -- most likely a driver/library version mismatch"
+        echo "  after a botched re-point on a multi-driver AMI."
+        exit 10
+      fi
+
+      # ------------------------------------------------------------------
+      # 1.5  test_nvidia_driver_version -- exact version assertion.
+      # On a multi-driver AMI the dangerous failure is not "no driver"
+      # but "the wrong driver". Assert every GPU reports the version
+      # this AMI was built to ship. Skip if EXPECTED_DRIVER_VERSION is
+      # unset (additive behaviour).
+      # ------------------------------------------------------------------
+      echo "=== 1.5 driver version = expected ==="
+      if [ -z "$EXPECTED_DRIVER_VERSION" ]; then
+        echo "SKIP 1.5: EXPECTED_DRIVER_VERSION not set"
+      else
+        # Capture nvidia-smi output first 
+        driver_versions=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader) || {
+          echo "FAIL 1.5: nvidia-smi driver_version query failed"
+          exit 11
+        }
+        if [ -z "$driver_versions" ]; then
+          echo "FAIL 1.5: nvidia-smi reported no GPUs"
+          exit 11
+        fi
+        while read -r actual; do
+          if [ "$actual" != "$EXPECTED_DRIVER_VERSION" ]; then
+            echo "FAIL 1.5: driver version '$actual' != expected '$EXPECTED_DRIVER_VERSION'"
+            exit 11
+          fi
+        done <<< "$driver_versions"
+        echo "OK 1.5: every GPU reports driver version $EXPECTED_DRIVER_VERSION"
+      fi
+
+      # ------------------------------------------------------------------
+      # 1.8  test_nvidia_gpu_model -- GPU model matches instance type.
+      # Regex per instance family. Anchored so "T4" != "T4G" and
+      # "L4" != "L40S". Skip if instance type has no mapping.
+      # ------------------------------------------------------------------
+      echo "=== 1.8 GPU model matches instance type ==="
+      case "$EC2_INSTANCE_TYPE" in
+        p3.*)         expected_regex='^Tesla V100-' ;;
+        p4d.*)        expected_regex='^NVIDIA A100-SXM4-40GB' ;;
+        p4de.*)       expected_regex='^NVIDIA A100-SXM4-80GB' ;;
+        p5.*)         expected_regex='^NVIDIA H100 ' ;;
+        p5e.*|p5en.*) expected_regex='^NVIDIA H200 ' ;;
+        g5.*)         expected_regex='^NVIDIA A10G$' ;;
+        g5g.*)        expected_regex='^NVIDIA T4G$' ;;
+        g4dn.*)       expected_regex='^Tesla T4$' ;;
+        g6.*)         expected_regex='^NVIDIA L4$' ;;
+        g6e.*)        expected_regex='^NVIDIA L40S$' ;;
+        g6f.*|gr6f.*) expected_regex='^NVIDIA L4-' ;;
+        g7.*)         expected_regex='^NVIDIA RTX PRO 4500 Blackwell Server Edition' ;;
+        *)            expected_regex="" ;;
+      esac
+
+      if [ -z "$expected_regex" ]; then
+        echo "SKIP 1.8: no GPU-model mapping for instance type '$EC2_INSTANCE_TYPE'"
+      else
+        gpu_names=$(nvidia-smi --query-gpu=name --format=csv,noheader) || {
+          echo "FAIL 1.8: nvidia-smi name query failed"
+          exit 12
+        }
+        if [ -z "$gpu_names" ]; then
+          echo "FAIL 1.8: nvidia-smi reported no GPUs"
+          exit 12
+        fi
+        while read -r name; do
+          if ! echo "$name" | grep -qE "$expected_regex"; then
+            echo "FAIL 1.8: GPU model '$name' does not match expected pattern '$expected_regex' for $EC2_INSTANCE_TYPE"
+            exit 12
+          fi
+        done <<< "$gpu_names"
+        echo "OK 1.8: every GPU model matches '$expected_regex'"
+      fi
+
+      echo "=== all driver-liveness checks passed ==="
+    resources:
+      requests:
+        nvidia.com/gpu: "1"
+      limits:
+        nvidia.com/gpu: "1"

--- a/test/cases/nvidia-fabric-manager/fabric_manager_test.go
+++ b/test/cases/nvidia-fabric-manager/fabric_manager_test.go
@@ -1,0 +1,115 @@
+//go:build e2e
+
+package nvidia_fabric_manager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+	"github.com/aws/aws-k8s-tester/test/common"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2ewait "sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+// On every NVSwitch node, the running fabric-manager daemon's version must match the
+// installed NVIDIA driver version. DaemonSet-based host check that reads
+// /host/var/log/fabricmanager.log for the FM version and
+// /host/proc/driver/nvidia/version for the driver version. Skips on
+// non-NVSwitch instances (tail -f). Soft-skips (still Ready) if the log
+// is missing or unparseable.
+func TestFabricManagerVersionMatchesDriver(t *testing.T) {
+	feat := features.New("nvidia-fabric-manager-version-check").
+		WithLabel("suite", "nvidia").
+		WithLabel("hardware", "gpu").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			if err := fwext.ApplyManifests(cfg.Client().RESTConfig(), dsFabricManagerVersionCheckManifest); err != nil {
+				t.Fatalf("apply DS: %v", err)
+			}
+			return ctx
+		}).
+		Assess("DS becomes Ready", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "nvidia-fabric-manager-version-check", Namespace: "default"}}
+			err := e2ewait.For(
+				fwext.NewConditionExtension(cfg.Client().Resources()).DaemonSetReady(ds),
+				e2ewait.WithTimeout(3*time.Minute),
+			)
+			if err != nil {
+				t.Logf("DS not Ready: %v", err)
+				fwext.PrintDaemonSetPodLogs(t, ctx, cfg.Client().RESTConfig(), "default", "app=nvidia-fabric-manager-version-check")
+				t.Fatalf("nvidia-fabric-manager-version-check DS not Ready within 3 minutes -- see pod logs for the 5.2 failure")
+			}
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			if err := fwext.DeleteManifests(cfg.Client().RESTConfig(), dsFabricManagerVersionCheckManifest); err != nil {
+				t.Errorf("delete DS: %v", err)
+			}
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}
+
+// TestFabricAndNVLinkInContainer covers the three in-container fabric/
+// NVLink assertions in one pod that dispatches by instance-family class:
+// fabric state, NVLinks Active + expected count, no NVLinks on non-NVLink hardware.
+// Each check either runs, prints
+// SKIP for its class, or fails with a distinct exit code (50, 51, 52,
+// 53 -- see the pod manifest).
+func TestFabricAndNVLinkInContainer(t *testing.T) {
+	feat := features.New("nvidia-fabric-nvlink-check").
+		WithLabel("suite", "nvidia").
+		WithLabel("hardware", "gpu").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rendered, err := fwext.RenderManifests(podFabricNVLinkCheckManifest, PodManifestTplVars{
+				NvidiaTestImage: testConfig.NvidiaTestImage,
+				GpuCount:        common.GPUCountForNodeType(testConfig.NodeType),
+			})
+			if err != nil {
+				t.Fatalf("render manifest: %v", err)
+			}
+			if err := fwext.ApplyManifests(cfg.Client().RESTConfig(), rendered); err != nil {
+				t.Fatalf("apply pod: %v", err)
+			}
+			ctx = context.WithValue(ctx, renderedManifestKey{}, rendered)
+			return ctx
+		}).
+		Assess("pod reaches Succeeded", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "nvidia-fabric-nvlink-check", Namespace: "default"}}
+			err := e2ewait.For(
+				fwext.NewConditionExtension(cfg.Client().Resources()).PodSucceeded(pod),
+				e2ewait.WithTimeout(3*time.Minute),
+			)
+			if err != nil {
+				if err == wait.ErrWaitTimeout {
+					t.Fatalf("fabric-nvlink pod did not complete within 3 minutes: %v", err)
+				}
+				t.Fatalf("fabric-nvlink pod ended in Failed phase: %v (exit 50=fabric state, 51=nvlink not Active, 52=nvlink count, 53=nvlinks on non-NVLink hw)", err)
+			}
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rendered, _ := ctx.Value(renderedManifestKey{}).([]byte)
+			if len(rendered) == 0 {
+				return ctx
+			}
+			if err := fwext.DeleteManifests(cfg.Client().RESTConfig(), rendered); err != nil {
+				t.Errorf("delete pod: %v", err)
+			}
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}
+
+type renderedManifestKey struct{}

--- a/test/cases/nvidia-fabric-manager/main_test.go
+++ b/test/cases/nvidia-fabric-manager/main_test.go
@@ -1,0 +1,120 @@
+//go:build e2e
+
+// Package nvidia_fabric_manager asserts fabric-manager and NVLink health.
+// Covers capability #11 test fabric-manager version matches driver
+// version via a host-scoped DaemonSet, plus the in-container tests
+// fabric state, NVLinks Active + expected count,
+// and no NVLinks on non-NVLink hardware via one pod that
+// dispatches by instance-family class.
+
+package nvidia_fabric_manager
+
+import (
+	"context"
+	_ "embed"
+	"log"
+	"os"
+	"os/signal"
+	"slices"
+	"testing"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+	"github.com/aws/aws-k8s-tester/test/common"
+	"github.com/aws/aws-k8s-tester/test/manifests"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+//go:embed manifests/daemonset-fabric-manager-version-check.yaml
+var dsFabricManagerVersionCheckManifest []byte
+
+//go:embed manifests/pod-fabric-nvlink-check.yaml
+var podFabricNVLinkCheckManifest []byte
+
+type Config struct {
+	NvidiaTestImage     string `flag:"nvidiaTestImage" desc:"URL of the nvidia test image -- required for the in-container 5.3/5.4+5.5/6.8 checks"`
+	NodeType            string `flag:"nodeType" desc:"EC2 instance type under qualification -- required for 5.3/5.4+5.5/6.8 dispatch"`
+	InstallDevicePlugin bool   `flag:"installDevicePlugin" desc:"install the NVIDIA k8s device plugin before the test and delete it after (default true)"`
+	EfaEnabled          bool   `flag:"efaEnabled" desc:"also install the aws-efa-k8s device plugin (default false)"`
+}
+
+var (
+	testenv    env.Environment
+	testConfig Config
+)
+
+func TestMain(m *testing.M) {
+	testConfig = Config{InstallDevicePlugin: true}
+
+	if _, err := common.ParseFlags(&testConfig); err != nil {
+		log.Fatalf("failed to parse flags: %v", err)
+	}
+	cfg, err := envconf.NewFromFlags()
+	if err != nil {
+		log.Fatalf("failed to initialize test environment: %v", err)
+	}
+	if testConfig.NvidiaTestImage == "" {
+		log.Fatalf("-nvidiaTestImage is required")
+	}
+	if testConfig.NodeType == "" {
+		log.Fatalf("-nodeType is required")
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	testenv = env.NewWithConfig(cfg).WithContext(ctx)
+
+	var pluginManifests [][]byte
+	var setUp []env.Func
+	if testConfig.InstallDevicePlugin {
+		pluginManifests = append(pluginManifests, manifests.NvidiaDevicePluginManifest)
+		setUp = append(setUp,
+			func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+				if err := fwext.ApplyManifests(config.Client().RESTConfig(), manifests.NvidiaDevicePluginManifest); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			},
+			common.DeployDaemonSet("nvidia-device-plugin-daemonset", "kube-system"),
+		)
+	}
+	if testConfig.EfaEnabled {
+		pluginManifests = append(pluginManifests, manifests.EfaDevicePluginManifest)
+		setUp = append(setUp,
+			func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+				if err := fwext.ApplyManifests(config.Client().RESTConfig(), manifests.EfaDevicePluginManifest); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			},
+			common.DeployDaemonSet("aws-efa-k8s-device-plugin-daemonset", "kube-system"),
+		)
+	}
+	if len(setUp) > 0 {
+		testenv.Setup(setUp...)
+	}
+	if len(pluginManifests) > 0 {
+		testenv.Finish(func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+			slices.Reverse(pluginManifests)
+			if err := fwext.DeleteManifests(config.Client().RESTConfig(), pluginManifests...); err != nil {
+				return ctx, err
+			}
+			return ctx, nil
+		})
+	}
+
+	os.Exit(testenv.Run(m))
+}
+
+// PodManifestTplVars is the template-variable set for the in-container
+// pod manifest. GpuCount is threaded into `nvidia.com/gpu:` so the pod
+// pins the entire node's GPUs -- 5.3/5.4/5.5 assert node-wide fabric
+// and NVLink counts, and the device plugin injects only the GPUs
+// asked for, so a single-GPU request would make those counts
+// unsatisfiable. The node type is not surfaced to the pod -- inside
+// the container, classification and expected counts are derived from
+// kernel state and GPU SKU respectively.
+type PodManifestTplVars struct {
+	NvidiaTestImage string
+	GpuCount        int
+}

--- a/test/cases/nvidia-fabric-manager/manifests/daemonset-fabric-manager-version-check.yaml
+++ b/test/cases/nvidia-fabric-manager/manifests/daemonset-fabric-manager-version-check.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-fabric-manager-version-check
+  namespace: default
+  labels:
+    app: nvidia-fabric-manager-version-check
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-fabric-manager-version-check
+  template:
+    metadata:
+      labels:
+        app: nvidia-fabric-manager-version-check
+    spec:
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: nvidia-fabric-manager-version-check
+        image: public.ecr.aws/amazonlinux/amazonlinux:latest
+        command:
+        - sh
+        - -c
+        - |
+          set -eu
+          set -o pipefail
+
+          yum install -y -q awk >/dev/null 2>&1 || \
+            dnf install -y -q awk >/dev/null 2>&1 || true
+
+          # 5.2 only meaningful on NVSwitch nodes. The kernel driver
+          # exposes /proc/driver/nvidia-nvswitch/devices/ (populated
+          # with one entry per bound switch) only when NVSwitch
+          # hardware is present -- more reliable than an EC2 instance
+          # family list, and works on any cloud / bare metal.
+          nvswitch_dir=/host/proc/driver/nvidia-nvswitch/devices
+          if [ ! -d "$nvswitch_dir" ] || [ -z "$(ls -A "$nvswitch_dir" 2>/dev/null)" ]; then
+            echo "OK: no NVSwitch devices bound on this node; 5.2 does not apply. Skipping."
+            exec tail -f /dev/null
+          fi
+          echo "NVSwitch devices detected: $(ls "$nvswitch_dir" | wc -l)"
+
+          echo "=== 5.2: fabric-manager version must match driver version ==="
+
+          driver_ver=""
+          if [ -r /host/proc/driver/nvidia/version ]; then
+            driver_ver="$(awk '/NVRM version/ {for(i=1;i<=NF;i++) if ($i ~ /^[0-9]+\.[0-9]+\.[0-9]+$/) {print $i; exit}}' /host/proc/driver/nvidia/version)"
+          fi
+          if [ -z "$driver_ver" ]; then
+            echo "FAIL: could not read driver version from /host/proc/driver/nvidia/version"
+            [ -r /host/proc/driver/nvidia/version ] && cat /host/proc/driver/nvidia/version
+            exit 1
+          fi
+
+          fm_log=""
+          for candidate in /host/var/log/fabricmanager.log /host/var/log/fabric-manager.log; do
+            if [ -r "$candidate" ]; then
+              fm_log="$candidate"
+              break
+            fi
+          done
+
+          if [ -z "$fm_log" ]; then
+            echo "SKIP-5.2: no fabric-manager log found under /host/var/log/."
+            echo "  Cannot verify daemon-vs-driver version match without invoking"
+            echo "  the binary (requires privileged/nsenter access)."
+            exec tail -f /dev/null
+          fi
+
+          fm_ver="$(grep -Eom1 '[Ff]abric [Mm]anager (SDK )?[Vv]ersion[[:space:]:]+[0-9]+\.[0-9]+\.[0-9]+' "$fm_log" \
+                     | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+          if [ -z "$fm_ver" ]; then
+            echo "SKIP-5.2: could not parse fabric-manager version from $fm_log."
+            head -20 "$fm_log" | sed 's/^/    /'
+            exec tail -f /dev/null
+          fi
+
+          if [ "$fm_ver" != "$driver_ver" ]; then
+            echo "FAIL: fabric-manager version ($fm_ver) does not match driver version ($driver_ver)."
+            echo "  Classic post-re-point failure on a multi-driver AMI."
+            exit 1
+          fi
+
+          echo "OK: fabric-manager version $fm_ver matches driver version $driver_ver."
+          exec tail -f /dev/null
+        volumeMounts:
+        - name: host-proc
+          mountPath: /host/proc
+          readOnly: true
+        - name: host-var-log
+          mountPath: /host/var/log
+          readOnly: true
+      volumes:
+      - name: host-proc
+        hostPath:
+          path: /proc
+      - name: host-var-log
+        hostPath:
+          path: /var/log

--- a/test/cases/nvidia-fabric-manager/manifests/pod-fabric-nvlink-check.yaml
+++ b/test/cases/nvidia-fabric-manager/manifests/pod-fabric-nvlink-check.yaml
@@ -1,0 +1,188 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nvidia-fabric-nvlink-check
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: "nvidia.com/gpu"
+    operator: "Exists"
+    effect: "NoSchedule"
+  containers:
+  - name: fabric-nvlink-check
+    image: {{.NvidiaTestImage}}
+    env:
+    - name: NVIDIA_DRIVER_CAPABILITIES
+      value: "compute,utility"
+    command:
+    - /bin/bash
+    - -c
+    - |
+      set -eu
+      set -o pipefail
+
+      # In-container fabric-manager / NVLink assertions gated by
+      # kernel-observed hardware topology, not EC2 instance family:
+      #
+      # nvswitch      -- /proc/driver/nvidia-nvswitch/devices/ populated.
+      #                  Assert Fabric State Completed on every GPU and
+      #                  NVLinks all Active with expected count derived
+      #                  from GPU SKU x GPU count.
+      # nvlink_direct -- no NVSwitch, but nvidia-smi nvlink -s reports
+      #                  at least one Link (multi-GPU NVLink mesh). No
+      #                  fabric state to assert; positive count check
+      #                  is skipped without a topology map.
+      # non_nvlink    -- neither. Assert nvidia-smi nvlink -s reports
+      #                  no active links (negative path).
+      #
+      # Exit codes: 50 fabric state != Completed, 51 NVLinks not all Active,
+      # 52 NVLink Active-count != expected, 53 NVLinks reported on non-NVLink hw.
+
+      # Node classification from kernel state, not an EC2 family list:
+      #   nvswitch      -- /host/proc/driver/nvidia-nvswitch/devices/
+      #                    is populated (one entry per bound switch).
+      #   nvlink_direct -- no NVSwitch, but nvidia-smi nvlink -s reports
+      #                    at least one Link line (multi-GPU NVLink mesh
+      #                    without switches).
+      #   non_nvlink    -- neither.
+      nvswitch_dir=/host/proc/driver/nvidia-nvswitch/devices
+      if [ -d "$nvswitch_dir" ] && [ -n "$(ls -A "$nvswitch_dir" 2>/dev/null)" ]; then
+        class=nvswitch
+      elif nvidia-smi nvlink -s 2>/dev/null | grep -qE 'Link[[:space:]]+[0-9]+'; then
+        class=nvlink_direct
+      else
+        class=non_nvlink
+      fi
+      echo "Node class: $class"
+
+      # -----------------------------------------------------------------
+      # 5.3 fabric state (NVSwitch only)
+      # -----------------------------------------------------------------
+      if [ "$class" = "nvswitch" ]; then
+        echo "=== 5.3 fabric state ==="
+        states=$(nvidia-smi -q | awk '/^[[:space:]]*Fabric$/,/^$/' | \
+                 awk -F':' '/State[[:space:]]*:/ {gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2); print $2}')
+        if [ -z "$states" ]; then
+          echo "FAIL 5.3: nvidia-smi -q reported no Fabric section on an NVSwitch host"
+          exit 50
+        fi
+        while IFS= read -r s; do
+          if [ "$s" != "Completed" ]; then
+            echo "FAIL 5.3: GPU reports fabric State='$s', expected 'Completed'"
+            exit 50
+          fi
+        done <<< "$states"
+        echo "OK 5.3: every GPU fabric state = Completed"
+      else
+        echo "SKIP 5.3: not an NVSwitch instance"
+      fi
+
+      # -----------------------------------------------------------------
+      # 5.4+5.5 NVLinks Active + expected count (NVSwitch only)
+      # -----------------------------------------------------------------
+      if [ "$class" = "nvswitch" ]; then
+        echo "=== 5.4+5.5 NVLinks all Active + expected count ==="
+        # Derive expected NVLink count from the GPU SKU rather than
+        # the EC2 instance family: link count is a property of the
+        # silicon (V100/A100/H100/H200/B200) times the number of
+        # GPUs on the node. This stays valid across future instance
+        # families that reuse an existing SKU.
+        gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -n1)
+        gpu_count=$(nvidia-smi -L | wc -l)
+        case "$gpu_name" in
+          *V100*)          links_per_gpu=6  ;;
+          *A100*)          links_per_gpu=12 ;;
+          *H100*|*H200*)   links_per_gpu=18 ;;
+          *B200*)          links_per_gpu=18 ;;
+          *)               links_per_gpu=0  ;;
+        esac
+        if [ "$links_per_gpu" -gt 0 ]; then
+          expected_count=$(( links_per_gpu * gpu_count ))
+        else
+          expected_count=""
+        fi
+        echo "GPU SKU: '$gpu_name'  count=$gpu_count  links/GPU=$links_per_gpu  expected_active=${expected_count:-<unknown>}"
+
+        raw=$(nvidia-smi nvlink -s 2>&1)
+        active=0
+        bad_count=0
+        current_gpu=""
+        while IFS= read -r line; do
+          case "$line" in
+            GPU\ *)
+              current_gpu=$(echo "$line" | awk '{print $2}' | tr -d ':') ;;
+            *Link*)
+              link_idx=$(echo "$line" | awk '{print $2}' | tr -d ':')
+              # `nvidia-smi nvlink -s` prints per-link bandwidth for
+              # healthy links (e.g. "Link 0: 25.781 GB/s") and a token
+              # like "<inactive>" for down links -- there is no
+              # "Active" literal to match on. Treat a numeric field
+              # (bandwidth) as up; anything else is down.
+              state=$(echo "$line" | awk '{print $3}')
+              case "$state" in
+                ''|'<inactive>'|Inactive|inactive|N/A|'<disabled>')
+                  echo "  bad link: GPU $current_gpu link $link_idx state=$state"
+                  bad_count=$((bad_count + 1))
+                  ;;
+                [0-9]*)
+                  active=$((active + 1))
+                  ;;
+                *)
+                  echo "  bad link: GPU $current_gpu link $link_idx state=$state (unrecognized)"
+                  bad_count=$((bad_count + 1))
+                  ;;
+              esac
+              ;;
+          esac
+        done <<< "$raw"
+
+        if [ "$bad_count" -gt 0 ]; then
+          echo "FAIL 5.4: $bad_count NVLink(s) not Active (see above)"
+          echo "$raw"
+          exit 51
+        fi
+
+        if [ -n "$expected_count" ]; then
+          if [ "$active" -ne "$expected_count" ]; then
+            echo "FAIL 5.5: NVLink Active count ($active) != expected ($expected_count) for GPU SKU '$gpu_name' ($gpu_count GPUs)"
+            echo "$raw"
+            exit 52
+          fi
+          echo "OK 5.4+5.5: all $active NVLinks Active (matches expected $expected_count for $gpu_count x $gpu_name)"
+        else
+          echo "OK 5.4: all $active reported NVLinks Active; SKIP 5.5 (no expected count for GPU SKU '$gpu_name')"
+        fi
+      else
+        echo "SKIP 5.4+5.5: not an NVSwitch instance"
+      fi
+
+      # -----------------------------------------------------------------
+      # 6.8 no NVLinks on non-NVLink hw (negative path)
+      # -----------------------------------------------------------------
+      if [ "$class" = "non_nvlink" ]; then
+        echo "=== 6.8 no NVLinks on non-NVLink hardware ==="
+        reported=$(nvidia-smi nvlink -s 2>/dev/null | grep -E 'Link[[:space:]]+[0-9]+' || true)
+        if [ -n "$reported" ]; then
+          echo "FAIL 6.8: this node classified as non-NVLink but driver reports NVLink state:"
+          echo "$reported"
+          exit 53
+        fi
+        echo "OK 6.8: no NVLinks reported (as expected for non-NVLink hardware)"
+      else
+        echo "SKIP 6.8: node is class=$class, not non_nvlink"
+      fi
+
+      echo "=== all applicable fabric/NVLink checks passed ==="
+    resources:
+      requests:
+        nvidia.com/gpu: "{{.GpuCount}}"
+      limits:
+        nvidia.com/gpu: "{{.GpuCount}}"
+    volumeMounts:
+    - name: host-proc-driver
+      mountPath: /host/proc/driver
+      readOnly: true
+  volumes:
+  - name: host-proc-driver
+    hostPath:
+      path: /proc/driver

--- a/test/cases/nvidia-gsp-firmware/gsp_firmware_test.go
+++ b/test/cases/nvidia-gsp-firmware/gsp_firmware_test.go
@@ -1,0 +1,76 @@
+//go:build e2e
+
+package nvidia_gsp_firmware
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+	"github.com/aws/aws-k8s-tester/test/common"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2ewait "sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	podName      = "nvidia-gsp-firmware-check"
+	podNamespace = "default"
+)
+
+// TestGSPFirmware runs the three folded GSP firmware assertions inside
+// a single pod. Pod exit codes: 41 empty/N/A GSP version, 42 GSP
+// version != driver version, 43 cross-GPU mismatch.
+func TestGSPFirmware(t *testing.T) {
+	feat := features.New("nvidia-gsp-firmware").
+		WithLabel("suite", "nvidia").
+		WithLabel("hardware", "gpu").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rendered, err := fwext.RenderManifests(podGSPFirmwareCheckManifest, PodManifestTplVars{
+				NvidiaTestImage: testConfig.NvidiaTestImage,
+				GpuCount:        common.GPUCountForNodeType(testConfig.NodeType),
+			})
+			if err != nil {
+				t.Fatalf("render manifest: %v", err)
+			}
+			if err := fwext.ApplyManifests(cfg.Client().RESTConfig(), rendered); err != nil {
+				t.Fatalf("apply manifest: %v", err)
+			}
+			ctx = context.WithValue(ctx, renderedManifestKey{}, rendered)
+			return ctx
+		}).
+		Assess("pod reaches Succeeded", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: podNamespace}}
+			err := e2ewait.For(
+				fwext.NewConditionExtension(cfg.Client().Resources()).PodSucceeded(pod),
+				e2ewait.WithTimeout(3*time.Minute),
+			)
+			if err != nil {
+				if err == wait.ErrWaitTimeout {
+					t.Fatalf("gsp-firmware pod did not complete within 3 minutes: %v", err)
+				}
+				t.Fatalf("gsp-firmware pod ended in Failed phase: %v (exit 41=empty version, 42=driver mismatch, 43=cross-GPU mismatch)", err)
+			}
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rendered, _ := ctx.Value(renderedManifestKey{}).([]byte)
+			if len(rendered) == 0 {
+				return ctx
+			}
+			if err := fwext.DeleteManifests(cfg.Client().RESTConfig(), rendered); err != nil {
+				t.Errorf("delete pod: %v", err)
+			}
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}
+
+type renderedManifestKey struct{}

--- a/test/cases/nvidia-gsp-firmware/main_test.go
+++ b/test/cases/nvidia-gsp-firmware/main_test.go
@@ -1,0 +1,109 @@
+//go:build e2e
+
+// Package nvidia_gsp_firmware asserts the GPU System Processor firmware
+// has loaded correctly and its version matches the NVIDIA driver
+// version. Covers capability #1 test : non-empty per
+// GPU, matches driver version, consistent across GPUs. Skips on
+// pre-Ampere hardware.
+package nvidia_gsp_firmware
+
+import (
+	"context"
+	_ "embed"
+	"log"
+	"os"
+	"os/signal"
+	"slices"
+	"testing"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+	"github.com/aws/aws-k8s-tester/test/common"
+	"github.com/aws/aws-k8s-tester/test/manifests"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+//go:embed manifests/pod-gsp-firmware-check.yaml
+var podGSPFirmwareCheckManifest []byte
+
+type Config struct {
+	NvidiaTestImage     string `flag:"nvidiaTestImage" desc:"URL of the nvidia test image -- required"`
+	NodeType            string `flag:"nodeType" desc:"EC2 instance type under qualification; drives GPU count so the cross-GPU consistency check (exit 43) sees every GPU on the node"`
+	InstallDevicePlugin bool   `flag:"installDevicePlugin" desc:"install the NVIDIA k8s device plugin before the test and delete it after (default true)"`
+	EfaEnabled          bool   `flag:"efaEnabled" desc:"also install the aws-efa-k8s device plugin (default false)"`
+}
+
+var (
+	testenv    env.Environment
+	testConfig Config
+)
+
+func TestMain(m *testing.M) {
+	testConfig = Config{InstallDevicePlugin: true}
+
+	if _, err := common.ParseFlags(&testConfig); err != nil {
+		log.Fatalf("failed to parse flags: %v", err)
+	}
+	cfg, err := envconf.NewFromFlags()
+	if err != nil {
+		log.Fatalf("failed to initialize test environment: %v", err)
+	}
+	if testConfig.NvidiaTestImage == "" {
+		log.Fatalf("-nvidiaTestImage is required")
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	testenv = env.NewWithConfig(cfg).WithContext(ctx)
+
+	var pluginManifests [][]byte
+	var setUp []env.Func
+	if testConfig.InstallDevicePlugin {
+		pluginManifests = append(pluginManifests, manifests.NvidiaDevicePluginManifest)
+		setUp = append(setUp,
+			func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+				if err := fwext.ApplyManifests(config.Client().RESTConfig(), manifests.NvidiaDevicePluginManifest); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			},
+			common.DeployDaemonSet("nvidia-device-plugin-daemonset", "kube-system"),
+		)
+	}
+	if testConfig.EfaEnabled {
+		pluginManifests = append(pluginManifests, manifests.EfaDevicePluginManifest)
+		setUp = append(setUp,
+			func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+				if err := fwext.ApplyManifests(config.Client().RESTConfig(), manifests.EfaDevicePluginManifest); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			},
+			common.DeployDaemonSet("aws-efa-k8s-device-plugin-daemonset", "kube-system"),
+		)
+	}
+	if len(setUp) > 0 {
+		testenv.Setup(setUp...)
+	}
+	if len(pluginManifests) > 0 {
+		testenv.Finish(func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+			slices.Reverse(pluginManifests)
+			if err := fwext.DeleteManifests(config.Client().RESTConfig(), pluginManifests...); err != nil {
+				return ctx, err
+			}
+			return ctx, nil
+		})
+	}
+
+	os.Exit(testenv.Run(m))
+}
+
+// PodManifestTplVars is the template-variable set for the pod manifest.
+// GpuCount is threaded into `nvidia.com/gpu:` so the cross-GPU
+// consistency check (exit 43) sees every GPU on the node -- the device
+// plugin injects only the GPUs requested, so a single-GPU request
+// would leave that assertion trivially satisfied.
+type PodManifestTplVars struct {
+	NvidiaTestImage string
+	GpuCount        int
+}

--- a/test/cases/nvidia-gsp-firmware/manifests/pod-gsp-firmware-check.yaml
+++ b/test/cases/nvidia-gsp-firmware/manifests/pod-gsp-firmware-check.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nvidia-gsp-firmware-check
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: "nvidia.com/gpu"
+    operator: "Exists"
+    effect: "NoSchedule"
+  containers:
+  - name: gsp-firmware-check
+    image: {{.NvidiaTestImage}}
+    env:
+    - name: NVIDIA_DRIVER_CAPABILITIES
+      value: "compute,utility"
+    command:
+    - /bin/bash
+    - -c
+    - |
+      set -eu
+      set -o pipefail
+
+      # GSP firmware assertions on Ampere+.
+      # Modern NVIDIA GPUs run a chunk of driver logic on an on-die
+      # RISC-V core (the GSP). The kernel module uploads a firmware
+      # blob at init; if it fails to load, the driver falls back to
+      # legacy CPU-side operation with different behavior.
+      #
+      # This pod asserts, on Ampere+ hardware (SM >= 8.0):
+      # every GPU reports a non-empty GSP Firmware Version
+      # the GSP version equals the driver version reported by
+      # nvidia-smi (fingerprint of a partial re-point)
+      # every GPU on the node reports the same GSP version
+      #
+      # Pre-Ampere hardware has no GSP; skip cleanly.
+      #
+      # Exit codes: 40 pre-Ampere skip (still Succeeded phase, echoes),
+      # 41 empty/N/A version, 42 GSP != driver, 43 cross-GPU mismatch.
+
+      cc=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d ' .' | head -c 3)
+      : "${cc:=0}"
+      if [ "$cc" -lt 80 ]; then
+        echo "SKIP 1.9: pre-Ampere hardware (compute cap $cc); no GSP firmware"
+        exit 0
+      fi
+
+      # Extract per-GPU GSP versions.
+      versions=$(nvidia-smi -q | awk -F':' '/GSP Firmware Version/ {gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2); print $2}')
+      if [ -z "$versions" ]; then
+        echo "FAIL 1.9a: nvidia-smi -q reported no GSP Firmware Version lines on an Ampere+ GPU"
+        exit 41
+      fi
+
+      driver_version=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -1 | tr -d ' \r\n')
+      if [ -z "$driver_version" ]; then
+        echo "FAIL 1.9: could not read driver_version"
+        exit 41
+      fi
+      echo "driver version: $driver_version"
+
+      unique=""
+      while IFS= read -r v; do
+        if [ -z "$v" ] || [ "$v" = "N/A" ]; then
+          echo "FAIL 1.9a: GSP Firmware Version is empty/N/A. Driver may be in legacy (non-GSP) mode."
+          exit 41
+        fi
+        if [ "$v" != "$driver_version" ]; then
+          echo "FAIL 1.9b: GSP version '$v' != driver version '$driver_version' (partial re-point)"
+          exit 42
+        fi
+        case "$unique" in
+          *"|$v|"*) ;;
+          *) unique="${unique}|$v|" ;;
+        esac
+      done <<< "$versions"
+
+      distinct=$(echo "$unique" | tr '|' '\n' | grep -c '[^[:space:]]' || true)
+      if [ "$distinct" -ne 1 ]; then
+        echo "FAIL 1.9c: cross-GPU mismatch, $distinct distinct GSP versions: $(echo "$unique" | tr '|' ' ' | tr -s ' ')"
+        exit 43
+      fi
+
+      echo "OK 1.9: every GPU reports GSP firmware version $driver_version (matches driver)"
+    resources:
+      requests:
+        nvidia.com/gpu: "{{.GpuCount}}"
+      limits:
+        nvidia.com/gpu: "{{.GpuCount}}"

--- a/test/cases/nvidia-persistence-device-nodes/device_nodes_test.go
+++ b/test/cases/nvidia-persistence-device-nodes/device_nodes_test.go
@@ -1,0 +1,76 @@
+//go:build e2e
+
+package nvidia_persistence_device_nodes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2ewait "sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	podName      = "nvidia-persistence-device-nodes-check"
+	podNamespace = "default"
+)
+
+// TestDeviceNodes verifies /dev/nvidia0..N, /dev/nvidiactl,
+// /dev/nvidia-uvm, /dev/nvidia-uvm-tools are all present as character
+// devices with root ownership. Pod exit codes: 30 (/dev missing),
+// 31 (a /dev/nvidia<N> is bad), 32 (nvidiactl), 33 (nvidia-uvm),
+// 34 (nvidia-uvm-tools), 35 (ownership).
+func TestDeviceNodes(t *testing.T) {
+	feat := features.New("nvidia-persistence-device-nodes").
+		WithLabel("suite", "nvidia").
+		WithLabel("hardware", "gpu").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rendered, err := fwext.RenderManifests(podDeviceNodesCheckManifest, PodManifestTplVars{
+				NvidiaTestImage: testConfig.NvidiaTestImage,
+			})
+			if err != nil {
+				t.Fatalf("render manifest: %v", err)
+			}
+			if err := fwext.ApplyManifests(cfg.Client().RESTConfig(), rendered); err != nil {
+				t.Fatalf("apply manifest: %v", err)
+			}
+			ctx = context.WithValue(ctx, renderedManifestKey{}, rendered)
+			return ctx
+		}).
+		Assess("pod reaches Succeeded", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: podNamespace}}
+			err := e2ewait.For(
+				fwext.NewConditionExtension(cfg.Client().Resources()).PodSucceeded(pod),
+				e2ewait.WithTimeout(3*time.Minute),
+			)
+			if err != nil {
+				if err == wait.ErrWaitTimeout {
+					t.Fatalf("device-nodes pod did not complete within 3 minutes: %v", err)
+				}
+				t.Fatalf("device-nodes pod ended in Failed phase: %v (see pod logs; exit 30-35 indicates which node/check failed)", err)
+			}
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rendered, _ := ctx.Value(renderedManifestKey{}).([]byte)
+			if len(rendered) == 0 {
+				return ctx
+			}
+			if err := fwext.DeleteManifests(cfg.Client().RESTConfig(), rendered); err != nil {
+				t.Errorf("delete pod: %v", err)
+			}
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}
+
+type renderedManifestKey struct{}

--- a/test/cases/nvidia-persistence-device-nodes/main_test.go
+++ b/test/cases/nvidia-persistence-device-nodes/main_test.go
@@ -1,0 +1,100 @@
+//go:build e2e
+
+// Package nvidia_persistence_device_nodes asserts the /dev/nvidia*
+// device nodes are present in the container with the correct file
+// mode and ownership.
+package nvidia_persistence_device_nodes
+
+import (
+	"context"
+	_ "embed"
+	"log"
+	"os"
+	"os/signal"
+	"slices"
+	"testing"
+
+	fwext "github.com/aws/aws-k8s-tester/internal/e2e"
+	"github.com/aws/aws-k8s-tester/test/common"
+	"github.com/aws/aws-k8s-tester/test/manifests"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+//go:embed manifests/pod-device-nodes-check.yaml
+var podDeviceNodesCheckManifest []byte
+
+type Config struct {
+	NvidiaTestImage     string `flag:"nvidiaTestImage" desc:"URL of the nvidia test image -- required"`
+	InstallDevicePlugin bool   `flag:"installDevicePlugin" desc:"install the NVIDIA k8s device plugin before the test and delete it after (default true)"`
+	EfaEnabled          bool   `flag:"efaEnabled" desc:"also install the aws-efa-k8s device plugin (default false)"`
+}
+
+var (
+	testenv    env.Environment
+	testConfig Config
+)
+
+func TestMain(m *testing.M) {
+	testConfig = Config{InstallDevicePlugin: true}
+
+	if _, err := common.ParseFlags(&testConfig); err != nil {
+		log.Fatalf("failed to parse flags: %v", err)
+	}
+	cfg, err := envconf.NewFromFlags()
+	if err != nil {
+		log.Fatalf("failed to initialize test environment: %v", err)
+	}
+	if testConfig.NvidiaTestImage == "" {
+		log.Fatalf("-nvidiaTestImage is required")
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	testenv = env.NewWithConfig(cfg).WithContext(ctx)
+
+	var pluginManifests [][]byte
+	var setUp []env.Func
+	if testConfig.InstallDevicePlugin {
+		pluginManifests = append(pluginManifests, manifests.NvidiaDevicePluginManifest)
+		setUp = append(setUp,
+			func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+				if err := fwext.ApplyManifests(config.Client().RESTConfig(), manifests.NvidiaDevicePluginManifest); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			},
+			common.DeployDaemonSet("nvidia-device-plugin-daemonset", "kube-system"),
+		)
+	}
+	if testConfig.EfaEnabled {
+		pluginManifests = append(pluginManifests, manifests.EfaDevicePluginManifest)
+		setUp = append(setUp,
+			func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+				if err := fwext.ApplyManifests(config.Client().RESTConfig(), manifests.EfaDevicePluginManifest); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			},
+			common.DeployDaemonSet("aws-efa-k8s-device-plugin-daemonset", "kube-system"),
+		)
+	}
+	if len(setUp) > 0 {
+		testenv.Setup(setUp...)
+	}
+	if len(pluginManifests) > 0 {
+		testenv.Finish(func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+			slices.Reverse(pluginManifests)
+			if err := fwext.DeleteManifests(config.Client().RESTConfig(), pluginManifests...); err != nil {
+				return ctx, err
+			}
+			return ctx, nil
+		})
+	}
+
+	os.Exit(testenv.Run(m))
+}
+
+type PodManifestTplVars struct {
+	NvidiaTestImage string
+}

--- a/test/cases/nvidia-persistence-device-nodes/manifests/pod-device-nodes-check.yaml
+++ b/test/cases/nvidia-persistence-device-nodes/manifests/pod-device-nodes-check.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nvidia-persistence-device-nodes-check
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: "nvidia.com/gpu"
+    operator: "Exists"
+    effect: "NoSchedule"
+  containers:
+  - name: device-nodes-check
+    image: {{.NvidiaTestImage}}
+    env:
+    - name: NVIDIA_DRIVER_CAPABILITIES
+      value: "compute,utility"
+    command:
+    - /bin/bash
+    - -c
+    - |
+      set -eu
+      set -o pipefail
+
+      # assert the /dev/nvidia* device nodes
+      # the container needs are present, are actual character devices,
+      # and are root-owned with the expected mode. These are created by
+      # nvidia-persistenced (modern kernels) or nvidia-modprobe (older)
+      # on the host and injected into the container by
+      # nvidia-container-runtime.
+      #
+      # Checks (each fails the pod with a distinct exit code):
+      #   30: /dev not accessible
+      #   31: /dev/nvidia<N> missing or not a character device
+      #   32: /dev/nvidiactl missing or not a character device
+      #   33: /dev/nvidia-uvm missing or not a character device
+      #   34: /dev/nvidia-uvm-tools missing or not a character device
+      #   35: ownership check failed (not root:root)
+
+      echo "=== 7.3 device nodes present + correct file mode/ownership ==="
+      if [ ! -d /dev ]; then
+        echo "FAIL 7.3: /dev is not accessible in the container"
+        exit 30
+      fi
+
+      gpu_count=$(nvidia-smi --query-gpu=index --format=csv,noheader | wc -l | tr -d ' ')
+      if [ "$gpu_count" -lt 1 ]; then
+        echo "FAIL 7.3: nvidia-smi reports no GPUs"
+        exit 31
+      fi
+      # Enumerate injected device nodes rather than assume contiguous numbering:
+      # with partial-GPU allocations (e.g. requesting 1 of 4 GPUs on the node)
+      # nvidia-container-runtime injects only the assigned device, whose host
+      # index is not necessarily 0.
+      devs=$(ls /dev/nvidia[0-9]* 2>/dev/null || true)
+      if [ -z "$devs" ]; then
+        echo "FAIL 7.3: no /dev/nvidia<N> device nodes present in the container"
+        exit 31
+      fi
+      dev_count=$(echo "$devs" | wc -w | tr -d ' ')
+      echo "Detected $gpu_count GPU(s) via nvidia-smi; $dev_count injected /dev/nvidia* node(s): $devs"
+
+      check_char_dev() {
+        local path="$1"
+        local exit_code="$2"
+        if [ ! -c "$path" ]; then
+          echo "FAIL 7.3: $path is missing or is not a character device"
+          echo "  Details:"; ls -la "$path" 2>&1 | sed 's/^/    /' || echo "    (path does not exist)"
+          exit "$exit_code"
+        fi
+        # Ownership: expect uid=0 (root). gid=0 on most drivers; some
+        # AMIs run persistenced with a different group, so we only fail
+        # on non-root owner.
+        local owner
+        owner=$(stat -c "%u" "$path" 2>/dev/null || echo -1)
+        if [ "$owner" != "0" ]; then
+          echo "FAIL 7.3: $path is not owned by root (uid=$owner)"
+          exit 35
+        fi
+        echo "OK: $path  $(stat -c 'mode=%a owner=%U:%G' "$path")"
+      }
+
+      for dev in $devs; do
+        check_char_dev "$dev" 31
+      done
+      check_char_dev /dev/nvidiactl        32
+      check_char_dev /dev/nvidia-uvm       33
+      check_char_dev /dev/nvidia-uvm-tools 34
+
+      echo "=== all expected /dev/nvidia* device nodes present, mode + ownership OK ==="
+    resources:
+      requests:
+        nvidia.com/gpu: "1"
+      limits:
+        nvidia.com/gpu: "1"

--- a/test/common/nodetype.go
+++ b/test/common/nodetype.go
@@ -1,0 +1,36 @@
+//go:build e2e
+
+package common
+
+import "strings"
+
+// GPUCountForNodeType returns the GPU count to request for pods whose
+// assertions depend on node-wide GPU visibility. Callers use it as the
+// value of `nvidia.com/gpu` in the pod resource request, forcing the
+// device plugin to inject every GPU on the node rather than a single
+// one. Instances not listed here fall through to 1, which is correct
+// for single-GPU SKUs and for pods that only need one representative
+// GPU (e.g. driver-liveness, CUDA sample runs).
+//
+// SKUs with confirmed GPU counts from AWS product pages / EC2
+// describe-instance-types:
+//   - p3.8xlarge: 4x V100
+//   - p3.16xlarge, p3dn.24xlarge: 8x V100
+//   - p4d.24xlarge, p4de.24xlarge: 8x A100
+//   - p5.48xlarge, p5e.48xlarge, p5en.48xlarge: 8x H100/H200
+//   - p6-b200.*, p6-b300.*: 8x B200 (Blackwell)
+func GPUCountForNodeType(nodeType string) int {
+	switch nodeType {
+	case "p3.8xlarge":
+		return 4
+	case "p3.16xlarge",
+		"p3dn.24xlarge",
+		"p4d.24xlarge", "p4de.24xlarge",
+		"p5.48xlarge", "p5e.48xlarge", "p5en.48xlarge":
+		return 8
+	}
+	if strings.HasPrefix(nodeType, "p6-b200") || strings.HasPrefix(nodeType, "p6-b300") {
+		return 8
+	}
+	return 1
+}

--- a/test/images/nvidia/Dockerfile
+++ b/test/images/nvidia/Dockerfile
@@ -51,11 +51,26 @@ RUN mkdir -p /var/run/sshd \
  && echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config \
  && sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config
 
-# Build CUDA Samples
+# Build CUDA Samples.
+# Each entry is "<relative-path-under-Samples>:<produced-binary-name>".
+# When cuda-samples upstream reorganizes a sample, update its path here.
 RUN git clone https://github.com/NVIDIA/cuda-samples.git /tmp/cuda-samples \
       --branch v$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
- && cd /tmp/cuda-samples/Samples/0_Introduction/vectorAdd && cmake . && make -j$(nproc) && cp vectorAdd /usr/bin \
- && cd /tmp/cuda-samples/Samples/1_Utilities/deviceQuery && cmake . && make -j$(nproc) && cp deviceQuery /usr/bin \
+ && for sample in \
+      "0_Introduction/vectorAdd:vectorAdd" \
+      "1_Utilities/deviceQuery:deviceQuery" \
+      "6_Performance/UnifiedMemoryPerf:UnifiedMemoryPerf" \
+      "3_CUDA_Features/immaTensorCoreGemm:immaTensorCoreGemm" \
+      "2_Concepts_and_Techniques/reductionMultiBlockCG:reductionMultiBlockCG" \
+      "2_Concepts_and_Techniques/shfl_scan:shfl_scan" \
+      "0_Introduction/simpleAWBarrier:simpleAWBarrier" \
+      "0_Introduction/simpleAtomicIntrinsics:simpleAtomicIntrinsics" \
+      "0_Introduction/simpleVoteIntrinsics:simpleVoteIntrinsics" \
+      "3_CUDA_Features/warpAggregatedAtomicsCG:warpAggregatedAtomicsCG" \
+      "3_CUDA_Features/globalToShmemAsyncCopy:globalToShmemAsyncCopy"; do \
+      dir="${sample%%:*}"; bin="${sample##*:}"; \
+      cd "/tmp/cuda-samples/Samples/$dir" && cmake . && make -j$(nproc) && cp "$bin" /usr/bin || exit 1; \
+    done \
  && cd && rm -rf /tmp/cuda-samples
 
 # Install EFA


### PR DESCRIPTION
Adding test suites for following capabilities, each capability has its own test suite + binary:
1) Driver liveness
2) Fabric Manager + NVLink
3) Cuda compute
4) Persistence device nodes 
5) GSP Firmware 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
